### PR TITLE
fix: `DirectiveAttributes` type

### DIFF
--- a/.sampo/changesets/stern-bard-goulven.md
+++ b/.sampo/changesets/stern-bard-goulven.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Aligns directive attribute type with `mdast-util-directive` by allowing nullish attribute values.

--- a/packages/satteri/src/directive-types.ts
+++ b/packages/satteri/src/directive-types.ts
@@ -13,7 +13,11 @@ import type {
   PhrasingContent,
 } from "mdast";
 
-export type DirectiveAttributes = Record<string, string>;
+// Even though `null` and `undefined` values are omitted in both Sätteri and mdast-util-directive,
+// they're allowed in the type definitions here to match the mdast-util-directive type.
+// https://github.com/syntax-tree/mdast-util-directive/blob/a683327fafc4e48f81caf8d09d15fef8dd42a627/lib/index.js#L212-L213
+// https://github.com/syntax-tree/mdast-util-directive/blob/main/index.d.ts#L49
+export type DirectiveAttributes = Record<string, string | null | undefined>;
 
 export interface ContainerDirective extends MdastParent {
   type: "containerDirective";

--- a/packages/satteri/test/visitor.test.ts
+++ b/packages/satteri/test/visitor.test.ts
@@ -12,7 +12,7 @@ import {
   applyCommandsAndConvertToHastHandle,
   renderHandle,
 } from "../index.js";
-import type { MdastNode } from "../src/types.js";
+import type { DirectiveAttributes, MdastNode } from "../src/types.js";
 import type { Heading, Text } from "mdast";
 import { defineMdastPlugin } from "../src/plugin.js";
 import { markdownToHtml, applyCommandsToMdastHandle } from "../src/index.js";
@@ -488,7 +488,7 @@ function setupDirective(md: string) {
 
 test("containerDirective visitor fires and exposes name + attributes", () => {
   const { handle, source } = setupDirective(":::tip{.note #id}\nbody\n:::\n");
-  const seen: { name: string; attributes: Record<string, string> }[] = [];
+  const seen: { name: string; attributes: DirectiveAttributes }[] = [];
   const plugin = defineMdastPlugin({
     name: "collect-container-directive",
     containerDirective(node) {
@@ -521,7 +521,7 @@ test("containerDirective with [label] exposes directiveLabel marker on first chi
 
 test("leafDirective visitor fires and exposes name", () => {
   const { handle, source } = setupDirective("::break{aria-label=section}\n");
-  const seen: { name: string; attributes: Record<string, string> }[] = [];
+  const seen: { name: string; attributes: DirectiveAttributes }[] = [];
   const plugin = defineMdastPlugin({
     name: "collect-leaf-directive",
     leafDirective(node) {


### PR DESCRIPTION
#### Description

This PR updates the [`DirectiveAttributes` type](https://github.com/bruits/satteri/blob/main/packages/satteri/src/directive-types.ts#L16) definition to match the one from [`mdast-util-directive`](https://github.com/syntax-tree/mdast-util-directive/blob/main/index.d.ts#L49).

Added a comment with links to explain why we can update the type without changing the implementation, as `mdast-util-directive` [omits `null` and `undefined` values](https://github.com/syntax-tree/mdast-util-directive/blob/a683327fafc4e48f81caf8d09d15fef8dd42a627/lib/index.js#L212-L213) while still allowing them in the type definition.