### PR TITLE
Fix smart double quote closing before adjacent text

### DIFF
--- a/.sampo/changesets/haughty-princess-goulven.md
+++ b/.sampo/changesets/haughty-princess-goulven.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-pulldown-cmark: patch
+npm/satteri: patch
+---
+
+Fixes a smart punctuation issue where a trailing double quote could be rendered as an opening quote when text immediately followed the quoted text without whitespace.

--- a/.sampo/changesets/haughty-princess-goulven.md
+++ b/.sampo/changesets/haughty-princess-goulven.md
@@ -3,4 +3,4 @@ cargo/satteri-pulldown-cmark: patch
 npm/satteri: patch
 ---
 
-Fixes a smart punctuation issue where a trailing double quote could be rendered as an opening quote when text immediately followed the quoted text without whitespace.
+Fixes a smart punctuation issue where double quotes could be rendered with the wrong direction when quoted text appeared next to text without whitespace.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -5627,6 +5627,14 @@ fn delim_run_can_open(
                 && (prev_char.is_whitespace() || is_punctuation(prev_char)));
     }
 
+    // Double quotes can open after a non-space word character. For example, `에"About Me"` has
+    // quoted text attached directly after Korean text.
+    if delim == b'"' {
+        return !is_punctuation(next_char)
+            || prev_char.is_whitespace()
+            || is_punctuation(prev_char);
+    }
+
     prev_char.is_whitespace()
         || is_punctuation(prev_char) && (delim != b'\'' || ![']', ')'].contains(&prev_char))
 }

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -5682,6 +5682,14 @@ fn delim_run_can_close(
                 && (next_char.is_whitespace() || is_punctuation(next_char)));
     }
 
+    // Double quotes can close before a non-space word character. For example, `"About Me"로` has
+    // Korean text attached directly after the quoted phrase.
+    if delim == b'"' {
+        return !is_punctuation(prev_char)
+            || next_char.is_whitespace()
+            || is_punctuation(next_char);
+    }
+
     next_char.is_whitespace() || is_punctuation(next_char)
 }
 

--- a/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
+++ b/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
@@ -94,6 +94,18 @@ fn combined_flag_still_works() {
 }
 
 #[test]
+fn double_quote_opens_after_ascii_letter() {
+    let html = render(r#"x"About Me""#, opts_quotes_only());
+    assert_eq!(html, "<p>x“About Me”</p>\n");
+}
+
+#[test]
+fn double_quote_opens_after_non_ascii_letter() {
+    let html = render(r#"에"About Me""#, opts_quotes_only());
+    assert_eq!(html, "<p>에“About Me”</p>\n");
+}
+
+#[test]
 fn double_quote_closes_before_ascii_letter() {
     let html = render(r#""About Me"x"#, opts_quotes_only());
     assert_eq!(html, "<p>“About Me”x</p>\n");
@@ -103,4 +115,16 @@ fn double_quote_closes_before_ascii_letter() {
 fn double_quote_closes_before_non_ascii_letter() {
     let html = render(r#""About Me"로"#, opts_quotes_only());
     assert_eq!(html, "<p>“About Me”로</p>\n");
+}
+
+#[test]
+fn double_quote_opens_and_closes_next_to_ascii_letters() {
+    let html = render(r#"x"About Me"y"#, opts_quotes_only());
+    assert_eq!(html, "<p>x“About Me”y</p>\n");
+}
+
+#[test]
+fn double_quote_opens_and_closes_next_to_non_ascii_letters() {
+    let html = render(r#"에"About Me"로"#, opts_quotes_only());
+    assert_eq!(html, "<p>에“About Me”로</p>\n");
 }

--- a/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
+++ b/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
@@ -92,3 +92,15 @@ fn combined_flag_still_works() {
     assert!(!html.contains("--"), "no ASCII dashes");
     assert!(!html.contains("..."), "no ASCII dots");
 }
+
+#[test]
+fn double_quote_closes_before_ascii_letter() {
+    let html = render(r#""About Me"x"#, opts_quotes_only());
+    assert_eq!(html, "<p>“About Me”x</p>\n");
+}
+
+#[test]
+fn double_quote_closes_before_non_ascii_letter() {
+    let html = render(r#""About Me"로"#, opts_quotes_only());
+    assert_eq!(html, "<p>“About Me”로</p>\n");
+}


### PR DESCRIPTION
#### Description

This PR fixes a smart punctuation issue and ensure a trailing double quote is rendered as a closing quote when text follows the quoted text without whitespace.

For example, considering the sentence `"About Me"로`, before this PR, the output would be `“About Me“로` instead of `“About Me”로`.

Note that I'm not quite sure I selected all the proper packages when running `pnpx sampo add`. Please let me know if I missed any or some may not be relevant to this change.