### PR TITLE
chore: create agent skills

### DIFF
--- a/.agents/skills/add-satteri-feature/SKILL.md
+++ b/.agents/skills/add-satteri-feature/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: add-satteri-feature
+description: "Workflow for adding features to Satteri. Use when adding a new node type (MDAST or HAST), a new Markdown or MDX extension, a new plugin capability or visitor method, a new context mutation method, a new public API function, or any feature that spans multiple crates or the Rust-to-JS boundary. Also use when the user asks how to extend the Satteri pipeline, add support for new syntax, or expose new functionality to JavaScript."
+---
+
+# Add Satteri Feature
+
+A checklist-driven workflow for adding features to the Satteri Markdown/MDX pipeline. Features in this codebase typically span multiple crates and the Rust/TypeScript boundary, so a systematic approach prevents missed steps.
+
+If you are not already familiar with the codebase, load the `navigate-satteri` skill first. For test guidance, read `.agents/skills/navigate-satteri/references/test-guide.md`.
+
+## Step 1: Scope the Change
+
+Before writing any code, identify which layers of the pipeline are affected.
+
+### Questions to answer
+
+1. **Does this change the parser?** If it adds new syntax (e.g., a new Markdown extension), the pulldown-cmark fork needs modification.
+2. **Does this add or change a node type?** If yes, the change spans the full stack: enum variant, codec, arena build, conversion, walk, rebuild, commands, TS types, TS reader, TS materializer, TS visitor, plugin definition, tests.
+3. **Does this cross the Rust/JS boundary?** If a new function needs to be callable from JS, it needs a NAPI binding and a TS wrapper.
+4. **Does this affect both MDAST and HAST?** Many features (new node types, new visitor methods, codec changes) require parallel work in both MDAST and HAST layers.
+5. **Does this change a binary format?** If type_data layout, walk result format, or command buffer encoding changes, every consumer of that format must be updated.
+
+### Implementation order
+
+Work from the bottom of the stack up:
+
+```
+1. Rust types and codecs (satteri-arena, satteri-ast)
+2. Parser changes (satteri-pulldown-cmark) if applicable
+3. Conversion (convert.rs) if the feature affects MDAST-to-HAST
+4. Walk/rebuild/commands (satteri-ast, satteri-plugin-api) if plugins interact with it
+5. NAPI binding (satteri-napi-binding) if JS needs access
+6. TypeScript types, reader, materializer, visitor
+7. Public API surface (index.ts) if user-facing
+8. Tests at each layer
+```
+
+This order ensures that dependencies are satisfied as you go. Rust types first, TS last.
+
+## Step 2: Choose the Right Checklist
+
+Detailed per-feature-type checklists are in `.agents/skills/add-satteri-feature/references/checklists.md`. Read the one that matches your feature type:
+
+- **New MDAST node type** -- Full stack from enum to TS visitor (15 steps)
+- **New HAST node type** -- Similar but without parser/conversion steps
+- **New Markdown extension** -- Parser options, implementation, arena bridge, spec tests
+- **New JS API function** -- Rust implementation, NAPI binding, TS wrapper, export
+- **New Rust plugin visitor method** -- Plugin trait, typed node view, runner dispatch
+- **New plugin context mutation method** -- Command enum, buffer encoding/decoding, rebuild handling
+- **New HAST element property handling** -- Property mapping, render changes, reader changes
+
+## Step 3: Implement
+
+Work through the checklist for your feature type. Key principles:
+
+### Match existing patterns
+
+Before writing new code, read an existing example of the same kind of change. For example:
+- Adding a new MDAST node type? Read how `Math` (type 27) or `ContainerDirective` (type 30) is implemented across the stack.
+- Adding a new NAPI function? Read how `text_content_handle` is exposed: Rust implementation, `#[napi]` attribute, TS binding re-export.
+- Adding a new visitor method? Read how `heading` is handled: trait method in `plugin.rs`, dispatch in `runner.rs`, typed node in `typed_nodes.rs`.
+
+### The MDAST/HAST symmetry rule
+
+If your feature adds something for MDAST, check whether a parallel addition is needed for HAST (and vice versa). This applies to:
+- Node type enum variants (`mdast/node.rs` <-> `hast/node.rs`)
+- Codec encode/decode functions (`mdast/codec.rs` <-> `hast/codec.rs`)
+- Reader decoder methods (`mdast-reader.ts` <-> `hast-reader.ts`)
+- Materializer type handlers (`mdast-materializer.ts` <-> `hast-materializer.ts`)
+- Visitor interfaces and dispatch (`mdast-visitor.ts` <-> `hast-visitor.ts`)
+- Walk serialization (`walk.rs` serialize_mdast_* <-> serialize_hast_*)
+- Rebuild StringRef remapping (`rebuild.rs` remap_mdast_* <-> remap_hast_*)
+- Command handling (`js_commands.rs` apply_mdast_* <-> apply_hast_*)
+
+### Binary format consistency
+
+When adding a new node type or changing type_data layout, these consumers must all agree on the format:
+
+| Consumer | File | What it does |
+|----------|------|-------------|
+| Encoder | `mdast/codec.rs` or `hast/codec.rs` | Writes type_data bytes |
+| Decoder | Same codec file | Reads type_data bytes |
+| Walk serializer | `walk.rs` | Reads type_data for inline serialization |
+| TS reader | `mdast-reader.ts` or `hast-reader.ts` | Reads binary buffer |
+| StringRef remapper | `rebuild.rs` | Finds and offsets StringRefs in type_data |
+| Set-property handler | `js_commands.rs` | Modifies type_data in-place |
+| Node builder | `js_commands.rs` | Creates type_data from JsNode JSON |
+
+### Do not add external dependencies without justification
+
+Prefer the standard library and existing utilities. The project is deliberately minimal in dependencies. If a new dependency is genuinely needed, explain why existing utilities cannot cover the use case.
+
+## Step 4: Test
+
+Add tests at each layer affected by the feature. For test formats, patterns, and commands, read `.agents/skills/navigate-satteri/references/test-guide.md`.
+
+### Test types by feature
+
+| Feature type | Required tests |
+|-------------|---------------|
+| New MDAST node type | Spec tests + codec roundtrip + conversion test + JS conformance |
+| New HAST node type | Codec roundtrip + render test + JS conformance |
+| New Markdown extension | Spec tests + conformance tests + error/edge cases |
+| New JS API function | JS integration test |
+| New plugin capability | JS plugin/visitor test + Rust plugin test |
+| New context method | JS plugin test showing the mutation takes effect in HTML output |
+
+### Conformance testing
+
+If the feature has a reference implementation in the remark/rehype ecosystem, add conformance tests that compare Satteri's output against the reference. Use the patterns in `test/conformance/helpers.ts`.
+
+## Step 5: Verify
+
+Run the full verification sequence:
+
+```sh
+cargo clippy --all --all-targets
+cargo fmt --all --check
+cargo test --all
+cd packages/satteri && pnpm build && pnpm test
+```
+
+Additionally check:
+- New public API is exported from `packages/satteri/src/index.ts`
+- TypeScript compiles without errors
+- No clippy warnings introduced
+- Code is formatted correctly

