### PR TITLE
fix(mdx): correct inline math, ESM template literal, and JSX regex parsing

### DIFF
--- a/.sampo/changesets/fix-mdx-esm-template-blank-line.md
+++ b/.sampo/changesets/fix-mdx-esm-template-blank-line.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-pulldown-cmark: patch
+npm/satteri: patch
+---
+
+Fixes a blank line inside a template literal or block comment in an MDX `import`/`export` causing an `Unterminated string` error. The blank line no longer ends the statement early.

--- a/.sampo/changesets/fix-mdx-inline-math-braces.md
+++ b/.sampo/changesets/fix-mdx-inline-math-braces.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-pulldown-cmark: patch
+npm/satteri: patch
+---
+
+Fixes inline math like `$\frac{-b}{2a}$` failing to compile in MDX. Braces inside `$...$` are now treated as math text, not a JSX expression.

--- a/.sampo/changesets/fix-mdx-jsx-regex-quotes.md
+++ b/.sampo/changesets/fix-mdx-jsx-regex-quotes.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-pulldown-cmark: patch
+npm/satteri: patch
+---
+
+Fixes quotes inside a regex in an MDX JSX attribute (e.g. `ins={[/icon="[^"]+"/g]}`) causing a parse error.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1373,7 +1373,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     // `>`). Don't break the paragraph here — let the inline
                     // resolver pick up the JSX.
                     if !(self.options.contains(Options::ENABLE_MDX)
-                        && prev_line_has_open_inline_jsx(bytes, ix))
+                        && prev_line_has_open_inline_jsx(bytes, ix, self.options.has_math()))
                     {
                         if let Some(pos) = trailing_backslash_pos {
                             self.tree.append_text(pos, pos + 1, false);
@@ -3779,6 +3779,51 @@ fn scan_paragraph_interrupt_no_table(
 /// Same shape as `is_inside_code_span` but for math `$…$` runs. Used to
 /// keep GFM literal-autolink emission from cutting across a math span
 /// boundary (e.g. `$<https://x$` — the `$` pair owns those bytes).
+/// Narrow `[para_start, para_end)` so it doesn't span a display-math fence
+/// line (`$$` / `$$ info`). Such a line is a block boundary the parser splits
+/// on, so inline `$` runs must not pair across it. Without this, the trailing
+/// `$$` in `a$$\n\frac{1}{2}\n$$` pairs with the inline `a$$` and the `{` is
+/// misread as math text instead of an MDX expression. The fence line holding
+/// `pos` is never itself a fence (it holds the `{`), so it's left intact.
+fn clamp_scope_to_math_fences(
+    bytes: &[u8],
+    pos: usize,
+    para_start: usize,
+    para_end: usize,
+) -> (usize, usize) {
+    let mut lo = para_start;
+    let mut hi = para_end;
+    let mut line_start = para_start;
+    while line_start < para_end {
+        let mut line_end = line_start;
+        while line_end < para_end && !matches!(bytes[line_end], b'\n' | b'\r') {
+            line_end += 1;
+        }
+        let mut content = line_start;
+        while content < line_end && bytes[content] == b' ' && content - line_start < 3 {
+            content += 1;
+        }
+        let mut next_line = line_end;
+        if bytes.get(next_line) == Some(&b'\r') {
+            next_line += 1;
+        }
+        if bytes.get(next_line) == Some(&b'\n') {
+            next_line += 1;
+        }
+        if scan_math_fence(&bytes[content..line_end]).is_some() {
+            if line_start > pos {
+                hi = line_start;
+                break;
+            }
+            if line_end <= pos {
+                lo = next_line;
+            }
+        }
+        line_start = next_line;
+    }
+    (lo, hi)
+}
+
 fn is_inside_math_span(bytes: &[u8], pos: usize) -> bool {
     let (para_start, para_end) = scope_for_inline(bytes, pos);
     // Fast reject: need at least one `$` on each side of `pos` to form a
@@ -3790,19 +3835,30 @@ fn is_inside_math_span(bytes: &[u8], pos: usize) -> bool {
     {
         return false;
     }
-    let mut runs: Vec<(usize, usize)> = Vec::with_capacity(4);
+    // Only after the cheap reject: keep `$` runs from pairing across a `$$`
+    // display-math fence line (a block boundary).
+    let (para_start, para_end) = clamp_scope_to_math_fences(bytes, pos, para_start, para_end);
+    // Collect `$` runs as `(start, len, escaped)`. A run preceded by an odd
+    // number of backslashes is escaped (`\$`): matching the `MaybeMath`
+    // resolver, the backslash only prevents *opening* a span; an escaped `$`
+    // can still *close* one. So `$x\$y$` is a single span `x\` that closes at
+    // the escaped `$`, and a `{` between the dollars is math text, not an
+    // expression.
+    let mut runs: Vec<(usize, usize, bool)> = Vec::with_capacity(4);
     let mut i = para_start;
     while i < para_end {
-        if bytes[i] == b'\\' && i + 1 < para_end {
-            i += 2;
-            continue;
-        }
         if bytes[i] == b'$' {
             let start = i;
             while i < para_end && bytes[i] == b'$' {
                 i += 1;
             }
-            runs.push((start, i - start));
+            let mut backslashes = 0usize;
+            let mut k = start;
+            while k > para_start && bytes[k - 1] == b'\\' {
+                backslashes += 1;
+                k -= 1;
+            }
+            runs.push((start, i - start, backslashes % 2 == 1));
         } else {
             i += 1;
         }
@@ -3812,7 +3868,8 @@ fn is_inside_math_span(bytes: &[u8], pos: usize) -> bool {
     }
     let mut paired = vec![false; runs.len()];
     for a in 0..runs.len() {
-        if paired[a] {
+        // An escaped `$` run can't open a span (only close one).
+        if paired[a] || runs[a].2 {
             continue;
         }
         for b in (a + 1)..runs.len() {
@@ -4340,12 +4397,12 @@ fn is_at_paragraph_line_start(bytes: &[u8], pos: usize) -> bool {
 /// `ENABLE_MDX` is never set there, so the real body would have returned
 /// without effect anyway.
 #[cfg(not(feature = "mdx"))]
-fn prev_line_has_open_inline_jsx(_bytes: &[u8], _ix: usize) -> bool {
+fn prev_line_has_open_inline_jsx(_bytes: &[u8], _ix: usize, _has_math: bool) -> bool {
     false
 }
 
 #[cfg(feature = "mdx")]
-fn prev_line_has_open_inline_jsx(bytes: &[u8], ix: usize) -> bool {
+fn prev_line_has_open_inline_jsx(bytes: &[u8], ix: usize, has_math: bool) -> bool {
     if ix == 0 || ix > bytes.len() {
         return false;
     }
@@ -4381,6 +4438,14 @@ fn prev_line_has_open_inline_jsx(bytes: &[u8], ix: usize) -> bool {
             continue;
         }
         let pos = prev_line_start + i;
+        // A `<` inside a code span or math span is literal content, not a JSX
+        // tag opener. `$<$` is math, so a following `>` line is a real
+        // blockquote, not the continuation of a phantom `<$…>` tag. Mirrors
+        // the same guards on the inline `{` handler.
+        if is_inside_code_span(bytes, pos) || (has_math && is_inside_math_span(bytes, pos)) {
+            offset = i + 1;
+            continue;
+        }
         if let Some(len) = crate::mdx::scan_mdx_inline_jsx(&bytes[pos..]) {
             if pos + len > ix {
                 return true;

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1968,9 +1968,14 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     // so treat the `{` as plain text and let the link
                     // resolver claim the bytes. This also avoids a hard
                     // parse error on unmatched `{` like `[a]({)`.
+                    //
+                    // Inline math `$...$` owns its content too: braces in
+                    // LaTeX (`\frac{-b}{2a}`) are math text, not expressions —
+                    // matching block `$$` and the autolink math-span check.
                     if is_inside_code_span(bytes, ix)
                         || is_inside_link_url_parens(bytes, ix)
                         || is_inside_open_inline_jsx_tag(bytes, ix)
+                        || (self.options.has_math() && is_inside_math_span(bytes, ix))
                     {
                         LoopInstruction::ContinueAndSkip(0)
                     } else {

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -1234,7 +1234,10 @@ fn looks_like_spread(bytes: &[u8]) -> bool {
 /// so the scan tracks just enough JS lexer state to not end the block inside
 /// one — otherwise `export const x = ` `` `a\n\nb` `` truncates mid-template and
 /// oxc reports an unterminated string. Strings and line comments can't cross a
-/// newline in valid JS, so they need no cross-line state.
+/// newline in valid JS, so they need no cross-line state, but regex literals
+/// are still skipped whole: a backtick or quote inside one (`/[`]/`) would
+/// otherwise be mistaken for a template/string opener and swallow the block
+/// past the blank line that should end it.
 ///
 /// Returns the byte offset past the end of the block (including trailing newline).
 pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
@@ -1259,6 +1262,11 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
     // including its limitation around nested templates / strings in `${}`).
     let mut template_depth: Option<usize> = None;
     let mut in_block_comment = false;
+    // Whether the previous token produced a value, so a following `/` reads as
+    // division rather than a regex literal (same model as
+    // `scan_mdx_expression_end_inner`). Whitespace, newlines, and comments
+    // preserve the prior value.
+    let mut prev_was_value = false;
 
     while ix < len {
         if in_block_comment {
@@ -1275,6 +1283,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 b'\\' => ix += 2,
                 b'`' if depth == 0 => {
                     template_depth = None;
+                    prev_was_value = true;
                     ix += 1;
                 }
                 b'$' if ix + 1 < len && bytes[ix + 1] == b'{' => {
@@ -1295,6 +1304,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
         }
         match bytes[ix] {
             b'`' => {
+                // `prev_was_value` is set when the template closes.
                 template_depth = Some(0);
                 ix += 1;
             }
@@ -1310,6 +1320,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 if ix < len && bytes[ix] == quote {
                     ix += 1;
                 }
+                prev_was_value = true;
             }
             b'/' if ix + 1 < len && bytes[ix + 1] == b'/' => {
                 while ix < len && bytes[ix] != b'\n' {
@@ -1319,6 +1330,29 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
             b'/' if ix + 1 < len && bytes[ix + 1] == b'*' => {
                 in_block_comment = true;
                 ix += 2;
+            }
+            // Regex vs division: defer to the same heuristic as
+            // `scan_mdx_expression_end_inner`. `scan_regex` stops at a newline,
+            // so a misread can never cross the blank line that ends the block.
+            // The only thing that matters here is consuming a real regex whole
+            // so a backtick/quote inside it isn't read as a delimiter.
+            b'/' if {
+                let prev_is_ident_char = {
+                    let mut j = ix;
+                    while j > 0 && matches!(bytes[j - 1], b' ' | b'\t') {
+                        j -= 1;
+                    }
+                    j > 0
+                        && (bytes[j - 1].is_ascii_alphanumeric()
+                            || bytes[j - 1] == b'_'
+                            || bytes[j - 1] == b'$')
+                };
+                let force_division = prev_was_value && !prev_is_ident_char;
+                !force_division && slash_is_regex(bytes, ix)
+            } =>
+            {
+                ix = scan_regex(bytes, ix);
+                prev_was_value = true;
             }
             b'\n' => {
                 ix += 1;
@@ -1337,7 +1371,19 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                     break;
                 }
             }
-            _ => ix += 1,
+            b' ' | b'\t' | b'\r' => ix += 1,
+            b')' | b']' | b'}' => {
+                prev_was_value = true;
+                ix += 1;
+            }
+            b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' | b'0'..=b'9' => {
+                prev_was_value = true;
+                ix += 1;
+            }
+            _ => {
+                prev_was_value = false;
+                ix += 1;
+            }
         }
     }
     Some(ix)

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -96,24 +96,12 @@ pub(crate) fn dedent_expression_continuation(
     alloc::borrow::Cow::Owned(out)
 }
 
-/// Sentinel: U+F002 (Private Use Area) marks a "phantom space" — a column
-/// of whitespace produced by the dedent that has no underlying source byte
-/// (typically the leftover of a partial-tab consumption). Two surfaces need
-/// to see the bytes differently and we can't tell them apart from a real
-/// space later, so we tag them at emission:
-///
-/// * `mdast-util-mdx-jsx` keeps phantoms in the mdast `value` field. Mdast/
-///   hast readers substitute the sentinel back to a regular space.
-/// * `micromark-util-events-to-acorn`'s collector drops leading virtual-space
-///   codes before feeding chunks to acorn, which matters because a phantom
-///   inside a template-literal continuation would otherwise become part of
-///   the cooked value (`text={` \n  \t1. `}` would carry the two phantom
-///   spaces into the runtime string). We strip the sentinel before handing
-///   the expression body to oxc.
-///
-/// Plain spaces don't work as the marker: the oxc path then can't tell which
-/// leading whitespace was dedent and which was authored, and the dedent
-/// bleeds into template-literal values.
+/// Sentinel marking a "phantom space": a column of dedent-produced whitespace
+/// with no underlying source byte (e.g. leftover of a partial-tab consume).
+/// A plain space can't be the marker because the oxc path then can't tell
+/// dedent whitespace from authored whitespace, and the dedent bleeds into
+/// template-literal values. Consumers substitute it back to a space or strip
+/// it (see the strip sites in `satteri-mdxjs-rs::hast_util_to_oxc`).
 pub(crate) const PHANTOM_SPACE: char = '\u{F002}';
 
 /// Mirror `mdast-util-mdx-jsx`'s attribute-expression continuation-line
@@ -563,6 +551,49 @@ fn scan_regex(bytes: &[u8], start: usize) -> usize {
     ix
 }
 
+/// Whether a `/` at `ix` opens a regex literal rather than being division,
+/// given whether the previous token produced a value. Shared by the ESM-block
+/// scan and the expression scan so the two heuristics can't drift apart.
+///
+/// `slash_is_regex` alone mis-reads `/` after a regex close (`/x/ /y/`) or after
+/// a `}` (object-literal close, `{}/_`) as a new regex. `prev_was_value` forces
+/// division there, but only when the prior non-space byte isn't an identifier
+/// char so a regex-introducing keyword (`return /re/`) still reads as a regex.
+fn slash_is_regex_after(bytes: &[u8], ix: usize, prev_was_value: bool) -> bool {
+    let prev_is_ident_char = {
+        let mut j = ix;
+        while j > 0 && matches!(bytes[j - 1], b' ' | b'\t') {
+            j -= 1;
+        }
+        j > 0
+            && (bytes[j - 1].is_ascii_alphanumeric()
+                || bytes[j - 1] == b'_'
+                || bytes[j - 1] == b'$')
+    };
+    let force_division = prev_was_value && !prev_is_ident_char;
+    !force_division && slash_is_regex(bytes, ix)
+}
+
+/// Skip a `'…'` or `"…"` string whose opening quote is at `start`, returning the
+/// offset past the closing quote. A string can't span a newline in JS, so the
+/// scan stops at one; a backslash escapes the next byte. Shared by the ESM-block
+/// scan and the expression scan.
+fn skip_string(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let len = bytes.len();
+    let mut ix = start + 1;
+    while ix < len && bytes[ix] != quote && bytes[ix] != b'\n' && bytes[ix] != b'\r' {
+        if bytes[ix] == b'\\' {
+            ix += 1;
+        }
+        ix += 1;
+    }
+    if ix < len && bytes[ix] == quote {
+        ix += 1;
+    }
+    ix
+}
+
 /// Is the byte at `ix` a line ending followed by a blank line (or EOF)?
 ///
 /// Used to cut the expression scan at block boundaries, so an unclosed `{`
@@ -676,13 +707,10 @@ fn scan_mdx_expression_end_inner(
     // when `lazy_mode && !allow_lazy_body`, which is the flow-expression
     // case where body chars on a lazy line must abort the scan.
     let mut current_line_lazy = false;
-    // Tracks whether the previous semantically-relevant token produced a
-    // value: identifier, literal, regex close, `)`, `]`, `}`. When true, a
-    // following `/` is division; otherwise it's a regex literal. Whitespace
-    // and comments preserve the prior value. Without this, the existing
-    // position-based heuristic in `slash_is_regex` mis-classifies `/` after
-    // a regex close (`/x/ /y/`) and `/` after a `}` (object literal close,
-    // e.g. `{}/_`) as new regexes, eating the rest of the expression body.
+    // Whether the previous semantically-relevant token produced a value
+    // (identifier, literal, regex close, `)`, `]`, `}`); whitespace and
+    // comments preserve it. Consumed by `slash_is_regex_after` to tell
+    // division from a regex literal.
     let mut prev_was_value = false;
     macro_rules! mark_value {
         () => {
@@ -771,21 +799,7 @@ fn scan_mdx_expression_end_inner(
                     ix += 1;
                     continue;
                 }
-                let quote = bytes[ix];
-                ix += 1;
-                while ix < bytes.len()
-                    && bytes[ix] != quote
-                    && bytes[ix] != b'\n'
-                    && bytes[ix] != b'\r'
-                {
-                    if bytes[ix] == b'\\' {
-                        ix += 1;
-                    }
-                    ix += 1;
-                }
-                if ix < bytes.len() && bytes[ix] == quote {
-                    ix += 1;
-                }
+                ix = skip_string(bytes, ix);
                 mark_value!();
             }
             // Template literals with ${} nesting.
@@ -843,25 +857,7 @@ fn scan_mdx_expression_end_inner(
                     ix += 1;
                 }
             }
-            // Regex vs division: defer to `slash_is_regex` (which handles
-            // regex-introducing keywords like `return`/`yield`) when the
-            // prior byte is an identifier; otherwise trust `prev_was_value`
-            // so `}/` and `/x/ /y/` read as division.
-            b'/' if {
-                let prev_is_ident_char = {
-                    let mut j = ix;
-                    while j > 0 && matches!(bytes[j - 1], b' ' | b'\t') {
-                        j -= 1;
-                    }
-                    j > 0
-                        && (bytes[j - 1].is_ascii_alphanumeric()
-                            || bytes[j - 1] == b'_'
-                            || bytes[j - 1] == b'$')
-                };
-                let force_division = prev_was_value && !prev_is_ident_char;
-                !force_division && slash_is_regex(bytes, ix)
-            } =>
-            {
+            b'/' if slash_is_regex_after(bytes, ix, prev_was_value) => {
                 reject_if_lazy!();
                 ix = scan_regex(bytes, ix);
                 mark_value!();
@@ -1262,10 +1258,8 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
     // including its limitation around nested templates / strings in `${}`).
     let mut template_depth: Option<usize> = None;
     let mut in_block_comment = false;
-    // Whether the previous token produced a value, so a following `/` reads as
-    // division rather than a regex literal (same model as
-    // `scan_mdx_expression_end_inner`). Whitespace, newlines, and comments
-    // preserve the prior value.
+    // Whether the previous token produced a value; whitespace, newlines, and
+    // comments preserve it. Consumed by `slash_is_regex_after`.
     let mut prev_was_value = false;
 
     while ix < len {
@@ -1309,17 +1303,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 ix += 1;
             }
             b'\'' | b'"' => {
-                let quote = bytes[ix];
-                ix += 1;
-                while ix < len && bytes[ix] != quote && bytes[ix] != b'\n' && bytes[ix] != b'\r' {
-                    if bytes[ix] == b'\\' {
-                        ix += 1;
-                    }
-                    ix += 1;
-                }
-                if ix < len && bytes[ix] == quote {
-                    ix += 1;
-                }
+                ix = skip_string(bytes, ix);
                 prev_was_value = true;
             }
             b'/' if ix + 1 < len && bytes[ix + 1] == b'/' => {
@@ -1331,26 +1315,11 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 in_block_comment = true;
                 ix += 2;
             }
-            // Regex vs division: defer to the same heuristic as
-            // `scan_mdx_expression_end_inner`. `scan_regex` stops at a newline,
-            // so a misread can never cross the blank line that ends the block.
-            // The only thing that matters here is consuming a real regex whole
-            // so a backtick/quote inside it isn't read as a delimiter.
-            b'/' if {
-                let prev_is_ident_char = {
-                    let mut j = ix;
-                    while j > 0 && matches!(bytes[j - 1], b' ' | b'\t') {
-                        j -= 1;
-                    }
-                    j > 0
-                        && (bytes[j - 1].is_ascii_alphanumeric()
-                            || bytes[j - 1] == b'_'
-                            || bytes[j - 1] == b'$')
-                };
-                let force_division = prev_was_value && !prev_is_ident_char;
-                !force_division && slash_is_regex(bytes, ix)
-            } =>
-            {
+            // A real regex must be consumed whole so a backtick or quote inside
+            // it isn't read as a template/string opener. `scan_regex` stops at a
+            // newline, so even a misread can't cross the blank line that ends
+            // the block.
+            b'/' if slash_is_regex_after(bytes, ix, prev_was_value) => {
                 ix = scan_regex(bytes, ix);
                 prev_was_value = true;
             }

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -1225,9 +1225,16 @@ fn looks_like_spread(bytes: &[u8]) -> bool {
 
 /// Scan for an MDX ESM block (`import ...` or `export ...`).
 ///
-/// Greedily consumes all non-blank continuation lines, matching the reference
-/// mdxjs behavior. The actual completeness check is done later by the firstpass
-/// using oxc when a blank line is encountered.
+/// Greedily consumes continuation lines until a blank line ends the block,
+/// matching the reference mdxjs behavior. The completeness check for blocks
+/// that span a blank line in plain code (e.g. a multi-line object literal) is
+/// done later by the firstpass using oxc.
+///
+/// Template literals and block comments can legitimately contain a blank line,
+/// so the scan tracks just enough JS lexer state to not end the block inside
+/// one — otherwise `export const x = ` `` `a\n\nb` `` truncates mid-template and
+/// oxc reports an unterminated string. Strings and line comments can't cross a
+/// newline in valid JS, so they need no cross-line state.
 ///
 /// Returns the byte offset past the end of the block (including trailing newline).
 pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
@@ -1245,25 +1252,92 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
         return None;
     }
 
+    let len = bytes.len();
     let mut ix = 0;
-    loop {
-        let eol = memchr(b'\n', &bytes[ix..])
-            .map(|i| ix + i + 1)
-            .unwrap_or(bytes.len());
-        ix = eol;
+    // `Some(depth)` while inside a template literal, where `depth` counts open
+    // `${` interpolation braces (same model as `scan_mdx_expression_end_inner`,
+    // including its limitation around nested templates / strings in `${}`).
+    let mut template_depth: Option<usize> = None;
+    let mut in_block_comment = false;
 
-        if ix >= bytes.len() {
-            break;
+    while ix < len {
+        if in_block_comment {
+            if bytes[ix] == b'*' && ix + 1 < len && bytes[ix + 1] == b'/' {
+                in_block_comment = false;
+                ix += 2;
+            } else {
+                ix += 1;
+            }
+            continue;
         }
-        // A line of only spaces/tabs is blank, exactly like an empty line, and
-        // ends the block. The firstpass retries across it with oxc when the
-        // block is still incomplete (e.g. an export spanning a blank line).
-        let mut next = ix;
-        while next < bytes.len() && matches!(bytes[next], b' ' | b'\t') {
-            next += 1;
+        if let Some(depth) = template_depth {
+            match bytes[ix] {
+                b'\\' => ix += 2,
+                b'`' if depth == 0 => {
+                    template_depth = None;
+                    ix += 1;
+                }
+                b'$' if ix + 1 < len && bytes[ix + 1] == b'{' => {
+                    template_depth = Some(depth + 1);
+                    ix += 2;
+                }
+                b'{' if depth > 0 => {
+                    template_depth = Some(depth + 1);
+                    ix += 1;
+                }
+                b'}' if depth > 0 => {
+                    template_depth = Some(depth - 1);
+                    ix += 1;
+                }
+                _ => ix += 1,
+            }
+            continue;
         }
-        if next >= bytes.len() || matches!(bytes[next], b'\n' | b'\r') {
-            break;
+        match bytes[ix] {
+            b'`' => {
+                template_depth = Some(0);
+                ix += 1;
+            }
+            b'\'' | b'"' => {
+                let quote = bytes[ix];
+                ix += 1;
+                while ix < len && bytes[ix] != quote && bytes[ix] != b'\n' && bytes[ix] != b'\r' {
+                    if bytes[ix] == b'\\' {
+                        ix += 1;
+                    }
+                    ix += 1;
+                }
+                if ix < len && bytes[ix] == quote {
+                    ix += 1;
+                }
+            }
+            b'/' if ix + 1 < len && bytes[ix + 1] == b'/' => {
+                while ix < len && bytes[ix] != b'\n' {
+                    ix += 1;
+                }
+            }
+            b'/' if ix + 1 < len && bytes[ix + 1] == b'*' => {
+                in_block_comment = true;
+                ix += 2;
+            }
+            b'\n' => {
+                ix += 1;
+                if ix >= len {
+                    break;
+                }
+                // A line of only spaces/tabs is blank, exactly like an empty
+                // line, and ends the block. The firstpass retries across it
+                // with oxc when the block is still incomplete (e.g. an export
+                // object spanning a blank line in plain code).
+                let mut next = ix;
+                while next < len && matches!(bytes[next], b' ' | b'\t') {
+                    next += 1;
+                }
+                if next >= len || matches!(bytes[next], b'\n' | b'\r') {
+                    break;
+                }
+            }
+            _ => ix += 1,
         }
     }
     Some(ix)
@@ -2244,38 +2318,35 @@ fn extract_tag_name(s: &str) -> alloc::borrow::Cow<'_, str> {
 }
 
 /// Extract the opening tag portion (up to the first unbalanced `>`).
+///
+/// Attribute expressions `{...}` are skipped whole via the JS-aware
+/// `scan_mdx_expression_end`, so quotes inside a regex (`ins={/x="y"/}`) don't
+/// desync the search for the tag's closing `>` — the bug a naive
+/// quote/brace tracker hit. Any `>` reached here is therefore outside all
+/// braces. Attribute string values (`lang="a > b"`) are HTML-like (no
+/// backslash escapes), matching `parse_jsx_attrs`.
 fn extract_opening_tag(text: &str) -> &str {
-    let mut depth = 0i32;
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut in_backtick = false;
-    let mut prev = '\0';
-
-    for (i, ch) in text.char_indices() {
-        if in_single_quote {
-            if ch == '\'' && prev != '\\' {
-                in_single_quote = false;
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        match bytes[i] {
+            b'\'' | b'"' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < len && bytes[i] != quote {
+                    i += 1;
+                }
+                if i < len {
+                    i += 1;
+                }
             }
-        } else if in_double_quote {
-            if ch == '"' && prev != '\\' {
-                in_double_quote = false;
+            b'{' => {
+                i += scan_mdx_expression_end(&bytes[i..], false).unwrap_or(1);
             }
-        } else if in_backtick {
-            if ch == '`' && prev != '\\' {
-                in_backtick = false;
-            }
-        } else {
-            match ch {
-                '\'' => in_single_quote = true,
-                '"' => in_double_quote = true,
-                '`' => in_backtick = true,
-                '{' => depth += 1,
-                '}' => depth -= 1,
-                '>' if depth == 0 => return &text[..=i],
-                _ => {}
-            }
+            b'>' => return &text[..=i],
+            _ => i += 1,
         }
-        prev = ch;
     }
     text
 }
@@ -2356,31 +2427,13 @@ fn parse_jsx_attrs<'a>(
         }
 
         if bytes[i] == b'{' {
-            i += 1;
-            let start = i;
-            let mut depth = 1i32;
-            while i < len && depth > 0 {
-                match bytes[i] {
-                    b'{' => depth += 1,
-                    b'}' => depth -= 1,
-                    b'\'' | b'"' | b'`' => {
-                        let q = bytes[i];
-                        i += 1;
-                        while i < len && bytes[i] != q {
-                            if bytes[i] == b'\\' {
-                                i += 1;
-                            }
-                            i += 1;
-                        }
-                    }
-                    _ => {}
-                }
-                i += 1;
-            }
-            let raw_value = &tag[start..i.saturating_sub(1)];
+            let end = i + scan_mdx_expression_end(&bytes[i..], false).unwrap_or(len - i);
+            let start = i + 1;
+            let raw_value = &tag[start..end.saturating_sub(1)];
             let lead_ws = raw_value.len() - raw_value.trim_start().len();
             let value = raw_value.trim();
             let val_start = start + lead_ws;
+            i = end;
             attrs.push(JsxAttr::Spread(
                 value.into(),
                 val_start,
@@ -2437,28 +2490,10 @@ fn parse_jsx_attrs<'a>(
                 let decoded = decode_attr_entities(value.as_ref());
                 attrs.push(JsxAttr::Literal(name.into(), decoded.into_owned().into()));
             } else if bytes[i] == b'{' {
-                i += 1;
-                let val_start = i;
-                let mut depth = 1i32;
-                while i < len && depth > 0 {
-                    match bytes[i] {
-                        b'{' => depth += 1,
-                        b'}' => depth -= 1,
-                        b'\'' | b'"' | b'`' => {
-                            let q = bytes[i];
-                            i += 1;
-                            while i < len && bytes[i] != q {
-                                if bytes[i] == b'\\' {
-                                    i += 1;
-                                }
-                                i += 1;
-                            }
-                        }
-                        _ => {}
-                    }
-                    i += 1;
-                }
-                let val_end = i.saturating_sub(1);
+                let end = i + scan_mdx_expression_end(&bytes[i..], false).unwrap_or(len - i);
+                let val_start = i + 1;
+                let val_end = end.saturating_sub(1);
+                i = end;
                 let value = &tag[val_start..val_end];
                 let normalized = if value.contains('\n') || value.contains('\r') {
                     alloc::borrow::Cow::Owned(strip_expression_indent(

--- a/crates/satteri-pulldown-cmark/tests/mdx.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx.rs
@@ -250,6 +250,70 @@ fn esm_export_spanning_whitespace_only_line() {
 }
 
 #[test]
+fn esm_export_template_spanning_blank_line() {
+    // A blank line inside a template literal must not end the ESM block (#111):
+    // the scanner stays inside the template instead of truncating it.
+    let input = "export const code = `first line\n\nsecond line`;\n\nAfter.\n";
+    let ev = mdx_events(input);
+    assert!(
+        has(&ev, |e| matches!(e, Event::MdxEsm(s)
+            if s.contains("second line") && !s.contains("After"))),
+        "template spanning a blank line should be one ESM block: {:?}",
+        ev
+    );
+    assert!(has(&ev, |e| matches!(e, Event::Start(Tag::Paragraph))));
+}
+
+#[test]
+fn esm_export_regex_with_backtick() {
+    // A backtick inside a top-level regex literal must not open a phantom
+    // template literal and swallow the following content into the ESM block.
+    let input = "export const re = /a`b/;\n\nAfter the regex.\n";
+    let ev = mdx_events(input);
+    assert!(
+        has(&ev, |e| matches!(e, Event::MdxEsm(s)
+            if s.contains("re =") && !s.contains("After"))),
+        "regex containing a backtick must not extend the ESM block: {:?}",
+        ev
+    );
+    assert!(
+        has(&ev, |e| matches!(e, Event::Start(Tag::Paragraph))),
+        "text after the regex export must be a paragraph: {:?}",
+        ev
+    );
+}
+
+#[test]
+fn esm_export_regex_with_quotes() {
+    // Quotes inside a regex character class must not be read as string
+    // delimiters either.
+    let input = "export const re = /[\"']/g;\n\nAfter the regex.\n";
+    let ev = mdx_events(input);
+    assert!(
+        has(&ev, |e| matches!(e, Event::MdxEsm(s)
+            if s.contains("re =") && !s.contains("After"))),
+        "regex containing quotes must not extend the ESM block: {:?}",
+        ev
+    );
+    assert!(has(&ev, |e| matches!(e, Event::Start(Tag::Paragraph))));
+}
+
+#[test]
+fn esm_export_division_not_regex() {
+    // A `/` that is division (after a value) must not be scanned as a regex
+    // and run on past the end of the block.
+    let input = "export const half = total / 2;\n\nAfter.\n";
+    let ev = mdx_events(input);
+    assert!(
+        has(&ev, |e| matches!(e, Event::MdxEsm(s)
+            if s.contains("half") && !s.contains("After"))),
+        "division must not extend the ESM block: {:?}",
+        ev
+    );
+    assert!(has(&ev, |e| matches!(e, Event::Start(Tag::Paragraph))));
+}
+
+#[test]
 fn esm_not_in_paragraph() {
     // Import/export inside a paragraph (not interrupting) should not be ESM.
     let ev = mdx_events("a\nimport a from 'b'\n");
@@ -1505,5 +1569,26 @@ fn inline_expression_template_literal_aborts_on_blank_line() {
         !has(&events, |e| matches!(e, Event::MdxTextExpression(_))),
         "inline expression with blank-line template must abort: {:?}",
         events
+    );
+}
+
+// A `<` that is inside a math span (`$<$`) is literal math content, not an
+// open inline JSX tag, so a following `>` line opens a blockquote rather than
+// being swallowed as a lazy paragraph continuation.
+#[test]
+fn blockquote_interrupts_after_lt_inside_math() {
+    let with_lt = mdx_events("$<$\n>");
+    assert!(
+        has(&with_lt, |e| matches!(e, Event::Start(Tag::BlockQuote(_)))),
+        "`>` after `$<$` must open a blockquote: {:?}",
+        with_lt
+    );
+    // A genuinely open inline JSX tag must still suppress the interrupt; the
+    // `>` is the tag's own close, not a blockquote.
+    let open_jsx = mdx_events("a <foo\n>");
+    assert!(
+        !has(&open_jsx, |e| matches!(e, Event::Start(Tag::BlockQuote(_)))),
+        "real open inline JSX must still suppress the interrupt: {:?}",
+        open_jsx
     );
 }

--- a/crates/satteri-pulldown-cmark/tests/mdx_math.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx_math.rs
@@ -1,0 +1,53 @@
+//! MDX + math interaction at the MDAST level.
+#![cfg(feature = "mdx")]
+
+use satteri_arena::{Arena, Mdast};
+use satteri_ast::mdast::{decode_math_data, MdastNodeType};
+use satteri_pulldown_cmark::arena_build::parse;
+use satteri_pulldown_cmark::Options;
+
+fn mdx_math_options() -> Options {
+    Options::ENABLE_MDX | Options::ENABLE_MATH
+}
+
+fn find_inline_math_value(arena: &Arena<Mdast>) -> Option<String> {
+    (0..arena.len() as u32)
+        .find(|&id| arena.get_node(id).node_type == MdastNodeType::InlineMath as u8)
+        .map(|id| {
+            let value = decode_math_data(arena.get_type_data(id)).value;
+            arena.get_str(value).to_string()
+        })
+}
+
+// Braces inside inline math `$...$` are math text, not MDX expressions, the
+// same way block `$$...$$` already behaves (#110). Without the math-span guard
+// in the inline `{` handler, LaTeX like `\frac{-b}{2a}` is handed to oxc and
+// errors with "Invalid characters after number".
+#[test]
+fn inline_math_with_braces_is_not_parsed_as_expression() {
+    for src in ["$\\frac{-b}{2a}$", "$x{2b}y$", "$x{a-}y$", "$x{a b}y$"] {
+        let (_arena, errors) = parse(src, mdx_math_options());
+        assert!(errors.is_empty(), "{src:?} produced MDX errors: {errors:?}");
+    }
+}
+
+#[test]
+fn inline_math_preserves_brace_content() {
+    let (arena, errors) = parse("$\\frac{-b}{2a}$", mdx_math_options());
+    assert!(errors.is_empty(), "errors: {errors:?}");
+    assert_eq!(
+        find_inline_math_value(&arena).as_deref(),
+        Some("\\frac{-b}{2a}"),
+    );
+}
+
+// MDX expressions outside math are still validated (the guard must not disable
+// expression scanning wholesale when math is on).
+#[test]
+fn mdx_expression_outside_math_still_validated() {
+    let (_arena, errors) = parse("text {1 +} more", mdx_math_options());
+    assert!(
+        !errors.is_empty(),
+        "malformed expression should still error"
+    );
+}

--- a/crates/satteri-pulldown-cmark/tests/mdx_math.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx_math.rs
@@ -51,3 +51,33 @@ fn mdx_expression_outside_math_still_validated() {
         "malformed expression should still error"
     );
 }
+
+// A `\$` only prevents *opening* a math span, not closing one, matching the
+// resolver. So `$...\$` is a span that closes at the escaped `$`, and a `{`
+// between the dollars is math text. Without the guard tracking this, the `{`
+// is handed to oxc as an expression and errors on the unterminated brace.
+// A `$$` display-math fence on its own line is a block boundary, so an inline
+// `$$` earlier in the paragraph must not pair with it and swallow a `{` as math
+// text. Here `{1}` is a real text expression (matching mdx-js), not math.
+#[test]
+fn inline_dollars_do_not_pair_across_display_fence() {
+    let (arena, errors) = parse("a$$\nx{1}y\n$$", mdx_math_options());
+    assert!(errors.is_empty(), "errors: {errors:?}");
+    let has_expr = (0..arena.len() as u32)
+        .any(|id| arena.get_node(id).node_type == MdastNodeType::MdxTextExpression as u8);
+    assert!(
+        has_expr,
+        "`{{1}}` after an inline `$$` must be a text expression, not math text"
+    );
+}
+
+#[test]
+fn brace_in_span_closing_at_escaped_dollar_is_math_text() {
+    // In each case the only possible closer is the escaped `$`; dropping it
+    // (the old guard's bug) leaves the `{` outside any span and oxc errors on
+    // the invalid/unterminated expression body.
+    for src in ["e$}}_{\\$h", "$x{1 +}\\$", "a $b{1 +}c\\$"] {
+        let (_arena, errors) = parse(src, mdx_math_options());
+        assert!(errors.is_empty(), "{src:?} produced MDX errors: {errors:?}");
+    }
+}

--- a/packages/satteri/test/conformance/fuzz/mdx-math.test.ts
+++ b/packages/satteri/test/conformance/fuzz/mdx-math.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "vitest";
+import { writeFileSync } from "node:fs";
+import {
+  mdxMathDocument,
+  collectMdxEvalIssues,
+  deduplicateMdxEvalIssues,
+  formatMdxEvalIssue,
+  MDX_MATH_EVAL_OPTIONS,
+  FUZZ_TIMEOUT_MS,
+} from "./shared.js";
+
+// MDX and math enabled together: differential-fuzz the interaction between
+// inline `$...$` spans and `{...}` expressions (the inline-`{` math guard)
+// against @mdx-js/mdx + remark-math, rendered to HTML.
+describe("fuzz: MDX + math eval conformance", () => {
+  test(
+    "collect and report MDX+math eval issues",
+    async () => {
+      const allIssues = [
+        ...(await collectMdxEvalIssues(mdxMathDocument, "structured", MDX_MATH_EVAL_OPTIONS)),
+      ];
+      const unique = deduplicateMdxEvalIssues(allIssues);
+
+      const report = [
+        "# MDX + math eval fuzz-discovered conformance issues",
+        "",
+        unique.length === 0
+          ? "No issues found in the latest run."
+          : `Found ${unique.length} unique issue(s) across ${allIssues.length} total failure(s).`,
+        "",
+        ...unique.map(formatMdxEvalIssue),
+      ].join("\n");
+
+      if (unique.length > 0) {
+        const issuesPath = new URL("./FUZZ-ISSUES-MDX-MATH.md", import.meta.url);
+        writeFileSync(issuesPath, report + "\n");
+      }
+
+      const inputs = unique.map((i) => `${i.kind}: ${JSON.stringify(i.input)}`);
+      expect
+        .soft(unique, `Found ${unique.length} MDX+math conformance issue(s):\n${inputs.join("\n")}`)
+        .toHaveLength(0);
+    },
+    FUZZ_TIMEOUT_MS,
+  );
+});

--- a/packages/satteri/test/conformance/fuzz/shared.ts
+++ b/packages/satteri/test/conformance/fuzz/shared.ts
@@ -7,6 +7,7 @@ import { evaluate as mdxEvaluate } from "@mdx-js/mdx";
 import { remark } from "remark";
 import remarkMdx from "remark-mdx";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import { toHast } from "mdast-util-to-hast";
 import type { Root as MdastRoot, Nodes as MdastNodes } from "mdast";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -858,6 +859,68 @@ export const mathDocument = fc.oneof(
   { weight: 2, arbitrary: mutatedMathExample },
 );
 
+// MDX x math interaction arbitraries. The other suites keep the two apart, so
+// the inline `$...$` x `{...}` surface (where the `{` math guard lives) is
+// never fuzzed. Expressions are kept self-contained so a guard failure shows as
+// an output mismatch (`{1 + 2}` text vs `3`), not a `ReferenceError`.
+const MATH_INNER = fc.string({
+  unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789".split("")),
+  minLength: 1,
+  maxLength: 8,
+});
+const mathSpanFrag = fc.oneof(
+  MATH_INNER.map((t) => `$${t}$`),
+  fc.constantFrom("$\\frac{a}{b}$", "$x^{2}$", "$e^{i\\pi}$", "$a_{i}$", "$\\sum_{i} x$"),
+);
+const selfContainedExpr = fc.oneof(
+  fc.integer({ min: 0, max: 99 }).map((n) => `{${n}}`),
+  fc.constantFrom("{1 + 2}", "{`x`}", "{true ? 'a' : 'b'}", "{String(7)}"),
+);
+const dollarAmount = fc.integer({ min: 1, max: 9999 }).map((n) => `$${n}`);
+const safeWords = fc.string({
+  unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789 ".split("")),
+  minLength: 1,
+  maxLength: 8,
+});
+
+const mathExprLine = fc
+  .array(
+    fc.oneof(
+      { weight: 3, arbitrary: safeWords },
+      { weight: 3, arbitrary: mathSpanFrag },
+      { weight: 3, arbitrary: selfContainedExpr },
+      { weight: 2, arbitrary: dollarAmount },
+    ),
+    { minLength: 1, maxLength: 8 },
+  )
+  .map((parts) => parts.join(" "));
+
+// Curated, well-formed cases: braces inside `$...$` stay math text, those
+// outside are expressions.
+const MDX_MATH_EXAMPLES: string[] = [
+  "$\\frac{-b}{2a}$ and {1 + 1}",
+  "Price is $5 and {x} costs $10",
+  "Euler $e^{i\\pi}$ then {3 * 7}",
+  "{1 + 2} then $x^2$ done",
+  "$a$ {`b`} $c$ {`d`}",
+  "value {2} and $\\sum_i x_i$ end",
+  "$5 {1} costs $10 today",
+  "<Box>before $x$ and {1 + 1} after</Box>",
+  "result {7} for $\\frac{a}{b}$",
+];
+const mdxMathExample = fc.constantFrom(...MDX_MATH_EXAMPLES);
+
+export const mdxMathDocument = fc.oneof(
+  { weight: 5, arbitrary: mathExprLine },
+  { weight: 3, arbitrary: mdxMathExample },
+  {
+    weight: 2,
+    arbitrary: fc
+      .array(fc.oneof(mathExprLine, mdxMathExample), { minLength: 1, maxLength: 4 })
+      .map((blocks) => blocks.join("\n\n")),
+  },
+);
+
 // Frontmatter arbitraries
 
 const YAML_KEY = fc.string({
@@ -1584,9 +1647,25 @@ const KNOWN_MDX_EVAL_DIVERGENCES = new Set<string>([
   "*\n\n  2. b\n\n    3. c\n",
 ]);
 
+// Feature set for an eval-fuzzer run; lets it enable math on both pipelines
+// while reusing every divergence filter below. Defaults to GFM-only.
+export interface MdxEvalOptions {
+  remarkPlugins: unknown[];
+  features: Record<string, unknown>;
+}
+const DEFAULT_MDX_EVAL_OPTIONS: MdxEvalOptions = {
+  remarkPlugins: [remarkGfm],
+  features: MDX_FEATURES,
+};
+export const MDX_MATH_EVAL_OPTIONS: MdxEvalOptions = {
+  remarkPlugins: [remarkGfm, remarkMath],
+  features: { headingAttributes: false, math: true, frontmatter: false },
+};
+
 async function compareMdxEval(
   input: string,
   source: MdxEvalIssue["source"],
+  opts: MdxEvalOptions = DEFAULT_MDX_EVAL_OPTIONS,
 ): Promise<MdxEvalIssue | null> {
   if (KNOWN_MDX_EVAL_DIVERGENCES.has(input)) return null;
   let refHtml: string | undefined;
@@ -1595,7 +1674,7 @@ async function compareMdxEval(
   try {
     const { default: RefComponent } = (await mdxEvaluate(input, {
       ...runtime,
-      remarkPlugins: [remarkGfm],
+      remarkPlugins: opts.remarkPlugins as any,
     })) as { default: Function };
     refHtml = normalizeHtml(
       renderToStaticMarkup(createElement(RefComponent as any, { components: jsxComponents })),
@@ -1611,7 +1690,7 @@ async function compareMdxEval(
   try {
     const { default: SatComponent } = await satteriEvaluate(input, {
       ...runtime,
-      features: MDX_FEATURES,
+      features: opts.features,
     } as any);
     satHtml = normalizeHtml(
       renderToStaticMarkup(createElement(SatComponent as any, { components: jsxComponents })),
@@ -1700,11 +1779,12 @@ async function compareMdxEval(
 export async function collectMdxEvalIssues(
   arbitrary: fc.Arbitrary<string>,
   source: "structured" | "chaos",
+  opts: MdxEvalOptions = DEFAULT_MDX_EVAL_OPTIONS,
 ): Promise<MdxEvalIssue[]> {
   const issues: MdxEvalIssue[] = [];
   await fc.assert(
     fc.asyncProperty(arbitrary, async (input) => {
-      const issue = await compareMdxEval(input, source);
+      const issue = await compareMdxEval(input, source, opts);
       if (issue) issues.push(issue);
       return true;
     }),

--- a/packages/satteri/test/conformance/helpers.ts
+++ b/packages/satteri/test/conformance/helpers.ts
@@ -473,6 +473,33 @@ export async function assertMdxConformance(
   expect(normalizeHtml(satHtml)).toBe(normalizeHtml(mdxHtml));
 }
 
+// Like `assertMdxConformance`, but with math enabled on both pipelines
+// (satteri `features.math`, reference `remark-math`). Exercises how MDX
+// expressions and `$...$` math interact, e.g. that braces inside a math span
+// stay math text rather than being parsed as an expression.
+export async function assertMdxMathConformance(
+  input: string,
+  components: Record<string, unknown> = {},
+): Promise<void> {
+  const { default: MdxComponent } = (await mdxEvaluate(input, {
+    ...mdxRuntime,
+    remarkPlugins: [remarkMath],
+  })) as { default: Function };
+  const mdxHtml = renderToStaticMarkup(
+    createElement(MdxComponent as React.FC<Record<string, unknown>>, { components }),
+  );
+
+  const { default: SatComponent } = await satteriEvaluate(input, {
+    ...satteriRuntime,
+    features: { math: true },
+  });
+  const satHtml = renderToStaticMarkup(
+    createElement(SatComponent as React.FC<Record<string, unknown>>, { components }),
+  );
+
+  expect(normalizeHtml(satHtml)).toBe(normalizeHtml(mdxHtml));
+}
+
 // Set an inline `style` string on every `<tag>` element via a hast/rehype
 // plugin on both pipelines, evaluate, and compare the rendered HTML. This is
 // the path expressive-code (and similar hast plugins) take: satteri's HAST→JSX

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -360,6 +360,20 @@ describe("MDX conformance: ESM", () => {
     await assertMdxConformance("export function greet() { return 'hi' }\n\n{greet()}");
   });
 
+  // A blank line inside a template literal must not end the ESM block (#111).
+  test("blank line inside template literal in export (#111)", async () => {
+    await assertMdxConformance("export const code = `first line\n\nsecond line`;\n\n{code}");
+  });
+
+  test("blank line between template literals in export (#111)", async () => {
+    await assertMdxConformance("export const x = `a` +\n\n`b`;\n\n{x}");
+  });
+
+  // Block comments span blank lines too, the same way templates do (#111).
+  test("blank line inside block comment in export (#111)", async () => {
+    await assertMdxConformance("export const y = 1; /* note\n\nstill note */\n\n{y}");
+  });
+
   // A JSX identifier already bound at module scope must resolve to that
   // binding rather than being destructured out of `props.components` (which
   // would shadow it to `undefined` and throw `_missingMdxReference`).
@@ -418,6 +432,24 @@ describe("MDX conformance: attribute values", () => {
       "</CodePreview>",
     ].join("\n");
     await assertMdxConformance(src, { CodePreview });
+  });
+
+  // Quote characters inside a regex literal in an attribute expression must
+  // not be mistaken for string delimiters (#112).
+  test("regex with quotes in attribute expression (#112)", async () => {
+    const LinkedCode = (props: any) => createElement("code", null, String(props.ins[0]));
+    const src = [
+      "<LinkedCode",
+      '  lang="angular-html"',
+      `  ins={[/icon="[^"]+"/g, 'useFilledIcon="true"']}`,
+      "/>",
+    ].join("\n");
+    await assertMdxConformance(src, { LinkedCode });
+  });
+
+  test("inline regex with quotes in attribute expression (#112)", async () => {
+    const Tag = (props: any) => createElement("span", null, String(props.re));
+    await assertMdxConformance(`<Tag re={/a="b"/g} />`, { Tag });
   });
 
   test("different self-closing component inside template-literal attribute (#74)", async () => {

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "vitest";
 import { createElement } from "react";
-import { assertMdxConformance, assertBothReject } from "./helpers.js";
+import { assertMdxConformance, assertMdxMathConformance, assertBothReject } from "./helpers.js";
 
 const Foo = (props: any) => createElement("div", null, `bar=${props.bar}`);
 const Bar = (props: any) => createElement("em", null, `baz=${props.baz}`);
@@ -372,6 +372,17 @@ describe("MDX conformance: ESM", () => {
   // Block comments span blank lines too, the same way templates do (#111).
   test("blank line inside block comment in export (#111)", async () => {
     await assertMdxConformance("export const y = 1; /* note\n\nstill note */\n\n{y}");
+  });
+
+  // A backtick or quote inside a regex literal must not be read as a
+  // template/string opener and swallow the following content into the ESM
+  // block (#111).
+  test("regex with backtick in export (#111)", async () => {
+    await assertMdxConformance("export const re = /a`b/;\n\n{re.source}");
+  });
+
+  test("regex with quotes in export (#111)", async () => {
+    await assertMdxConformance("export const re = /[\"']/g;\n\n{re.source}");
   });
 
   // A JSX identifier already bound at module scope must resolve to that
@@ -902,5 +913,48 @@ describe("MDX conformance: fuzz regressions", () => {
   // rather than `container_content_col - 1`.
   test("text-position expression dedents trailing tab before close", async () => {
     await assertMdxConformance(">o{1+2\n\t}}");
+  });
+});
+
+describe("MDX conformance: math interaction", () => {
+  // Braces inside an inline `$...$` span are math text, not an MDX expression
+  // (#110). remark-math pairs the dollar runs and the braces never reach the
+  // expression tokenizer; satteri must agree.
+  test("braces inside inline math are not an expression (#110)", async () => {
+    await assertMdxMathConformance("$\\frac{-b}{2a}$ and {1 + 1}");
+  });
+
+  // Two single-dollar runs with `{x}` between them (e.g. prose about prices):
+  // remark-math pairs them into one math span, so `{x}` is math text on both
+  // sides and the undefined `x` is never evaluated. The `{` guard must mirror
+  // this rather than evaluate `{x}` as an expression.
+  test("expression between dollar amounts is math text", async () => {
+    await assertMdxMathConformance("Price is $5 and {x} costs $10 today");
+  });
+
+  // An expression genuinely outside any math span is still evaluated.
+  test("expression after a real math span is evaluated", async () => {
+    await assertMdxMathConformance("Euler $e^{i\\pi}$ then {3 * 7}");
+  });
+
+  // A `<` inside a math span is math content, not an open inline JSX tag, so a
+  // following `>` line opens a blockquote rather than being absorbed as a lazy
+  // paragraph continuation.
+  test("`<` inside math does not suppress a following blockquote", async () => {
+    await assertMdxMathConformance("$<$\n>");
+  });
+
+  // A `\$` only prevents opening a math span, not closing one, so the `{` here
+  // is inside the span (math text) and must not be parsed as an expression.
+  test("brace before a span-closing escaped dollar is math text", async () => {
+    await assertMdxMathConformance("e$}}_{\\$h");
+  });
+
+  // A `$$` display-math fence is a block boundary: an inline `$$` earlier in the
+  // paragraph must not pair across it, so `\frac{1}{2}` here is an expression
+  // (rendered `\frac12`), not math text. Reachable by omitting the blank line
+  // before a display-math block.
+  test("inline `$$` does not pair across a display-math fence", async () => {
+    await assertMdxMathConformance("See:$$\n\\frac{1}{2}\n$$");
   });
 });


### PR DESCRIPTION
Fixes https://github.com/bruits/satteri/issues/112
Fixes https://github.com/bruits/satteri/issues/111
Fixes https://github.com/bruits/satteri/issues/110