### PR TITLE
fix: preserve rawHtml braces in markdown HTML

### DIFF
--- a/.sampo/changesets/fix-raw-html-braces.md
+++ b/.sampo/changesets/fix-raw-html-braces.md
@@ -1,4 +1,5 @@
 ---
+cargo/satteri-plugin-api: minor
 npm/satteri: patch
 ---
 

--- a/.sampo/changesets/fix-raw-html-braces.md
+++ b/.sampo/changesets/fix-raw-html-braces.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Fixes Markdown plugins returning `rawHtml` with literal `{` or `}` rendering those braces as MDX escape fragments in `markdownToHtml`.

--- a/crates/satteri-napi-binding/src/lib.rs
+++ b/crates/satteri-napi-binding/src/lib.rs
@@ -560,7 +560,8 @@ pub fn apply_commands_to_mdast_handle(
     let mut arena = handle
         .lock()
         .map_err(|e| napi::Error::from_reason(format!("lock: {e}")))?;
-    let parse_markdown = make_parse_fn(arena.mdx, arena.parse_options);
+    let mdx = arena.mdx;
+    let parse_markdown = make_parse_fn(mdx, arena.parse_options);
     let owned = std::mem::replace(
         &mut *arena,
         satteri_arena::Arena::<Mdast>::new(String::new()),
@@ -569,9 +570,16 @@ pub fn apply_commands_to_mdast_handle(
     // removed is dropped rather than fatal — the plugin discarded that subtree,
     // so a transform queued on a node within it is moot. A passed-through child
     // keeps its identity (via `_ref`) and so is never stranded this way.
-    let (new_arena, dropped) =
-        satteri_plugin_api::apply_mdast_commands_lenient(owned, &command_buf, &parse_markdown)
-            .map_err(|e| napi::Error::from_reason(format!("command error: {e}")))?;
+    let options = satteri_plugin_api::MdastCommandOptions {
+        escape_raw_html_braces: mdx,
+    };
+    let (new_arena, dropped) = satteri_plugin_api::apply_mdast_commands_lenient_with_options(
+        owned,
+        &command_buf,
+        &parse_markdown,
+        options,
+    )
+    .map_err(|e| napi::Error::from_reason(format!("command error: {e}")))?;
     *arena = new_arena;
     Ok(dropped.len() as u32)
 }
@@ -619,8 +627,16 @@ pub fn apply_commands_and_convert_to_hast_handle(
         &mut *arena,
         satteri_arena::Arena::<Mdast>::new(String::new()),
     );
-    let mutated = satteri_plugin_api::apply_mdast_commands(owned, &command_buf, &parse_markdown)
-        .map_err(|e| napi::Error::from_reason(format!("command error: {e}")))?;
+    let options = satteri_plugin_api::MdastCommandOptions {
+        escape_raw_html_braces: mdx,
+    };
+    let mutated = satteri_plugin_api::apply_mdast_commands_with_options(
+        owned,
+        &command_buf,
+        &parse_markdown,
+        options,
+    )
+    .map_err(|e| napi::Error::from_reason(format!("command error: {e}")))?;
     let mut hast_arena =
         satteri_ast::hast::mdast_arena_to_hast_arena_with_options(&mutated, &convert_opts);
     hast_arena.mdx = mdx;

--- a/crates/satteri-plugin-api/src/js_commands.rs
+++ b/crates/satteri-plugin-api/src/js_commands.rs
@@ -297,6 +297,25 @@ fn escape_braces_in_html_text(html: &str) -> String {
     result
 }
 
+/// Options controlling how MDAST command buffers are applied.
+#[derive(Debug, Clone, Copy)]
+pub struct MdastCommandOptions {
+    /// Escape raw HTML text braces before re-parsing it through an MDX parser.
+    ///
+    /// MDX needs this so literal `{` / `}` in HTML text are not interpreted as
+    /// expressions. Plain Markdown-to-HTML pipelines should leave raw HTML
+    /// opaque so the final HTML preserves those braces verbatim.
+    pub escape_raw_html_braces: bool,
+}
+
+impl Default for MdastCommandOptions {
+    fn default() -> Self {
+        Self {
+            escape_raw_html_braces: true,
+        }
+    }
+}
+
 /// Emit a reference placeholder: a `REF_NODE_TYPE` node carrying the target
 /// original id (u32 LE) in its type_data. The rebuild resolves it by splicing
 /// that original subtree and applying any pending patch on it.
@@ -844,6 +863,7 @@ fn read_mdast_payload(
     parse_markdown: &dyn Fn(&str) -> Arena<Mdast>,
     orig: &Arena<Mdast>,
     anchor: u32,
+    options: MdastCommandOptions,
 ) -> Result<(Arena<Mdast>, bool), CommandError> {
     let payload_type = reader.read_u8()?;
     let len = reader.read_u32()? as usize;
@@ -855,8 +875,12 @@ fn read_mdast_payload(
         }
         PAYLOAD_RAW_HTML => {
             let html = reader.read_str(len)?;
-            let escaped = escape_braces_in_html_text(html);
-            Ok((parse_markdown(&escaped), false))
+            if options.escape_raw_html_braces {
+                let escaped = escape_braces_in_html_text(html);
+                Ok((parse_markdown(&escaped), false))
+            } else {
+                Ok((parse_markdown(html), false))
+            }
         }
         PAYLOAD_OPSTREAM => {
             let ops = reader.read_bytes(len)?;
@@ -1039,7 +1063,23 @@ pub fn apply_mdast_commands(
     command_buf: &[u8],
     parse_markdown: &dyn Fn(&str) -> Arena<Mdast>,
 ) -> Result<Arena<Mdast>, CommandError> {
-    let (arena, dropped) = apply_mdast_commands_lenient(arena, command_buf, parse_markdown)?;
+    apply_mdast_commands_with_options(
+        arena,
+        command_buf,
+        parse_markdown,
+        MdastCommandOptions::default(),
+    )
+}
+
+/// Like [`apply_mdast_commands`], with explicit command application options.
+pub fn apply_mdast_commands_with_options(
+    arena: Arena<Mdast>,
+    command_buf: &[u8],
+    parse_markdown: &dyn Fn(&str) -> Arena<Mdast>,
+    options: MdastCommandOptions,
+) -> Result<Arena<Mdast>, CommandError> {
+    let (arena, dropped) =
+        apply_mdast_commands_lenient_with_options(arena, command_buf, parse_markdown, options)?;
     if let Some(anchor) = dropped.first() {
         return Err(CommandError::PatchOnRemovedSubtree(*anchor));
     }
@@ -1053,9 +1093,25 @@ pub fn apply_mdast_commands(
 /// splices it back with its id intact, so a transform queued on a nested node
 /// (e.g. a `:::tip` inside a `:::note`) still applies, in the same pass.
 pub fn apply_mdast_commands_lenient(
+    arena: Arena<Mdast>,
+    command_buf: &[u8],
+    parse_markdown: &dyn Fn(&str) -> Arena<Mdast>,
+) -> Result<(Arena<Mdast>, Vec<u32>), CommandError> {
+    apply_mdast_commands_lenient_with_options(
+        arena,
+        command_buf,
+        parse_markdown,
+        MdastCommandOptions::default(),
+    )
+}
+
+/// Like [`apply_mdast_commands_lenient`], with explicit command application
+/// options.
+pub fn apply_mdast_commands_lenient_with_options(
     mut arena: Arena<Mdast>,
     command_buf: &[u8],
     parse_markdown: &dyn Fn(&str) -> Arena<Mdast>,
+    options: MdastCommandOptions,
 ) -> Result<(Arena<Mdast>, Vec<u32>), CommandError> {
     if command_buf.is_empty() {
         return Ok((arena, Vec::new()));
@@ -1086,21 +1142,21 @@ pub fn apply_mdast_commands_lenient(
             CMD_INSERT_BEFORE => {
                 let node_id = reader.read_u32()?;
                 let (new_tree, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::InsertBefore { node_id, new_tree });
             }
 
             CMD_INSERT_AFTER => {
                 let node_id = reader.read_u32()?;
                 let (new_tree, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::InsertAfter { node_id, new_tree });
             }
 
             CMD_PREPEND_CHILD => {
                 let node_id = reader.read_u32()?;
                 let (child_tree, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::PrependChild {
                     node_id,
                     child_tree,
@@ -1110,7 +1166,7 @@ pub fn apply_mdast_commands_lenient(
             CMD_APPEND_CHILD => {
                 let node_id = reader.read_u32()?;
                 let (child_tree, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::AppendChild {
                     node_id,
                     child_tree,
@@ -1120,7 +1176,7 @@ pub fn apply_mdast_commands_lenient(
             CMD_WRAP => {
                 let node_id = reader.read_u32()?;
                 let (parent_tree, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::Wrap {
                     node_id,
                     parent_tree,
@@ -1130,7 +1186,7 @@ pub fn apply_mdast_commands_lenient(
             CMD_REPLACE => {
                 let node_id = reader.read_u32()?;
                 let (new_tree, keep_children) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::Replace {
                     node_id,
                     new_tree,
@@ -1141,7 +1197,7 @@ pub fn apply_mdast_commands_lenient(
             CMD_SET_CHILDREN => {
                 let node_id = reader.read_u32()?;
                 let (new_children, _) =
-                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id)?;
+                    read_mdast_payload(&mut reader, parse_markdown, &arena, node_id, options)?;
                 patches.push(Patch::SetChildren {
                     node_id,
                     new_children,

--- a/crates/satteri-plugin-api/src/lib.rs
+++ b/crates/satteri-plugin-api/src/lib.rs
@@ -12,7 +12,8 @@ pub use context::{Diagnostic, PluginContext, Severity};
 pub use data::{DataMap, DataValue, TypedDataMap};
 pub use js_commands::{
     apply_hast_commands, apply_hast_commands_lenient, apply_mdast_commands,
-    apply_mdast_commands_lenient,
+    apply_mdast_commands_lenient, apply_mdast_commands_lenient_with_options,
+    apply_mdast_commands_with_options, MdastCommandOptions,
 };
 pub use plugin::{NodeView, Plugin, PluginMeta, VisitResult};
 pub use runner::{PluginRunResult, PluginRunner};

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -270,6 +270,48 @@ describe("markdownToHtml", () => {
 
   // with MDAST plugins only
 
+  test("rawHtml preserves Mermaid curly braces in rendered HTML", () => {
+    const plugin = defineMdastPlugin({
+      name: "raw-html-mermaid-braces",
+      code(node) {
+        if (node.type === "code" && node.lang === "mermaid") {
+          return {
+            rawHtml: `<pre class="mermaid">${node.value}</pre>`,
+          };
+        }
+      },
+    });
+
+    const { html } = markdownToHtml("```mermaid\nflowchart TD\n    C{JWT valid?}\n```", {
+      features: { gfm: true },
+      mdastPlugins: [plugin],
+    });
+
+    expect(html).toContain("C{JWT valid?}");
+    expect(html).not.toContain("{'{'}");
+    expect(html).not.toContain("{'}'}");
+  });
+
+  test("rawHtml preserves Shiki-like curly braces in rendered HTML", () => {
+    const plugin = defineMdastPlugin({
+      name: "raw-html-shiki-braces",
+      code() {
+        return {
+          rawHtml: '<pre class="shiki"><code><span style="color:red">{foo: 1}</span></code></pre>',
+        };
+      },
+    });
+
+    const { html } = markdownToHtml("```js\nconst x = {foo: 1}\n```", {
+      mdastPlugins: [plugin],
+    });
+
+    expect(html).toContain("{foo: 1}");
+    expect(html).not.toContain("{'{'}");
+    expect(html).not.toContain("{'}'}");
+    expect(html).toContain("shiki");
+  });
+
   test("MDAST plugin removes headings", () => {
     const removeHeadings = defineMdastPlugin({
       name: "remove-headings",

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -694,6 +694,30 @@ describe("mdxToJs", () => {
     expect(js).toContain("Kept");
   });
 
+  test("rawHtml braces survive MDX reparse as escaped literals", () => {
+    const plugin = defineMdastPlugin({
+      name: "raw-html-mermaid-braces",
+      code(node) {
+        if (node.type === "code" && node.lang === "mermaid") {
+          return {
+            rawHtml: `<pre class="mermaid">${node.value}</pre>`,
+          };
+        }
+      },
+    });
+
+    // Unlike markdownToHtml, the MDX pipeline must escape braces so the reparse
+    // does not read `{JWT valid?}` as a (broken) expression. The escape compiles
+    // to literal `{` / `}` string children, preserving the Mermaid source.
+    const { code: js } = mdxToJs("```mermaid\nflowchart TD\n    C{JWT valid?}\n```", {
+      mdastPlugins: [plugin],
+    });
+
+    expect(js).toContain('"{"');
+    expect(js).toContain('"}"');
+    expect(js).toContain("JWT valid?");
+  });
+
   test("MDAST plugin can read JSX attributes", () => {
     const collected: unknown[] = [];
     const readAttrs = defineMdastPlugin({

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -289,6 +289,8 @@ For HAST elements, `setProperty` takes a HAST property key (e.g. `"className"`, 
 | `{ raw: string }`             | Splice raw Markdown (re-parsed)  | N/A     |
 | `{ rawHtml: string }`         | Splice raw HTML (passthrough)    | N/A     |
 
+`rawHtml` is emitted verbatim, as such literal `{` and `}` are preserved, so HTML carrying curly brackets (e.g. a Mermaid decision node `C{JWT valid?}`) survives intact in Markdown. In MDX since the same content is reparsed as MDX, curly brackets are auto-escaped so they still render as literals.
+
 ## Async plugins
 
 Any visitor may return a `Promise`. Sync and async visitors can be mixed freely. If any visitor in the pipeline is async, `markdownToHtml` and `mdxToJs` return a `Promise`; otherwise they return synchronously.


### PR DESCRIPTION
## Summary

- Preserve literal `{` and `}` from plugin `rawHtml` payloads when rendering through `markdownToHtml`.
- Keep the existing MDX rawHtml brace escaping behavior for `mdxToJs`, where braces must be protected before MDX reparse.
- Add Markdown HTML regressions for Mermaid and Shiki-like rawHtml output, plus a patch changeset for `npm/satteri`.

## Root cause

`rawHtml` payloads were always rewritten with MDX brace escapes before being parsed back into the MDAST command stream. That is needed for MDX compilation, but in the plain Markdown-to-HTML pipeline the final renderer treats those escape fragments as raw text and emits `{'{'}` / `{'}'}`.

## Validation

- `pnpm format`
- `pnpm --filter satteri test`
- `cargo test --all`
- `git diff --check`
- `pnpm lint` partially checked: oxlint and cargo clippy passed; knip still reports pre-existing generated binding/unused-export issues outside this diff.

Fixes https://github.com/bruits/satteri/issues/108