--- a/.agents/skills/add-satteri-feature/references/checklists.md
+++ b/.agents/skills/add-satteri-feature/references/checklists.md
@@ -1,0 +1,249 @@
+# Feature Checklists
+
+Detailed step-by-step checklists for common feature types. Each step includes the file to modify and what to do there.
+
+## New MDAST Node Type
+
+Adding a new node type to the Markdown AST (e.g., a new extension like directives, math, or custom syntax).
+
+### Rust layer
+
+1. **Enum variant** -- `crates/satteri-ast/src/mdast/node.rs`
+   - Add a new variant to `MdastNodeType` with a unique `u8` discriminant
+   - Add the variant to `from_u8()` match
+
+2. **Codec** -- `crates/satteri-ast/src/mdast/codec.rs`
+   - Define a `#[repr(C)]` data struct if the node has type-specific fields (use `StringRef` for strings)
+   - Implement `encode_*_data()` function that writes the struct bytes
+   - Implement `decode_*_data()` function(s) that read the struct bytes
+   - Add codec roundtrip unit test in the `#[cfg(test)]` module
+
+3. **Parser bridge** -- `crates/satteri-pulldown-cmark/src/arena_build.rs`
+   - Map the pulldown-cmark event(s) to the new node type
+   - Use `ArenaBuilder::open_node()` / `close_node()` for container nodes, `add_leaf()` for leaf nodes
+   - Call the codec's `encode_*_data()` to produce the type_data bytes
+
+4. **Conversion** -- `crates/satteri-ast/src/convert.rs`
+   - Add a match arm in `convert_node()` for the new `MdastNodeType` variant
+   - Map it to the appropriate HAST element (or skip it if it has no HTML representation)
+
+5. **Walk serialization** -- `crates/satteri-ast/src/walk.rs`
+   - Add the node type to `serialize_mdast_node_inline()` in the match
+   - Serialize the type-specific data inline (position, children, then custom fields)
+
+6. **Rebuild StringRef remapping** -- `crates/satteri-ast/src/rebuild.rs`
+   - Add the node type to `remap_mdast_string_refs()` if its type_data contains any `StringRef` fields
+   - List the byte offsets of each StringRef that needs remapping
+
+7. **Text content** -- `crates/satteri-ast/src/text_content.rs` (via `mdast/mod.rs`)
+   - If the node contributes text content (like Text or InlineCode), add its type_data offset to the `text_offset` closure in `mdast/mod.rs::text_content_with_options()`
+
+8. **JS node builder** -- `crates/satteri-plugin-api/src/js_commands.rs`
+   - Add the node type string to `name_to_node_type()` match
+   - Add encoding logic in `encode_js_node_data()` for when JS sends this node type in a SERDE_JSON payload
+   - If the node has properties that can be set via `setProperty`, add field resolution in `resolve_mdast_field()` and handle the set in `apply_mdast_set_property()`
+
+### TypeScript layer
+
+9. **Types** -- `packages/satteri/src/types.ts` (or `mdx-types.ts` / `directive-types.ts`)
+   - Define the TypeScript interface for the node
+   - Add module augmentation to register it in the mdast content maps
+
+10. **Reader** -- `packages/satteri/src/mdast/mdast-reader.ts`
+    - Add the node type number to the `NodeType` constant object and `NodeTypeName` reverse map
+    - Add decoder method(s) for type-specific data (e.g., `getMyNodeData()`)
+
+11. **Materializer** -- `packages/satteri/src/mdast/mdast-materializer.ts`
+    - Add the type string to `TYPE_NAMES`
+    - Add to `LEAF_TYPES` if the node never has children
+    - Add a case in `addTypeProperties()` to attach lazy property getters using `lazyProp` / `lazyGroup`
+
+12. **Visitor** -- `packages/satteri/src/mdast/mdast-visitor.ts`
+    - Add the visitor method to `MdastPluginInstance` interface with the correct node type
+    - Add subscription resolution in `resolveMdastSubscriptions()` (map method name to node type number)
+    - Add the node decoding case in `readMdastMatchedNode()` (read from the walk binary buffer)
+
+13. **Plugin definition** -- `packages/satteri/src/plugin.ts`
+    - The `MdastPluginDefinition` type picks up the new visitor from `MdastPluginInstance` automatically
+
+14. **Public export** -- `packages/satteri/src/index.ts`
+    - Export the new type if it's part of the public API
+
+### Tests
+
+15. **Tests at each layer:**
+    - Spec test in `crates/satteri-pulldown-cmark/specs/*.txt`
+    - Codec roundtrip in `crates/satteri-ast/src/mdast/codec.rs`
+    - Conversion test (if applicable) in `crates/satteri-ast/src/convert.rs` or `crates/satteri-ast/tests/html.rs`
+    - JS conformance test in `packages/satteri/test/conformance/`
+    - JS visitor test showing the plugin can visit and mutate the new node type
+
+---
+
+## New HAST Node Type
+
+Adding a new node type to the HTML AST.
+
+1. **Enum variant** -- `crates/satteri-ast/src/hast/node.rs`
+   - Add variant to `HastNodeType` with unique `u8` discriminant, add to `from_u8()`
+
+2. **Codec** -- `crates/satteri-ast/src/hast/codec.rs`
+   - Define type_data layout, implement encode/decode functions
+
+3. **Conversion** -- `crates/satteri-ast/src/convert.rs`
+   - Produce this node type from the appropriate MDAST source node(s)
+
+4. **Render** -- `crates/satteri-ast/src/hast/render.rs`
+   - Add a match arm in `render_node()` to serialize this node type to HTML
+
+5. **Walk** -- `crates/satteri-ast/src/walk.rs`
+   - Add to `serialize_hast_node_inline()` match
+
+6. **Rebuild** -- `crates/satteri-ast/src/rebuild.rs`
+   - Add to `remap_hast_string_refs()` if type_data contains StringRefs
+
+7. **JS node builder** -- `crates/satteri-plugin-api/src/js_commands.rs`
+   - Add to `name_to_hast_type()`, `encode_hast_js_node_data()`, and `apply_hast_set_property()` as needed
+
+8. **TS types** -- `packages/satteri/src/types.ts`
+
+9. **TS reader** -- `packages/satteri/src/hast/hast-reader.ts`
+   - Add node type constant, add decoder method
+
+10. **TS materializer** -- `packages/satteri/src/hast/hast-materializer.ts`
+    - Add case in `materializeHastNode()`
+
+11. **TS visitor** -- `packages/satteri/src/hast/hast-visitor.ts`
+    - Add to `HastVisitorInstance`, subscription resolution, and match reading
+
+12. **Tests** at each layer
+
+---
+
+## New Markdown Extension
+
+Adding parser support for new syntax (e.g., a new pulldown-cmark extension).
+
+1. **Option flag** -- `crates/satteri-pulldown-cmark/src/lib.rs`
+   - Add a new bit to the `Options` bitflags
+
+2. **Parser implementation** -- one or more of:
+   - `src/firstpass.rs` for block-level constructs
+   - `src/parse.rs` / `src/scanners.rs` for inline constructs
+   - New dedicated module (e.g., `src/my_extension.rs`) for complex extensions
+
+3. **Arena bridge** -- `crates/satteri-pulldown-cmark/src/arena_build.rs`
+   - Map parser events to MDAST node type(s)
+   - Usually requires a new MDAST node type (see that checklist)
+
+4. **Feature toggle** -- `crates/satteri-napi-binding/src/lib.rs`
+   - Add the option to `JsFeatures` struct and the options-building logic
+
+5. **TS feature** -- `packages/satteri/src/compile.ts`
+   - Add to `Features` interface and the features-to-options mapping
+
+6. **Spec tests** -- `crates/satteri-pulldown-cmark/specs/`
+   - Create a new spec file (or add to an existing one)
+   - Add extension-specific test flag if needed (in `build.rs` `base_options_for_spec()`)
+
+7. **Conformance tests** -- `packages/satteri/test/conformance/`
+   - If a reference implementation exists (remark plugin), add conformance tests
+
+---
+
+## New JS API Function
+
+Exposing a new function to JavaScript users.
+
+1. **Rust implementation** -- `crates/satteri/src/lib.rs` or the relevant crate
+   - Implement the core logic in Rust
+
+2. **NAPI binding** -- `crates/satteri-napi-binding/src/lib.rs`
+   - Add a `#[napi]` function that wraps the Rust implementation
+   - Define JS-facing input/output types (use `#[napi(object)]` for structs)
+   - Handle errors by converting `Result` to NAPI errors
+
+3. **TS binding** -- `packages/satteri/src/binding.ts`
+   - The NAPI-generated `index.js` auto-exports the function
+   - Re-export it in `binding.ts` (and `binding.browser.ts` for WASM if applicable)
+
+4. **TS wrapper** -- `packages/satteri/src/compile.ts` or a new file
+   - Add a TypeScript wrapper function with proper types
+   - Handle options, defaults, and type narrowing
+
+5. **Public export** -- `packages/satteri/src/index.ts`
+   - Export the function and its associated types
+
+6. **Tests** -- `packages/satteri/test/`
+   - Add integration tests exercising the new function
+
+---
+
+## New Rust Plugin Visitor Method
+
+Adding a new typed visitor to the Rust `Plugin` trait.
+
+1. **Typed node view** -- `crates/satteri-plugin-api/src/typed_nodes.rs`
+   - Add a new struct (e.g., `MyNode<'a>`) with arena-backed accessors
+   - Implement type-specific data decoding (call codec decode functions)
+
+2. **Plugin trait** -- `crates/satteri-plugin-api/src/plugin.rs`
+   - Add `visit_my_node(&mut self, node: &MyNode, ctx: &mut PluginContext) -> VisitResult` with a default no-op implementation
+
+3. **Runner dispatch** -- `crates/satteri-plugin-api/src/runner.rs`
+   - Add a match arm in `dispatch_visitor()` that constructs the typed node view and calls the visitor method
+
+4. **Tests** -- `crates/satteri-plugin-api/tests/`
+   - Add a test plugin that implements the new visitor and verify it receives the correct node data
+
+---
+
+## New Plugin Context Mutation Method
+
+Adding a new way for plugins to mutate the AST (e.g., a new structural operation).
+
+### Rust side
+
+1. **Command variant** -- `crates/satteri-plugin-api/src/commands.rs`
+   - Add a new variant to the `Command` enum
+
+2. **Context method** -- `crates/satteri-plugin-api/src/context.rs`
+   - Add a method to `PluginContext` that pushes the new command
+
+3. **Runner patch conversion** -- `crates/satteri-plugin-api/src/runner.rs`
+   - Add conversion from `Command` to `Patch` in `commands_to_patches()`
+
+4. **Rebuild handling** -- `crates/satteri-ast/src/rebuild.rs`
+   - Add a `Patch` variant if needed, and handle it in `copy_node()`
+
+### JS side
+
+5. **Command buffer encoding** -- `packages/satteri/src/command-buffer.ts`
+   - Add a command byte constant (must not collide with existing ones)
+   - Add an encoding method to `CommandBuffer` class
+
+6. **JS command parsing** -- `crates/satteri-plugin-api/src/js_commands.rs`
+   - Add the command byte constant (must match TS)
+   - Add parsing logic in the command dispatch loop
+
+7. **Visitor context** -- `packages/satteri/src/mdast/mdast-visitor.ts` and/or `src/hast/hast-visitor.ts`
+   - Add the method to `MdastVisitorContext` / `HastVisitorContextImpl`
+
+8. **Tests** -- JS plugin test + Rust command test
+
+---
+
+## New HAST Element Property Handling
+
+If a new HTML/SVG attribute needs special handling in rendering.
+
+1. **Property mapping** -- `crates/satteri-ast/src/hast/properties.rs`
+   - Add the property to the appropriate resolution path in `property_to_attribute()`
+   - If it's an SVG attribute, add to `svg_attribute_for()`
+   - If it's a new HTML boolean attribute, add to the known-property lists
+
+2. **Render handling** -- `crates/satteri-ast/src/hast/render.rs`
+   - The renderer already handles property types generically (string, bool, space-sep, etc.)
+   - Special handling is only needed for new value type semantics
+
+3. **Tests** -- Unit test in `properties.rs`, render test in `crates/satteri-ast/tests/html.rs`

