### PR TITLE
Fix small accessibility issues in the website

### DIFF
--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -13,7 +13,7 @@
   --color-paper: #f7f2e8;
   --color-surface: #ede6d6;
   --color-border: #c9bfa8;
-  --color-tertiary: #756d5e;
+  --color-tertiary: #6c6456;
   --color-secondary: #5c5446;
   --color-body: #2a2620;
   --color-ink: #14110c;
@@ -41,7 +41,7 @@
     --color-paper: #f7f2e8;
     --color-surface: #ede6d6;
     --color-border: #c9bfa8;
-    --color-tertiary: #756d5e;
+    --color-tertiary: #6c6456;
     --color-secondary: #5c5446;
     --color-body: #2a2620;
     --color-ink: #14110c;

--- a/website/src/docs_layout.rs
+++ b/website/src/docs_layout.rs
@@ -123,7 +123,7 @@ fn render_sidebar(ctx: &mut PageContext) -> Markup {
     }
 
     html! {
-        nav.text-base {
+        nav.text-base aria-label="Documentation" {
             @if let Some(row) = prologue {
                 @let active = row.url == current_path;
                 ul.mb-6 {

--- a/website/src/layout.rs
+++ b/website/src/layout.rs
@@ -110,7 +110,7 @@ fn header() -> Markup {
                 a.no-underline.text-ink.font-logo.text-3xl.leading-none.transition-opacity.hover:opacity-70 href="/" {
                     "Sätteri"
                 }
-                nav.hidden."md:flex".items-center.gap-6.text-base.text-secondary.relative."top-px" {
+                nav.hidden."md:flex".items-center.gap-6.text-base.text-secondary.relative."top-px" aria-label="Main" {
                     @for (href, label) in NAV_LINKS {
                         a.no-underline.transition-colors.hover:text-ink.hover:underline.decoration-current.underline-offset-4 href=(href) { (label) }
                     }

--- a/website/src/routes/index.rs
+++ b/website/src/routes/index.rs
@@ -103,7 +103,7 @@ fn demo() -> Markup {
                         }
                     }
                     div.flex.flex-col {
-                        div.px-4.py-2.text-xs.uppercase.tracking-widest.text-paper.bg-ink.font-bold {
+                        h3.px-4.py-2.text-xs.uppercase.tracking-widest.text-paper.bg-ink.font-bold {
                             "Rendered HTML"
                         }
                         div #demo-output .prose."min-h-[26rem]"."md:min-h-[36rem]"."max-h-[26rem]"."md:max-h-[36rem]".overflow-auto.p-4.text-sm.leading-relaxed {}

--- a/website/src/routes/index.rs
+++ b/website/src/routes/index.rs
@@ -62,6 +62,7 @@ fn hero() -> Markup {
 }
 
 fn demo() -> Markup {
+    let markdown_input_id = "demo-input";
     html! {
         section #demo .border-b.border-border.bg-surface {
             div.max-w-7xl.mx-auto.px-6.py-16 {
@@ -88,13 +89,15 @@ fn demo() -> Markup {
                 div.grid.grid-cols-1.md:grid-cols-2.border.border-border.rounded-sm.overflow-hidden.bg-paper {
                     div.flex.flex-col.border-b.md:border-b-0.md:border-r.border-border {
                         div.px-4.py-2.text-xs.uppercase.tracking-widest.text-paper.bg-ink.font-bold  {
-                            "Markdown"
+                            label for=(markdown_input_id) {
+                                "Markdown"
+                            }
                         }
                         div.relative."flex-1"."min-h-[26rem]"."md:min-h-[36rem]"."max-h-[26rem]"."md:max-h-[36rem]" {
                             pre #demo-highlight .demo-editor-layer.absolute.inset-0.m-0.overflow-auto.pointer-events-none {
                                 code {}
                             }
-                            textarea #demo-input
+                            textarea id=(markdown_input_id)
                                 spellcheck="false"
                                 class="demo-editor-layer absolute inset-0 m-0 resize-none w-full h-full bg-transparent text-transparent caret-ink focus:outline-none" {}
                         }


### PR DESCRIPTION
This PR fixes some small WCAG issues with the website:

- Makes sure the textarea input in the landing page demo has an accessible label
- Fixes colour contrast on tertiary text in light mode (I nudged it a few clicks darker to pass WCAG AA requirements)
- Adds unique labels to the two `<nav>` elements so that when used on the same page (i.e. in docs) there are unique accessible names for these. Important to make sure these landmark elements show up correctly to assistive tech.

N.B. there are more issues in the playground to fix but I didn’t get that working locally in dev so skipped for now.