### PR TITLE
Add documentation comment to website routes module

### DIFF
--- a/website/src/routes/mod.rs
+++ b/website/src/routes/mod.rs
@@ -1,3 +1,5 @@
+//! Website routes module.
+
 mod chat;
 mod docs;
 mod index;


### PR DESCRIPTION
## Background
The `website/src/routes/mod.rs` module is a public module that defines and re-exports routes for the website, but it lacked any documentation comment. In Rust projects, adding doc comments improves code readability and maintainability, especially for modules that serve as entry points or re-export items.

## Changes
Added a module-level doc comment (`//! Website routes module.`) to `website/src/routes/mod.rs` to provide clear documentation for this module's purpose.

## Verification
- The change is minimal and only adds a doc comment, so it does not affect functionality.
- Verify by running `cargo doc` to ensure documentation generates correctly and checking that the comment appears in the generated docs.
- This follows Rust documentation best practices and maintains code style consistency.