--- a/.agents/skills/fix-satteri-bug/SKILL.md
+++ b/.agents/skills/fix-satteri-bug/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: fix-satteri-bug
+description: "Workflow for diagnosing and fixing bugs in Satteri. Use when a test is failing, the user reports incorrect output (wrong HTML, wrong AST, wrong JS compilation), a plugin is not behaving correctly, there is a parsing issue, a conformance failure, a panic, or any other bug in the Satteri Markdown/MDX pipeline. Also use when investigating regressions or when conformance tests diverge from the remark/rehype reference implementations."
+---
+
+# Fix Satteri Bug
+
+A staged workflow for diagnosing and fixing bugs in the Satteri Markdown/MDX pipeline. If you are not already familiar with the codebase, load the `navigate-satteri` skill first.
+
+## Stage 1: Classify the Bug Layer
+
+Before writing any code, determine which layer of the pipeline the bug is in. This narrows the search space and determines where to add the reproduction test.
+
+### Decision tree
+
+1. **Is the markdown source parsed incorrectly?** (wrong AST shape, missing nodes, wrong positions)
+   - **Layer:** Parser (`crates/satteri-pulldown-cmark/`)
+   - **Key files:** `src/arena_build.rs` (event-to-arena bridge), `src/parse.rs` (core parser), `src/firstpass.rs` (block-level pass), `src/mdx.rs` (MDX-specific parsing)
+   - **Test location:** Add spec test in `specs/*.txt` or Rust integration test in `tests/`
+
+2. **Is the MDAST correct but HAST conversion is wrong?** (wrong element mapping, missing attributes, footnote numbering)
+   - **Layer:** Conversion (`crates/satteri-ast/src/convert.rs`)
+   - **Key file:** `convert.rs` (2228 lines, handles all node type conversions)
+   - **Test location:** JS conformance test in `test/conformance/hast.test.ts` or Rust unit test in `convert.rs`
+
+3. **Is the HAST correct but HTML output is wrong?** (missing attributes, wrong escaping, void element issues)
+   - **Layer:** Renderer (`crates/satteri-ast/src/hast/render.rs`)
+   - **Key files:** `render.rs` (HTML serialization), `properties.rs` (property-to-attribute mapping)
+   - **Test location:** JS conformance test in `test/conformance/html.test.ts` or Rust test in `crates/satteri-ast/tests/html.rs`
+
+4. **Is the HAST correct but MDX compilation is wrong?** (wrong JS output, missing imports, broken JSX)
+   - **Layer:** MDX compiler (`crates/satteri-mdxjs-rs/`)
+   - **Key files:** `hast_util_to_oxc.rs`, `mdx_plugin_recma_document.rs`, `mdx_plugin_recma_jsx_rewrite.rs`
+   - **Test location:** Rust test in `crates/satteri-mdxjs-rs/tests/test.rs` or JS conformance in `test/conformance/mdx.test.ts`
+
+5. **Does a plugin visitor receive wrong data?** (wrong node properties, missing children, incorrect tag names)
+   - **Layer:** Walker (`crates/satteri-ast/src/walk.rs`) or TS reader (`src/mdast/mdast-reader.ts`, `src/hast/hast-reader.ts`)
+   - The walk binary format serializes node data inline -- a codec mismatch between the Rust serializer and TS reader is a common failure mode
+   - **Test location:** JS visitor tests in `test/visitor.test.ts` or `test/hast-visitor.test.ts`
+
+6. **Do plugin mutations not take effect?** (setProperty ignored, replaceNode not working, insertBefore in wrong position)
+   - **Layer:** Command buffer (`src/command-buffer.ts` <-> `crates/satteri-plugin-api/src/js_commands.rs`) or rebuild (`crates/satteri-ast/src/rebuild.rs`)
+   - Check that the wire format constants match between TS and Rust
+   - **Test location:** JS plugin tests in `test/html-plugin.test.ts` or Rust tests in `js_commands.rs`
+
+7. **Does the bug only occur through NAPI?** (works in pure Rust but fails from JS)
+   - **Layer:** NAPI boundary (`crates/satteri-napi-binding/src/lib.rs`)
+   - Common issues: handle lifetime problems, wrong buffer conversion, missing Mutex lock
+   - **Test location:** JS tests
+
+8. **Is there a codec mismatch between encoding and decoding?** (data corruption, wrong field values)
+   - **Layer:** Codecs (`satteri-ast/src/mdast/codec.rs` or `hast/codec.rs`)
+   - The binary type_data format is defined by the encode function and must be read identically by: Rust decode functions, `walk.rs` serialization, TS readers, `rebuild.rs` StringRef remapping, and `js_commands.rs` set-property handling
+   - **Test location:** Unit tests in the codec file + integration tests
+
+## Stage 2: Reproduce with a Test
+
+Write a failing test before attempting a fix. The test type depends on the layer identified in Stage 1.
+
+For detailed test formats, locations, and commands, read `.agents/skills/navigate-satteri/references/test-guide.md`.
+
+### Quick reference
+
+- **Parsing bug:** Add a spec test case in the appropriate `specs/*.txt` file. Use the 32-backtick fence format with markdown input and expected HTML separated by `.`.
+- **Conversion/rendering bug:** Add a test case in `crates/satteri-ast/tests/html.rs` using `mdast_to_html()`, or a JS conformance test comparing against remark/rehype.
+- **Plugin bug:** Add a test in `test/html-plugin.test.ts` or `test/visitor.test.ts` that exercises the specific mutation.
+- **MDX bug:** Add a test in `crates/satteri-mdxjs-rs/tests/test.rs` (Rust) or `test/conformance/mdx.test.ts` (JS).
+- **Conformance regression:** Add a case in the appropriate `test/conformance/*.test.ts` file.
+
+Run only the relevant test subset first to confirm the failure before proceeding.
+
+## Stage 3: Diagnose
+
+### Trace the data flow
+
+Follow the pipeline trace for the relevant layer. For a `markdownToHtml` call:
+
+```
+source -> pulldown-cmark parser -> arena_build.rs -> Arena<Mdast>
+       -> MDAST plugin walk/dispatch/rebuild cycle
+       -> convert.rs -> Arena<Hast>
+       -> HAST plugin walk/dispatch/rebuild cycle
+       -> hast/render.rs -> HTML string
+```
+
+Read the specific files at the layer where the bug occurs. Use `cargo test` with `--nocapture` to see debug output, or add temporary `eprintln!` statements in the Rust code.
+
+### Common failure patterns
+
+**Codec mismatches:**
+The most common cross-layer bug. A field is encoded with one byte layout but decoded with a different assumption. Check that:
+- `mdast/codec.rs` `encode_*` and `decode_*` functions agree on field order and sizes
+- `walk.rs` `serialize_mdast_node_inline()` / `serialize_hast_node_inline()` reads type_data at the correct offsets
+- `mdast-reader.ts` / `hast-reader.ts` decode functions read the same offsets
+- `rebuild.rs` `remap_mdast_string_refs()` / `remap_hast_string_refs()` knows the correct StringRef positions
+- `js_commands.rs` `apply_mdast_set_property()` / `apply_hast_set_property()` modifies the correct bytes
+
+**StringRef offset errors:**
+When `rebuild.rs` splices sub-arenas, all StringRefs in the sub-arena must be remapped (source strings are concatenated). If a new node type's type_data contains StringRefs that `remap_*_string_refs()` doesn't know about, the resolved strings will point to wrong bytes.
+
+**Children range off-by-one:**
+`ArenaNode::children_start` and `children_count` index into the flat `Arena::children` array. An off-by-one here can cause nodes to appear as children of the wrong parent or be missing entirely.
+
+**Missing node type dispatch:**
+When a new node type is added, every switch/match on `MdastNodeType` or `HastNodeType` needs a new arm. Forgetting one in `walk.rs`, `rebuild.rs`, `js_commands.rs`, or the TS visitor files causes the node to be silently skipped or fall through to a default case.
+
+**Property type tag mismatch:**
+HAST element properties use type tags (`PROP_STRING=0`, `PROP_BOOL_TRUE=1`, etc.) defined in `shared.rs`. The same constants must be used in `hast/codec.rs`, `hast/render.rs`, `hast-reader.ts`, `command-buffer.ts`, and `js_commands.rs`. A mismatch causes property values to be misinterpreted.
+
+**Command buffer wire format:**
+The command byte constants (`CMD_REMOVE=0x01`, `CMD_REPLACE=0x0B`, etc.) and payload type constants (`PAYLOAD_RAW_MARKDOWN=0x10`, `PAYLOAD_SERDE_JSON=0x12`, etc.) must match exactly between `command-buffer.ts` and `js_commands.rs`. A mismatch causes command parsing failures or wrong mutations.
+
+## Stage 4: Fix
+
+### Apply the fix
+
+Fix the root cause in the identified layer. Keep changes minimal and focused.
+
+### The MDAST/HAST mirror check
+
+After fixing, check whether the same issue exists in the parallel layer. The MDAST and HAST codepaths share structural patterns:
+
+| If you fixed something in... | Check the same pattern in... |
+|-----|------|
+| `mdast/codec.rs` | `hast/codec.rs` |
+| `mdast-reader.ts` | `hast-reader.ts` |
+| `mdast-materializer.ts` | `hast-materializer.ts` |
+| `mdast-visitor.ts` | `hast-visitor.ts` |
+| `walk.rs` `serialize_mdast_*` | `walk.rs` `serialize_hast_*` |
+| `rebuild.rs` `remap_mdast_*` | `rebuild.rs` `remap_hast_*` |
+| `js_commands.rs` `apply_mdast_*` | `js_commands.rs` `apply_hast_*` |
+
+### Cross-layer consistency
+
+If the fix changes a binary format (type_data layout, walk result format, command buffer encoding), verify that all consumers of that format are updated:
+
+**Type data changes:** `codec.rs` (encode + decode) + `walk.rs` (inline serialization) + reader TS (decode) + `rebuild.rs` (StringRef remapping) + `js_commands.rs` (set-property)
+
+**Walk result changes:** `walk.rs` (Rust serializer) + visitor TS (JS reader in `readMdastMatchedNode` / `readMatchedNode`)
+
+**Command buffer changes:** `command-buffer.ts` (JS encoder) + `js_commands.rs` (Rust parser)
+
+### Quality checklist
+
+From CONTRIBUTING.md:
+- Self-documenting code. Comments explain _why_, not _how_.
+- Tests assert observable behavior, not implementation details.
+- Rust: typed error enums, `?` propagation, `.expect()`/`.unwrap()` only for programmer bugs.
+- TypeScript: strict types, no `any`.
+- Clarity over cleverness. Small focused functions. Avoid duplication.
+
+## Stage 5: Verify
+
+Run the verification sequence appropriate to the scope of the change. For test commands and scope-based test selection, read `.agents/skills/navigate-satteri/references/test-guide.md`.
+
+Minimum verification:
+```sh
+cargo clippy --all --all-targets
+cargo fmt --all --check
+cargo test --all
+cd packages/satteri && pnpm build && pnpm test
+```
+
+Confirm:
+1. The originally failing test now passes
+2. No other tests have regressed
+3. Clippy reports no new warnings
+4. Code is formatted correctly

