### PR TITLE
chore: add missing, required targets

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,3 +3,5 @@
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
 channel = "1.95.0"
+targets = ["aarch64-apple-darwin", "wasm32-wasip1-threads"]
+


### PR DESCRIPTION
Added targets that are needed for the build to succeed. 

Run `cargo build` locally and it worked