### PR TITLE
chore: add toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+profile = "default"
+channel = "1.95.0"


### PR DESCRIPTION
This PR adds `rust-toolchain.toml`, so that all contributors will use the same Rust version in the project.

Made sure that fmt and clippy pass. 