--- a/.agents/skills/navigate-satteri/SKILL.md
+++ b/.agents/skills/navigate-satteri/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: navigate-satteri
+description: "Codebase navigation map for the Satteri monorepo. Use this skill when exploring the codebase, tracing how a feature flows through the pipeline, finding where something is defined or implemented, understanding the relationship between Rust crates and TypeScript packages, or when you need to know which files to read for a given area of the code. Also load this skill before working on bugs or features if you are not already familiar with the project structure."
+---
+
+# Navigate Satteri
+
+Satteri is a Rust + TypeScript monorepo for high-performance Markdown/MDX processing. The core pipeline runs in Rust with an arena-allocated binary AST. JavaScript gets read-only views of the AST and sends mutations back as binary command buffers. This architecture means changes often span multiple crates and the TypeScript layer, and understanding the data flow is essential before modifying anything.
+
+## Crate Map
+
+Each crate has a specific role in the pipeline. The relationships form a DAG with `satteri-arena` at the bottom and `satteri-napi-binding` at the top.
+
+### `satteri-arena` (crates/satteri-arena/)
+
+The foundation. Defines the arena allocator, node layout, and binary wire format.
+
+| File | Role |
+|------|------|
+| `node.rs` | `ArenaNode` (52-byte `#[repr(C)]` struct) and `StringRef` (8-byte offset+len into source). These are the atoms of the entire system. |
+| `arena.rs` | `Arena<K>` -- the main container. Holds `nodes: Vec<ArenaNode>`, `children: Vec<u32>` (flat child array), `type_data: Vec<u8>` (packed per-node data), `source: String`, `node_data: FxHashMap<u32, Vec<u8>>` (plugin data blobs). |
+| `builder.rs` | `ArenaBuilder<K>` -- SAX-style incremental builder with open/close stack. Used by parsers and the conversion pass. |
+| `kind.rs` | Phantom type markers `Mdast` and `Hast` with `ArenaKind` trait. Prevents cross-kind arena misuse at compile time. |
+| `raw_buffer.rs` | `Arena::to_raw_buffer()` -- serializes to flat bytes for NAPI transfer. 44-byte header + nodes + children + type_data + source. |
+| `codec.rs` | `StringRef` encode/decode helpers for type_data. |
+| `line_index.rs` | Byte offset to (line, column) mapping using `memchr`. |
+| `mdx_types.rs` | MDX-specific types (`Point`, `Position`, `MdxSignal`, JSX attribute types). Used by the MDX compiler. |
+
+### `satteri-ast` (crates/satteri-ast/)
+
+Node types, codecs, conversion, rendering, tree walking, and arena reconstruction.
+
+| File | Role |
+|------|------|
+| `mdast/node.rs` | `MdastNodeType` enum -- 33 variants (Root through MdxjsEsm). |
+| `mdast/codec.rs` | Binary encode/decode for every MDAST node's `type_data`. Each node type has a `#[repr(C)]` data struct (e.g., `HeadingData { depth: u8 }`, `LinkData { url: StringRef, title: StringRef }`). 28 encode/decode function pairs. |
+| `hast/node.rs` | `HastNodeType` enum -- 11 variants (Root through MdxTextExpression). |
+| `hast/codec.rs` | Binary encode/decode for HAST `type_data`. Element layout: 16-byte header (tag + prop_count) + 20 bytes per property (name + type + value). |
+| `hast/properties.rs` | JS property name to HTML/SVG attribute mapping (`className` -> `class`, ARIA, data-*, SVG). Port of `property-information`. |
+| `hast/render.rs` | `hast_arena_to_html()` -- HAST arena to HTML string. Handles void elements, raw text elements, entity escaping, SVG context. |
+| `convert.rs` | `mdast_arena_to_hast_arena()` -- the MDAST-to-HAST conversion (2228 lines). Port of `mdast-util-to-hast` / `remark-rehype`. Handles reference definitions, footnotes, GFM tables, `hName`/`hProperties`/`hChildren` overrides. |
+| `rebuild.rs` | `rebuild()` -- applies `Patch` operations to produce a new arena. 7 patch types: Replace, Remove, InsertBefore, InsertAfter, Wrap, PrependChild, AppendChild. Includes `StringRef` remapping when splicing sub-arenas. |
+| `walk.rs` | `walk_mdast()` / `walk_hast()` -- subscription-based DFS walker. Returns a flat binary buffer of matched nodes with inline-resolved type-specific data for zero-copy JS consumption. |
+| `commands.rs` | `JsNode` (serde-deserializable struct for JS-originated nodes), `JsNodeAttribute`, `CommandError`. |
+| `shared.rs` | Property type constants (`PROP_STRING`, `PROP_BOOL_TRUE`, etc.) and MDX attribute kind constants. Used by both MDAST and HAST codecs. |
+| `text_content.rs` | Generic text extraction parameterized by arena kind. |
+
+### `satteri-pulldown-cmark` (crates/satteri-pulldown-cmark/)
+
+Vendored fork of pulldown-cmark with MDX extension support.
+
+| File | Role |
+|------|------|
+| `lib.rs` | `Options` bitflags, `Event` enum, `Parser` type. The public parsing API. |
+| `arena_build.rs` | `parse()` -- bridges pulldown-cmark events into an `Arena<Mdast>` (3270 lines). This is where markdown source becomes a tree. |
+| `parse.rs` | Core parser (`ParserInner`). |
+| `firstpass.rs` | Block-level first pass. |
+| `mdx.rs` | MDX JSX/expression parsing. |
+| `scanners.rs` | Inline scanning and pattern matching. |
+| `specs/` | 10 spec test files (table, footnotes, math, etc.). |
+| `build.rs` | Generates Rust test files from spec `.txt` files. |
+
+**Guardrail:** This crate intentionally diverges from upstream pulldown-cmark. Do not "update" it to match upstream without explicit instruction.
+
+### `satteri-mdxjs-rs` (crates/satteri-mdxjs-rs/)
+
+MDX-to-JavaScript compiler. Fork of mdxjs-rs, adapted for OXC.
+
+| File | Role |
+|------|------|
+| `lib.rs` | `compile()` and `compile_hast_arena()` entry points. |
+| `hast_util_to_oxc.rs` | HAST arena to OXC AST conversion. |
+| `mdx_plugin_recma_document.rs` | MDX document structure transform. |
+| `mdx_plugin_recma_jsx_rewrite.rs` | JSX to function call rewriting. |
+| `oxc_util_build_jsx.rs` | JSX AST building utilities. |
+| `configuration.rs` | `Options`, `JsxRuntime`, `OutputFormat`. |
+
+### `satteri-plugin-api` (crates/satteri-plugin-api/)
+
+The Rust plugin system.
+
+| File | Role |
+|------|------|
+| `plugin.rs` | `Plugin` trait with 14 typed visitor methods, `VisitResult` enum, `NodeView`. |
+| `runner.rs` | `PluginRunner` -- walks arena, dispatches to visitors, converts results to patches, rebuilds. |
+| `commands.rs` | `Command` enum (Replace, Remove, Insert*, Wrap, *Child, SetData), `NewNode`, `NodeBuilder`. |
+| `js_commands.rs` | Binary command buffer parser for JS-to-Rust mutations (1642 lines). `apply_mdast_commands()` and `apply_hast_commands()`. The wire format constants here must match `command-buffer.ts`. |
+| `context.rs` | `PluginContext` -- arena access, data maps, mutation methods, diagnostics. |
+| `typed_nodes.rs` | Zero-copy typed views: `Heading`, `Text`, `Link`, `Image`, `Code`, `Paragraph`. |
+| `data.rs` | `DataMap` (untyped key-value) and `TypedDataMap` (Rust-only typed storage). |
+
+### `satteri-napi-binding` (crates/satteri-napi-binding/)
+
+The NAPI boundary. Every function callable from JavaScript is defined in `src/lib.rs` (651 lines). 24 `#[napi]` functions including: `create_mdast_handle`, `walk_mdast_handle`, `apply_commands_to_mdast_handle`, `convert_mdast_to_hast_handle`, `walk_handle`, `apply_commands_to_handle`, `render_handle`, `compile_handle`, `serialize_handle`, `drop_handle`, etc.
+
+Arenas never leave Rust memory -- only opaque `External<Mutex<Arena>>` handles cross NAPI. Binary data crosses in two directions:
+- **Rust to JS:** `serialize_handle` / `walk_*_handle` produce `Uint8Array` buffers
+- **JS to Rust:** `apply_commands_to_*_handle` accepts `Uint8Array` command buffers
+
+### `satteri` (crates/satteri/)
+
+Thin facade. `markdown_to_html()` and `compile_mdx()` for pure-Rust usage. 20 lines.
+
+## TypeScript Layer (packages/satteri/)
+
+| File | Role |
+|------|------|
+| `src/index.ts` | Public API surface. All exports go through here. |
+| `src/compile.ts` | Pipeline orchestrator (577 lines). `markdownToHtml`, `mdxToJs`, `evaluate`, `markdownToMdast`, etc. Wires together parsing, plugins, conversion, rendering. Conditional sync/async return types based on plugin signatures. |
+| `src/plugin.ts` | `defineMdastPlugin` / `defineHastPlugin` factory functions. |
+| `src/types.ts` | `MdastNode`, `HastNode`, `BufferHeader`, module augmentation for custom node types. |
+| `src/mdx-types.ts` | MDX JSX node type definitions (avoids transitive deps). |
+| `src/directive-types.ts` | Directive node type definitions. |
+| `src/command-buffer.ts` | `CommandBuffer` class -- binary encoder for JS-to-Rust mutations (247 lines). Constants must match `js_commands.rs`. |
+| `src/lazy-props.ts` | `lazyProp` / `lazyGroup` utilities for deferred property resolution on materialized nodes. |
+| `src/binding.ts` | Re-exports NAPI functions (Node.js target). |
+| `src/binding.browser.ts` | Re-exports WASI functions (browser target). |
+| `src/mdast/mdast-reader.ts` | `MdastReader` -- decodes binary MDAST wire format. 33 node types, type-specific decoders. |
+| `src/mdast/mdast-materializer.ts` | `materializeMdastTree()` -- binary arena to lazy JS objects. |
+| `src/mdast/mdast-visitor.ts` | MDAST plugin visitor pipeline (792 lines). `MdastVisitorContext`, `resolveMdastSubscriptions`, `visitMdastHandle`. |
+| `src/hast/hast-reader.ts` | `HastReader` -- decodes binary HAST wire format. 11 node types. |
+| `src/hast/hast-materializer.ts` | `materializeHastTree()` -- binary arena to lazy JS objects. |
+| `src/hast/hast-visitor.ts` | HAST plugin visitor pipeline (792 lines). Filtered visitors for elements. `WalkElement` with prototype-based lazy getters. |
+
+## Pipeline Trace: `markdownToHtml`
+
+This is the full data flow for a `markdownToHtml(source, { mdastPlugins, hastPlugins })` call:
+
+```
+1. createMdMdastHandle(source, features)
+   TS: compile.ts -> NAPI: create_mdast_handle()
+   Rust: pulldown-cmark parser -> arena_build.rs -> Arena<Mdast>
+   Returns: opaque MdastHandle (External<Mutex<Arena<Mdast>>>)
+
+2. For each MDAST plugin (sequential):
+   a. resolveMdastSubscriptions(plugin) -> [{nodeType, visitFn}]
+      TS: mdast-visitor.ts (maps method names to node type numbers)
+   
+   b. walkMdastHandle(handle, subscriptions) -> Uint8Array
+      NAPI -> Rust: walk.rs::walk_mdast() (DFS, subscription filter, inline serialization)
+   
+   c. For each matched node in the binary buffer:
+      TS: readMdastMatchedNode() decodes inline binary data
+      TS: dispatches to visitor function
+      TS: classifies return value -> CommandBuffer mutations
+   
+   d. Merge context commands + return-value commands -> single Uint8Array
+   
+   e. applyCommandsToMdastHandle(handle, buffer)
+      NAPI -> Rust: js_commands.rs::apply_mdast_commands()
+      -> SET_PROPERTY: mutates type_data in-place
+      -> Structural commands: collected as Patch objects
+      -> rebuild.rs::rebuild() produces new Arena<Mdast>
+
+3. readFrontmatter(handle) -> extract YAML/TOML from MDAST
+   NAPI: get_mdast_frontmatter()
+
+4. convertMdastToHastHandle(handle)
+   NAPI -> Rust: convert.rs::mdast_arena_to_hast_arena()
+   Consumes MdastHandle, returns HastHandle (External<Mutex<Arena<Hast>>>)
+
+5. For each HAST plugin (same walk/dispatch/apply cycle as step 2):
+   resolveSubscriptions() includes tag filters for element visitors
+   walkHandle() filters by tag name in Rust (only matching elements cross NAPI)
+   HastVisitorContextImpl handles element property mutations
+
+6. renderHandle(handle)
+   NAPI -> Rust: hast/render.rs::hast_arena_to_html()
+   Returns: HTML string
+
+7. dropHandle(handle) -- releases Rust memory
+```
+
+For `mdxToJs`, step 6 becomes `compileHandle()` which calls `satteri-mdxjs-rs::compile_hast_arena()` (HAST -> OXC AST -> JS string).
+
+## MDAST/HAST Parallel Structure
+
+These file pairs mirror each other. When modifying one side, check whether the same change applies to the other:
+
+| MDAST | HAST |
+|-------|------|
+| `satteri-ast/src/mdast/node.rs` | `satteri-ast/src/hast/node.rs` |
+| `satteri-ast/src/mdast/codec.rs` | `satteri-ast/src/hast/codec.rs` |
+| `satteri-ast/src/mdast/mod.rs` | `satteri-ast/src/hast/mod.rs` |
+| `src/mdast/mdast-reader.ts` | `src/hast/hast-reader.ts` |
+| `src/mdast/mdast-materializer.ts` | `src/hast/hast-materializer.ts` |
+| `src/mdast/mdast-visitor.ts` | `src/hast/hast-visitor.ts` |
+
+The walk, rebuild, and js_commands modules are generic or branched internally -- they handle both kinds via `ArenaKind` or explicit match arms.
+
+## Guardrails
+
+From AGENTS.md -- these apply to all agents:
+
+- Do not create new documentation files to explain implementation.
+- Do not add external dependencies without justification. Prefer the standard library and existing utilities.
+- Match the current project structure, naming, and style; do not create parallel patterns.
+- All code, comments, documentation, commit messages, and user-facing output must be in English.
+- The vendored `pulldown-cmark` intentionally diverges from upstream -- do not "update" to match upstream without explicit instruction.
+- If an optimization or pattern is applied for MDAST, it should most likely also be applied for HAST, unless there is a specific reason not to.
+
+## References
+
+For deeper information:
+- Read `.agents/skills/navigate-satteri/references/architecture.md` for file-by-file breakdowns, binary format layouts, and key data structures.
+- Read `.agents/skills/navigate-satteri/references/test-guide.md` for all testing information: test locations, how to add tests, spec test format, conformance patterns, and commands.

--- a/.agents/skills/navigate-satteri/references/architecture.md
+++ b/.agents/skills/navigate-satteri/references/architecture.md
@@ -1,0 +1,279 @@
+# Satteri Architecture Reference
+
+Deep dive into binary formats, key data structures, and file-level details.
+
+## Binary Formats
+
+### ArenaNode (52 bytes, `#[repr(C)]`)
+
+Defined in `crates/satteri-arena/src/node.rs`. Every node in the arena is exactly this struct:
+
+```
+Offset  Size  Field
+0       4     id: u32
+4       1     node_type: u8
+5       3     _padding
+8       4     parent: u32 (u32::MAX = no parent)
+12      4     start_offset: u32
+16      4     end_offset: u32
+20      4     start_line: u32
+24      4     start_column: u32
+28      4     end_line: u32
+32      4     end_column: u32
+36      4     children_start: u32 (index into Arena::children)
+40      4     children_count: u32
+44      4     data_offset: u32 (index into Arena::type_data)
+48      4     data_len: u32
+```
+
+### StringRef (8 bytes, `#[repr(C)]`)
+
+Defined in `crates/satteri-arena/src/node.rs`. A zero-copy reference into the arena's source string:
+
+```
+Offset  Size  Field
+0       4     offset: u32
+4       4     len: u32
+```
+
+Resolved via `Arena::get_str(string_ref)`. When a new string is synthesized (e.g., character references, plugin-generated content), it is appended to `Arena::source` via `alloc_string()` and a new `StringRef` is returned.
+
+### Wire Format (Rust to JS)
+
+Produced by `Arena::to_raw_buffer()` in `crates/satteri-arena/src/raw_buffer.rs`. Consumed by `MdastReader` / `HastReader` in TypeScript.
+
+```
+[Header: 44 bytes (11 x u32, native endian)]
+  0: magic = b"MDAR" (0x5244414D)
+  4: kind (1=Mdast, 2=Hast)
+  8: node_struct_size (52)
+ 12: node_count
+ 16: nodes_offset
+ 20: children_count
+ 24: children_offset
+ 28: type_data_len
+ 32: type_data_offset
+ 36: source_len
+ 40: source_offset
+
+[Nodes section: node_count * 52 bytes]
+  Raw ArenaNode structs, cast from Vec<ArenaNode>
+
+[Children section: children_count * 4 bytes]
+  Raw u32 child IDs, cast from Vec<u32>
+
+[Type data section: type_data_len bytes]
+  Packed per-node binary data
+
+[Source section: source_len bytes]
+  UTF-8 source string
+```
+
+### Walk Result Format (Rust to JS)
+
+Produced by `walk_mdast()` / `walk_hast()` in `crates/satteri-ast/src/walk.rs`. Read by `visitMdastHandle` / `visitHastHandle` in TypeScript.
+
+```
+[match_count: u32]
+[match_index: count * 12 bytes]
+  Per entry (12 bytes each):
+    node_id: u32 (4B)
+    sub_index: u8 (1B, which subscription matched)
+    pad: u8 (1B)
+    data_offset: u32 (4B, byte offset into data section)
+    data_len: u16 (2B)
+
+[data section: variable length]
+  Per matched node (format depends on node type):
+    node_data_len: u32  (JSON blob length, 0 if none)
+    node_data: [u8; node_data_len]
+    position: 6 x u32 (start_offset, end_offset, start_line, start_col, end_line, end_col)
+    child_count: u16
+    child_ids: child_count x u32
+    ...type-specific data (heading depth, text value as StringRef, etc.)
+```
+
+The inline serialization avoids per-node NAPI round-trips. JS reads everything from the flat buffer via `DataView`.
+
+### Command Buffer Format (JS to Rust)
+
+Encoded by `CommandBuffer` class in `packages/satteri/src/command-buffer.ts`. Parsed by `apply_mdast_commands()` / `apply_hast_commands()` in `crates/satteri-plugin-api/src/js_commands.rs`.
+
+```
+Repeated command frames:
+  command_type: u8
+    0x01 = REMOVE
+    0x05 = INSERT_BEFORE
+    0x06 = INSERT_AFTER
+    0x07 = PREPEND_CHILD
+    0x08 = APPEND_CHILD
+    0x09 = WRAP
+    0x0B = REPLACE
+    0x0C = SET_PROPERTY
+
+For structural commands (INSERT/REPLACE/WRAP/CHILD):
+  node_id: u32
+  payload_type: u8
+    0x10 = RAW_MARKDOWN (Rust re-parses the string)
+    0x11 = RAW_HTML (inserted as Raw node)
+    0x12 = SERDE_JSON (structured JsNode, deserialized in Rust)
+  payload_len: u32
+  payload: [u8; payload_len]
+
+For REMOVE:
+  node_id: u32
+
+For SET_PROPERTY:
+  node_id: u32
+  field_name_len: u32
+  field_name: UTF-8 string
+  value_type: u8
+    0 = PROP_STRING
+    1 = PROP_BOOL_TRUE
+    2 = PROP_BOOL_FALSE
+    3 = PROP_SPACE_SEP (space-separated list, for HAST element properties)
+    5 = PROP_INT
+    6 = PROP_NULL
+  For PROP_STRING/PROP_SPACE_SEP: value_len: u32, value: UTF-8 string
+  For PROP_INT: value: u32
+  For PROP_BOOL_TRUE/FALSE/NULL: no additional data
+```
+
+## MDAST Type Data Layouts
+
+Each MDAST node type stores its data as packed bytes in `Arena::type_data`. Defined in `crates/satteri-ast/src/mdast/codec.rs`.
+
+| Node Type | Layout | Size |
+|-----------|--------|------|
+| Heading | `depth: u8` | 1B |
+| Text, InlineCode, Html, Yaml, Toml, InlineMath | `value: StringRef` | 8B |
+| Link | `url: StringRef, title: StringRef` | 16B |
+| Image | `url: StringRef, alt: StringRef, title: StringRef` | 24B |
+| Code | `lang: StringRef, meta: StringRef, value: StringRef, fence_char: u8` | 28B |
+| Definition | `url: StringRef, title: StringRef, identifier: StringRef, label: StringRef` | 32B |
+| List | `start: u32, ordered: bool, spread: bool` | 8B |
+| ListItem | `checked: u8 (0=unchecked, 1=checked, 2=not-task), spread: bool` | 2B |
+| Table | `align_count: u32` + `align_count` x `ColumnAlign` (1B each) | 4B + N |
+| LinkReference, ImageReference, FootnoteReference | `identifier: StringRef, label: StringRef, reference_kind: u8` | 20B |
+| FootnoteDefinition | `identifier: StringRef, label: StringRef` | 16B |
+| Math | `meta: StringRef, value: StringRef` | 16B |
+| Expression (MdxFlow/TextExpression, MdxjsEsm) | `value: StringRef` | 8B |
+| MdxJsxFlowElement, MdxJsxTextElement | `name: StringRef` + 16B header + N x 20B attrs | 24B + 20N |
+| Directive (Container/Leaf/Text) | `name: StringRef` + N x 16B attrs (key: StringRef, value: StringRef) | 8B + 16N |
+| Root, Paragraph, ThematicBreak, Blockquote, Emphasis, Strong, Break, Delete, TableRow, TableCell | (no type data) | 0B |
+
+MDX JSX attribute entry (20 bytes):
+```
+kind: u8 (0=boolean, 1=literal, 2=expression, 3=spread)
+_pad: 3 bytes
+name: StringRef (8B)
+value: StringRef (8B)
+```
+
+## HAST Type Data Layouts
+
+Defined in `crates/satteri-ast/src/hast/codec.rs`.
+
+| Node Type | Layout | Size |
+|-----------|--------|------|
+| Element | 16B header: `tag_name: StringRef, prop_count: u32, _pad: u32` + N x 20B props | 16B + 20N |
+| Text, Comment, Raw | `value: StringRef` | 8B |
+| MdxJsxElement, MdxJsxTextElement | Same as MDAST MDX JSX encoding | variable |
+| MdxFlowExpression, MdxTextExpression, MdxEsm | `value: StringRef` | 8B |
+| Root, Doctype | (no type data) | 0B |
+
+HAST Element property entry (20 bytes):
+```
+name: StringRef (8B)
+value_type: u8 (0=string, 1=bool_true, 2=bool_false, 3=space_sep, 4=comma_sep, 5=int, 6=null)
+_pad: 3 bytes
+value: StringRef (8B)
+```
+
+## Arena<K> Fields
+
+Defined in `crates/satteri-arena/src/arena.rs`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nodes` | `Vec<ArenaNode>` | Flat node storage. Index = node ID. |
+| `children` | `Vec<u32>` | Flat child ID array. Nodes reference ranges via `children_start`/`children_count`. |
+| `type_data` | `Vec<u8>` | Packed variable-length per-node data. Nodes reference slices via `data_offset`/`data_len`. |
+| `source` | `String` | Original source text (+ any strings appended by `alloc_string`). StringRefs point into this. |
+| `node_data` | `FxHashMap<u32, Vec<u8>>` | Optional per-node JSON blobs set by JS plugins (for `data` property / `hProperties` / etc.). |
+| `mdx` | `bool` | Whether the arena was parsed with MDX extensions. |
+| `parse_options` | `u32` | Bitflags of the parser options used. |
+
+## ArenaBuilder<K> Stack Model
+
+Defined in `crates/satteri-arena/src/builder.rs`. The builder maintains:
+
+- `arena: Arena<K>` -- the arena being built
+- `stack: Vec<(u32, u32)>` -- `(node_id, children_start)` pairs
+- `pending_children: Vec<u32>` -- children collected for the current open node
+
+`open_node(type)` pushes onto the stack. `close_node()` pops, copies pending children to `arena.children`, sets parent backlinks, and registers the closed node as a child of the new stack top. `add_leaf(type)` is a shortcut for nodes with no children.
+
+## The Rebuild System
+
+Defined in `crates/satteri-ast/src/rebuild.rs`. After plugin mutations are collected as `Patch` objects, `rebuild()` produces a new arena:
+
+1. Build a `patch_map: FxHashMap<u32, Vec<Patch>>` from all patches
+2. Validate: Wrap+Remove on same node is an error; Child patches on removed nodes error
+3. DFS via `copy_node()`: for each node, apply patches in order:
+   - InsertBefore patches first (emit sub-arenas as siblings)
+   - If Remove: skip the node entirely
+   - If Replace: emit the replacement sub-arena (optionally keeping original children)
+   - If Wrap: emit wrapper root, then the original node as its child
+   - Normal copy: emit the node, handle PrependChild/AppendChild
+   - InsertAfter patches last
+4. `emit_subtree()` copies sub-arenas into the new builder with StringRef remapping (source strings are concatenated, offsets adjusted)
+5. Verify no patches were stranded on removed subtrees
+
+`remap_string_refs()` dispatches to `remap_mdast_string_refs()` or `remap_hast_string_refs()` based on `K::KIND_TAG`. These functions know the byte layout of every node type's type_data to find and offset StringRef fields.
+
+## The JS Plugin Execution Model
+
+When a JS plugin runs (e.g., an MDAST plugin in `visitMdastHandle`):
+
+1. **Subscription resolution**: Plugin method names (e.g., `heading`, `text`, `code`) are mapped to numeric node type IDs
+2. **Rust walk**: `walkMdastHandle()` calls `walk_mdast()` which does a DFS, filtering by subscriptions. For HAST element visitors, tag name filters are applied in Rust -- only matching elements cross NAPI.
+3. **Binary match buffer**: Matched nodes are serialized inline with all their type-specific data (avoiding per-node NAPI round-trips).
+4. **JS dispatch**: For each match, `readMdastMatchedNode()` decodes the binary data into a lightweight JS object. Element nodes use `WalkElement` with prototype-based lazy getters (V8-optimized, ~16x faster than per-instance `defineProperty`). Children use `LazyChildResolver` -- serializes the handle once, then materializes via reader + materializer.
+5. **Visitor call**: The visitor function receives `(Readonly<Node>, Context)`. It can:
+   - Return `void` (no change)
+   - Return a replacement `MdastNode` / `HastNode` (replace)
+   - Return `{ raw: string }` (Rust re-parses as Markdown)
+   - Return `{ rawHtml: string }` (Rust inserts as Raw node)
+   - Call context methods: `ctx.setProperty()`, `ctx.removeNode()`, `ctx.insertBefore()`, etc.
+6. **Command buffer**: Both return values and context methods write to `CommandBuffer` instances. These are merged and sent to Rust as a single `Uint8Array`.
+7. **Rust apply**: `apply_mdast_commands()` / `apply_hast_commands()` parses the buffer. SET_PROPERTY mutations happen in-place. Structural mutations become `Patch` objects and trigger `rebuild()`.
+
+## NAPI Handle Types
+
+Defined in `crates/satteri-napi-binding/src/lib.rs`:
+
+- `MdastHandle` = `External<Mutex<Arena<Mdast>>>` -- created by `create_mdast_handle`, consumed by `convert_mdast_to_hast_handle`
+- `HastHandle` = `External<Mutex<Arena<Hast>>>` -- created by `convert_mdast_to_hast_handle` or `create_hast_handle`
+- `AnyHandle` = `Either<&MdastHandle, &HastHandle>` -- used by kind-agnostic operations like `serialize_handle`
+
+Handles are reference-counted by NAPI. `drop_handle()` explicitly releases the arena memory. Forgetting to drop causes a memory leak (the Rust memory stays alive until the JS garbage collector finalizes the External, which is non-deterministic).
+
+## Key Crate Dependencies
+
+```
+satteri-arena (standalone, depends on: memchr, rustc-hash)
+    |
+    v
+satteri-ast (depends on: satteri-arena, rustc-hash, serde, serde_json, pulldown-cmark-escape)
+    |
+    +---> satteri-pulldown-cmark (depends on: satteri-arena, satteri-ast, memchr, unicode-id-start)
+    +---> satteri-mdxjs-rs (depends on: satteri-arena, satteri-ast, satteri-pulldown-cmark, oxc_*)
+    +---> satteri-plugin-api (depends on: satteri-arena, satteri-ast, rustc-hash, serde, serde_json)
+              |
+              v
+         satteri-napi-binding (depends on: all of the above, napi, napi-derive)
+              |
+              v
+         satteri (facade, depends on: satteri-ast, satteri-pulldown-cmark, satteri-mdxjs-rs)
+```

--- a/.agents/skills/navigate-satteri/references/test-guide.md
+++ b/.agents/skills/navigate-satteri/references/test-guide.md
@@ -1,0 +1,265 @@
+# Satteri Test Guide
+
+Complete reference for testing: where tests live, how to add them, how to run them.
+
+## Test Locations Overview
+
+### Rust Tests
+
+| Location | What it tests |
+|----------|--------------|
+| `crates/satteri-pulldown-cmark/specs/*.txt` | Spec test cases (CommonMark extensions) |
+| `crates/satteri-pulldown-cmark/third_party/*.txt` | CommonMark and GFM upstream specs |
+| `crates/satteri-pulldown-cmark/tests/` | Integration tests (HTML output, MDX, errors) |
+| `crates/satteri-ast/tests/` | Arena construction, HTML rendering, codec roundtrips, rebuild, positions |
+| `crates/satteri-plugin-api/tests/` | Plugin basics, commands, data, runner, rebuild integration |
+| `crates/satteri-mdxjs-rs/tests/test.rs` | MDX-to-JS compilation end-to-end |
+| Inline `#[cfg(test)]` modules | Unit tests in ~20 files across all crates |
+
+### JavaScript Tests
+
+| Location | What it tests |
+|----------|--------------|
+| `packages/satteri/test/compile.test.ts` | Top-level API: `markdownToHtml`, `mdxToJs`, frontmatter, plugin integration |
+| `packages/satteri/test/visitor.test.ts` | MDAST visitor handle API: subscriptions, callbacks, mutations |
+| `packages/satteri/test/hast-visitor.test.ts` | HAST visitor handle API: element/text callbacks, mutations |
+| `packages/satteri/test/html-plugin.test.ts` | End-to-end MDAST/HAST plugin pipeline affecting HTML output |
+| `packages/satteri/test/plugin.test.ts` | `defineMdastPlugin` identity and validation |
+| `packages/satteri/test/materializer.test.ts` | MDAST tree materialization from binary arena buffers |
+| `packages/satteri/test/mdast-reader.test.ts` | Low-level `MdastReader` binary buffer reading |
+| `packages/satteri/test/conformance/` | Conformance against remark/rehype ecosystem (19 test files) |
+| `packages/satteri/test/fixtures.ts` | Test utility: builds binary arena buffers in pure JS |
+
+### Key Conformance Test Files
+
+| File | Reference implementation |
+|------|------------------------|
+| `conformance/mdast.test.ts` | `remark-parse` + `remark-gfm` |
+| `conformance/hast.test.ts` | `remark-parse` + `remark-gfm` + `remark-rehype` |
+| `conformance/mdx.test.ts` | `@mdx-js/mdx` |
+| `conformance/mdx-ast.test.ts` | `remark` + `remark-mdx` |
+| `conformance/math.test.ts` | `remark-math` |
+| `conformance/frontmatter.test.ts` | `remark-frontmatter` |
+| `conformance/directive.test.ts` | `remark-directive` |
+| `conformance/fuzz.test.ts` | Property-based fuzz tests with `fast-check` |
+| `conformance/spec-deltas.test.ts` | Known deviations from CommonMark spec |
+
+### Inline Unit Test Locations
+
+Major `#[cfg(test)]` modules in the Rust codebase:
+
+| File | Line | What it tests |
+|------|------|--------------|
+| `satteri-arena/src/arena.rs` | ~236 | Allocation, position roundtrip, children/parent, string resolution |
+| `satteri-arena/src/builder.rs` | ~302 | Open/close, auto-close on finish, leaf creation |
+| `satteri-arena/src/node.rs` | ~87 | Size assertions (52-byte node, 8-byte StringRef) |
+| `satteri-arena/src/line_index.rs` | ~70 | Byte offset to line/column mapping |
+| `satteri-ast/src/mdast/codec.rs` | ~608 | MDAST type_data encode/decode roundtrips |
+| `satteri-ast/src/hast/codec.rs` | ~62 | HAST type_data encode/decode roundtrips |
+| `satteri-ast/src/hast/properties.rs` | ~467 | Property to attribute name mapping |
+| `satteri-ast/src/convert.rs` | ~1999 | MDAST-to-HAST conversion |
+| `satteri-ast/src/rebuild.rs` | ~609 | All patch types, composition, error cases |
+| `satteri-ast/src/walk.rs` | ~510 | Subscription matching, binary serialization |
+| `satteri-ast/src/text_content.rs` | ~52 | Text extraction |
+| `satteri-plugin-api/src/js_commands.rs` | ~1172 | Command buffer parsing, set-property, replace, directives |
+| `satteri-pulldown-cmark/src/parse.rs` | ~2728 | Core parser internals |
+| `satteri-pulldown-cmark/src/firstpass.rs` | ~3851 | Block-level first pass |
+| `satteri-pulldown-cmark/src/scanners.rs` | ~1596 | Inline scanning patterns |
+
+## Spec Test Format
+
+Spec tests live in `.txt` files under `crates/satteri-pulldown-cmark/specs/` (custom extensions) and `crates/satteri-pulldown-cmark/third_party/` (CommonMark/GFM upstream).
+
+### Format of a spec test case
+
+```
+Optional prose description of what this tests.
+
+```````````````````````````````` example
+markdown input here
+can be multiple lines
+.
+expected HTML output here
+can also be multiple lines
+````````````````````````````````
+```
+
+Rules:
+- Opening fence: exactly 32 backticks followed by ` example`
+- Input and expected output are separated by a line containing only `.`
+- Closing fence: exactly 32 backticks
+- Tabs in specs are represented as the arrow character and converted to `\t` at parse time
+- Disable a test by using `DISABLED example` instead of `example`
+
+### Extension-specific flags
+
+Append to the `example` keyword to enable specific parser options:
+
+| Suffix | Parser option enabled |
+|--------|---------------------|
+| `example_smartpunct` | Smart punctuation |
+| `example_metadata_blocks` | YAML/TOML metadata blocks |
+| `example_super_sub` | Superscript/subscript |
+| `example_wikilinks` | Wikilinks |
+| `example_deflists` | Definition lists |
+| `example_container_extensions` | Directives |
+
+Each spec file is mapped to a base set of parser options in the `base_options_for_spec()` function in `build.rs`. Tests within a file inherit that base, and the flag suffix adds on top.
+
+### Adding a new spec test
+
+1. Open the appropriate `.txt` file under `specs/` (or create one for a new extension)
+2. Append the test case in the format above
+3. Run `cargo test -p satteri-pulldown-cmark` -- the `build.rs` script auto-generates Rust test files from the spec files
+
+### Spec files inventory
+
+| File | What it covers |
+|------|---------------|
+| `specs/table.txt` | GFM table extension |
+| `specs/footnotes.txt` | Footnote definitions and references |
+| `specs/strikethrough.txt` | GFM strikethrough |
+| `specs/math.txt` | Math blocks and inline math |
+| `specs/heading_attrs.txt` | Heading attribute syntax |
+| `specs/metadata_blocks.txt` | YAML/TOML frontmatter |
+| `specs/regression.txt` | Regression test cases |
+| `specs/super_sub.txt` | Superscript/subscript |
+| `specs/wikilinks.txt` | Wikilink syntax |
+| `specs/container_extensions.txt` | Directive syntax |
+
+## Conformance Test Pattern
+
+JS conformance tests compare Satteri output against the canonical remark/rehype ecosystem. The pattern is defined in `test/conformance/helpers.ts`.
+
+### MDAST conformance
+
+```ts
+assertMdastConformance("# Hello");
+// reference = unified().use(remarkParse).use(remarkGfm).parse(md)
+// actual    = markdownToMdast(md, { features: { frontmatter: false, math: false } })
+// Deeply compared after JSON serialization
+```
+
+### HAST conformance
+
+```ts
+assertHastConformance("# Hello");
+// reference = remarkParse -> remarkGfm -> remarkRehype -> runSync
+// actual    = markdownToHast(md, { features: { frontmatter: false, math: false } })
+// Compared with normalizations (align->style, strip data)
+```
+
+### Extension conformance
+
+```ts
+assertExtMdastConformance("$x^2$", ["math"]);
+// Builds a custom reference processor with the specified remark plugins
+// Enables matching features on the Satteri side
+```
+
+### MDX conformance
+
+```ts
+await assertMdxConformance("<Foo bar={1}/>", { Foo });
+// Both @mdx-js/mdx and Satteri evaluate the MDX
+// Rendered to HTML via React's renderToStaticMarkup
+// Normalized HTML strings compared
+```
+
+### Normalizations applied during comparison
+
+- `data` properties are stripped (remark attaches internal data)
+- Table `align` properties are converted to `style="text-align: ..."` (different HAST conventions)
+- HTML void elements normalized (`<br>` / `<br/>` to `<br />`)
+- HTML entities normalized
+- Position columns may differ for non-ASCII inputs (byte vs. codepoint counting), use `assertExtMdastConformanceNoPosition` in those cases
+
+## Running Tests
+
+### Rust
+
+```sh
+# All Rust tests
+cargo test --all
+
+# Specific crate
+cargo test -p satteri-pulldown-cmark
+cargo test -p satteri-ast
+cargo test -p satteri-plugin-api
+cargo test -p satteri-mdxjs-rs
+
+# Specific test by name substring
+cargo test -p satteri-pulldown-cmark regression_test_1
+
+# Specific integration test file
+cargo test -p satteri-pulldown-cmark --test html
+cargo test -p satteri-pulldown-cmark --test mdx
+cargo test -p satteri-pulldown-cmark --test errors
+
+# Spec suite subsets
+cargo test -p satteri-pulldown-cmark suite::table
+cargo test -p satteri-pulldown-cmark suite::regression
+cargo test -p satteri-pulldown-cmark suite::spec
+```
+
+### JavaScript
+
+```sh
+# All JS tests (must be run from packages/satteri/)
+pnpm test
+# This runs: vitest run
+
+# Specific test file
+pnpm vitest run test/compile.test.ts
+pnpm vitest run test/conformance/mdast.test.ts
+pnpm vitest run test/conformance/fuzz.test.ts
+
+# Filter by test name
+pnpm vitest run -t "heading"
+```
+
+**Important:** If native Rust code changed, rebuild before running JS tests:
+```sh
+pnpm build
+# This runs: napi build + tsc
+```
+
+### Linting and formatting (required before PRs)
+
+```sh
+cargo clippy --all --all-targets    # Rust lint
+cargo fmt --all                      # Rust format
+pnpm lint                            # oxlint + cargo clippy + knip
+pnpm format                          # oxfmt + cargo fmt
+```
+
+### Full verification sequence
+
+After any change, the minimum verification before submitting:
+```sh
+cargo clippy --all --all-targets
+cargo fmt --all --check
+cargo test --all
+cd packages/satteri && pnpm build && pnpm test
+```
+
+## Which Tests to Run Based on What Changed
+
+| Changed area | Tests to run |
+|-------------|-------------|
+| `crates/satteri-pulldown-cmark/` | `cargo test -p satteri-pulldown-cmark` + conformance tests |
+| `crates/satteri-ast/src/mdast/` | `cargo test -p satteri-ast` + JS mdast conformance |
+| `crates/satteri-ast/src/hast/` | `cargo test -p satteri-ast` + JS hast conformance + HTML tests |
+| `crates/satteri-ast/src/convert.rs` | `cargo test -p satteri-ast` + JS hast conformance |
+| `crates/satteri-ast/src/rebuild.rs` | `cargo test -p satteri-ast` + JS plugin tests |
+| `crates/satteri-ast/src/walk.rs` | `cargo test -p satteri-ast` + JS visitor tests |
+| `crates/satteri-plugin-api/` | `cargo test -p satteri-plugin-api` + JS plugin/visitor tests |
+| `crates/satteri-plugin-api/src/js_commands.rs` | `cargo test -p satteri-plugin-api` + all JS tests |
+| `crates/satteri-mdxjs-rs/` | `cargo test -p satteri-mdxjs-rs` + JS MDX conformance |
+| `crates/satteri-napi-binding/` | JS tests (no Rust tests in this crate) |
+| `packages/satteri/src/mdast/` | JS mdast/visitor/plugin tests |
+| `packages/satteri/src/hast/` | JS hast-visitor/html-plugin tests |
+| `packages/satteri/src/compile.ts` | `pnpm test` (all JS tests) |
+| `packages/satteri/src/command-buffer.ts` | JS plugin/visitor tests + Rust js_commands tests |
+
+When in doubt, run the full verification sequence.


### PR DESCRIPTION
I used an agent, with the skill `skill-creator` to create skills that could help an agent navigate the code base and fix bugs. 