### PR TITLE
fix(mdx): lower JSX in attribute expressions and scan their children as JSX text

### DIFF
--- a/.sampo/changesets/fix-mdx-jsx-in-attribute-expression.md
+++ b/.sampo/changesets/fix-mdx-jsx-in-attribute-expression.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-mdxjs: patch
+npm/satteri: patch
+---
+
+Fixes JSX nested in an MDX attribute expression (e.g. `prop={<p>hi</p>}` or `title={<>x</>}`) being emitted as raw, un-lowered JSX, which produced invalid JavaScript. Also fixes quotes and apostrophes in such JSX text (e.g. `prop={<p>Inc.'s "best" tool</p>}`) being mis-scanned as JS string literals and causing a parse error — the expression scanner now consumes a JSX element's children as text.

--- a/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
+++ b/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
@@ -1931,16 +1931,29 @@ fn jsx_to_call<'a>(
     filepath: Option<&String>,
     location: Option<&Location>,
     create_element_name: &str,
-    _fragment_name: &str,
-    _import_fragment: &mut bool,
+    fragment_name: &str,
+    import_fragment: &mut bool,
     import_jsx: &mut bool,
     import_jsxs: &mut bool,
     import_jsx_dev: &mut bool,
 ) -> Result<Expression<'a>, Message> {
     let (callee, parameters) = if automatic {
         let is_static_children = children.len() > 1;
-        let (props, key) =
-            jsx_attributes_to_props(alloc, attributes, Some(&mut children), location)?;
+        let (props, key) = jsx_attributes_to_props(
+            alloc,
+            attributes,
+            Some(&mut children),
+            location,
+            automatic,
+            development,
+            filepath,
+            create_element_name,
+            fragment_name,
+            import_fragment,
+            import_jsx,
+            import_jsxs,
+            import_jsx_dev,
+        )?;
 
         let mut parameters = OxcVec::with_capacity_in(6, alloc);
         parameters.push(Argument::from(name));
@@ -2044,7 +2057,21 @@ fn jsx_to_call<'a>(
         (create_ident_expression(alloc, callee_name), parameters)
     } else {
         // Classic runtime
-        let (props, _key) = jsx_attributes_to_props(alloc, attributes, None, location)?;
+        let (props, _key) = jsx_attributes_to_props(
+            alloc,
+            attributes,
+            None,
+            location,
+            automatic,
+            development,
+            filepath,
+            create_element_name,
+            fragment_name,
+            import_fragment,
+            import_jsx,
+            import_jsxs,
+            import_jsx_dev,
+        )?;
 
         let mut parameters = OxcVec::with_capacity_in(4, alloc);
         parameters.push(Argument::from(name));
@@ -2198,11 +2225,21 @@ fn jsx_expression_to_expression(jsx_expr: JSXExpression<'_>) -> Option<Expressio
 }
 
 /// Convert JSX attributes to props expression and optional key.
+#[allow(clippy::too_many_arguments)]
 fn jsx_attributes_to_props<'a>(
     alloc: &'a Allocator,
     attributes: Option<Vec<JSXAttributeItem<'a>>>,
     children: Option<&mut Vec<Expression<'a>>>,
     location: Option<&Location>,
+    automatic: bool,
+    development: bool,
+    filepath: Option<&String>,
+    create_element_name: &str,
+    fragment_name: &str,
+    import_fragment: &mut bool,
+    import_jsx: &mut bool,
+    import_jsxs: &mut bool,
+    import_jsx_dev: &mut bool,
 ) -> Result<(Option<Expression<'a>>, Option<Expression<'a>>), Message> {
     let mut objects: Vec<Expression<'a>> = vec![];
     let mut fields: Vec<ObjectPropertyKind<'a>> = vec![];
@@ -2213,11 +2250,26 @@ fn jsx_attributes_to_props<'a>(
         for attribute in attributes {
             match attribute {
                 JSXAttributeItem::SpreadAttribute(spread_attr) => {
-                    let spread_attr = spread_attr.unbox();
+                    let mut spread_attr = spread_attr.unbox();
                     if !fields.is_empty() {
                         let props_vec = OxcVec::from_iter_in(fields.drain(..), alloc);
                         objects.push(create_object_expression(alloc, props_vec));
                     }
+                    // Lower any JSX inside the spread argument (e.g. `{...{x: <p/>}}`).
+                    process_expression_jsx(
+                        &mut spread_attr.argument,
+                        alloc,
+                        automatic,
+                        development,
+                        filepath,
+                        location,
+                        create_element_name,
+                        fragment_name,
+                        import_fragment,
+                        import_jsx,
+                        import_jsxs,
+                        import_jsx_dev,
+                    )?;
                     objects.push(spread_attr.argument);
                     spread = true;
                 }
@@ -2229,7 +2281,26 @@ fn jsx_attributes_to_props<'a>(
                         false
                     };
 
-                    let value = jsx_attr_value_to_expression(alloc, jsx_attr.value);
+                    let mut value = jsx_attr_value_to_expression(alloc, jsx_attr.value);
+                    // Lower any JSX nested in the attribute value (e.g.
+                    // `d={<p>x</p>}`, `d={<>x</>}`, `d={cond ? <a/> : <b/>}`).
+                    // Children are recursed into separately (in
+                    // `jsx_element_to_call`); attribute values were not, so
+                    // their JSX leaked through un-lowered as raw `<...>`.
+                    process_expression_jsx(
+                        &mut value,
+                        alloc,
+                        automatic,
+                        development,
+                        filepath,
+                        location,
+                        create_element_name,
+                        fragment_name,
+                        import_fragment,
+                        import_jsx,
+                        import_jsxs,
+                        import_jsx_dev,
+                    )?;
 
                     if is_key && children.is_some() {
                         // automatic runtime: extract key

--- a/crates/satteri-mdxjs-rs/tests/test.rs
+++ b/crates/satteri-mdxjs-rs/tests/test.rs
@@ -1384,3 +1384,85 @@ fn multiline_inline_expression_error_is_exact() {
          prefix, got {p:?}"
     );
 }
+
+#[test]
+fn jsx_in_attribute_expression_is_lowered() -> Result<(), satteri_arena::mdx_types::Message> {
+    // JSX nested in an attribute expression must be transformed to `_jsx(...)`
+    // calls, exactly like JSX in children. It used to leak through un-lowered
+    // as a raw JSX element in the output (`d: <_components.p>...`), producing
+    // invalid JavaScript.
+    let element = compile(
+        "<Foo d={<p>hi there</p>} />\n",
+        &Options::default(),
+        MDX_OPTS,
+    )?;
+    assert!(
+        element.contains(r#"d: _jsx(_components.p, { children: "hi there" })"#),
+        "element attr should be lowered, got:\n{element}"
+    );
+
+    let fragment = compile("<Foo d={<>hi</>} />\n", &Options::default(), MDX_OPTS)?;
+    assert!(
+        fragment.contains(r#"d: _jsx(_Fragment, { children: "hi" })"#),
+        "fragment attr should be lowered, got:\n{fragment}"
+    );
+
+    let conditional = compile(
+        "<Foo d={cond ? <a>x</a> : <b>y</b>} />\n",
+        &Options::default(),
+        MDX_OPTS,
+    )?;
+    assert!(
+        conditional.contains("_jsx(_components.a,") && conditional.contains("_jsx(_components.b,"),
+        "JSX in a conditional attr value should be lowered, got:\n{conditional}"
+    );
+
+    // No raw JSX (`<_components.` / `<_Fragment`) may survive into the output.
+    for out in [&element, &fragment, &conditional] {
+        assert!(
+            !out.contains("<_components.") && !out.contains("<_Fragment"),
+            "raw JSX leaked into output:\n{out}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn apostrophe_in_jsx_text_after_close_tag() -> Result<(), satteri_arena::mdx_types::Message> {
+    // End-to-end guard combining both halves of the fix: the scanner must run
+    // past an apostrophe that follows a child close tag inside an attribute
+    // expression (`</b>'s`), and the resulting JSX must then be lowered.
+    let out = compile(
+        "<Foo d={<p>a<b>x</b>'s</p>} />\n",
+        &Options::default(),
+        MDX_OPTS,
+    )?;
+    assert!(
+        out.contains("_jsxs(_components.p,")
+            && out.contains(r#"_jsx(_components.b, { children: "x" })"#)
+            && out.contains(r#""'s""#),
+        "apostrophe-after-close-tag attr expr should parse and lower, got:\n{out}"
+    );
+    assert!(
+        !out.contains("<_components."),
+        "raw JSX leaked into output:\n{out}"
+    );
+
+    // Quotes elsewhere in JSX text — after a `.` (`Inc.'s`) and a paired
+    // double-quote (`"!?"`) — must likewise stay literal text, not open a JS
+    // string. (These defeat a preceding-token heuristic; the scanner consumes
+    // element children as text instead.)
+    for src in [
+        "<Foo d={<p>Stream.io, Inc.'s view</p>} />\n",
+        "<Foo d={<p>a \"!?\" icon here</p>} />\n",
+    ] {
+        let out = compile(src, &Options::default(), MDX_OPTS)?;
+        assert!(
+            out.contains("_jsx(_components.p,") && !out.contains("<_components."),
+            "quote in JSX text should parse and lower: {src:?} ->\n{out}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -862,13 +862,17 @@ fn scan_mdx_expression_end_inner(
                 ix = scan_regex(bytes, ix);
                 mark_value!();
             }
-            // JSX tags — skip `<tag ...>` and `</tag>` so their `/` and `{}`
-            // don't interfere with brace/regex tracking. When the lookahead
-            // doesn't form a valid JSX tag, treat the `<` as a less-than
-            // operator: mark_op so a following `/` is read as a regex (the
-            // acorn interpretation), not as division. Without this, an
-            // expression like `l</:/}` mis-parses the trailing `/}` as a
-            // regex literal and swallows the closing brace.
+            // JSX — skip a whole `<tag ...>...</tag>` element (or a self-closing
+            // / closing tag). Scanning the *element* (not just the tag) means
+            // its children are consumed as JSX text, where quotes and braces
+            // are literal — so an apostrophe (`Inc.'s`), a quote (`a "!?" b`),
+            // or text after a child tag (`</b>'s`) can't be mis-lexed as a JS
+            // string and swallow the closing `}`. When the lookahead doesn't
+            // form a valid JSX tag, treat the `<` as a less-than operator:
+            // mark_op so a following `/` is read as a regex (the acorn
+            // interpretation), not as division. Without this, an expression
+            // like `l</:/}` mis-parses the trailing `/}` as a regex literal and
+            // swallows the closing brace.
             b'<' if ix + 1 < bytes.len()
                 && (bytes[ix + 1].is_ascii_alphabetic()
                     || bytes[ix + 1] == b'_'
@@ -877,8 +881,7 @@ fn scan_mdx_expression_end_inner(
                     || bytes[ix + 1] == b'>') =>
             {
                 reject_if_lazy!();
-                if let Some(end) = scan_mdx_jsx_tag_end_inner(&bytes[ix..], None, nesting_depth + 1)
-                {
+                if let Some(end) = scan_mdx_jsx_element_end(&bytes[ix..], nesting_depth + 1) {
                     ix += end;
                     mark_value!();
                 } else {
@@ -1217,6 +1220,67 @@ fn looks_like_spread(bytes: &[u8]) -> bool {
         i += 1;
     }
     i + 2 < bytes.len() && &bytes[i..i + 3] == b"..."
+}
+
+/// Scan a full JSX element beginning at `bytes[0] == '<'`, returning the byte
+/// offset past its matching close tag (or past `/>` for a self-closing element,
+/// or past the tag for a bare closing tag). Returns `None` if the bytes don't
+/// open a valid JSX tag.
+///
+/// Unlike [`scan_mdx_jsx_tag_end_inner`] (which scans a single tag), this also
+/// descends through the element's children: text is consumed literally — so
+/// quotes and braces in JSX text are NOT lexed as JS — while nested `{...}` are
+/// scanned as expressions and nested `<...>` as elements. That is what lets a
+/// quote in JSX text inside an attribute expression (`d={<p>Inc.'s "best"
+/// tool</p>}`, `d={<p>a<b>x</b>'s</p>}`) avoid being mistaken for a string
+/// literal that swallows the closing brace.
+fn scan_mdx_jsx_element_end(bytes: &[u8], nesting_depth: u32) -> Option<usize> {
+    if nesting_depth > MAX_MDX_NESTING {
+        return None;
+    }
+    // The opening (or closing, or fragment) tag itself.
+    let tag_end = scan_mdx_jsx_tag_end_inner(bytes, None, nesting_depth)?;
+    // A closing tag (`</x>`) or self-closing tag (`<x/>`) has no children.
+    let is_closing = bytes.len() > 1 && bytes[1] == b'/';
+    let is_self_closing = tag_end >= 2 && bytes[tag_end - 2] == b'/';
+    if is_closing || is_self_closing {
+        return Some(tag_end);
+    }
+    // Opening tag (or fragment `<>`): scan children to the matching close tag.
+    let mut ix = tag_end;
+    while ix < bytes.len() {
+        match bytes[ix] {
+            // Nested expression child — JS lexing resumes inside it.
+            b'{' => {
+                let len = scan_mdx_expression_end_inner(
+                    &bytes[ix..],
+                    false,
+                    None,
+                    false,
+                    true,
+                    nesting_depth,
+                )?;
+                ix += len;
+            }
+            // The close tag for this element.
+            b'<' if ix + 1 < bytes.len() && bytes[ix + 1] == b'/' => {
+                let len = scan_mdx_jsx_tag_end_inner(&bytes[ix..], None, nesting_depth)?;
+                return Some(ix + len);
+            }
+            // A nested element, or a literal `<` in text (`a < b`). Try to scan
+            // an element; if it isn't one, the `<` is just text.
+            b'<' => {
+                if let Some(len) = scan_mdx_jsx_element_end(&bytes[ix..], nesting_depth + 1) {
+                    ix += len;
+                } else {
+                    ix += 1;
+                }
+            }
+            // Any other byte (quotes and apostrophes included) is literal text.
+            _ => ix += 1,
+        }
+    }
+    None
 }
 
 /// Scan for an MDX ESM block (`import ...` or `export ...`).

--- a/crates/satteri-pulldown-cmark/tests/mdx.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx.rs
@@ -658,6 +658,33 @@ fn jsx_flow_with_expression_attr() {
 }
 
 #[test]
+fn jsx_flow_expr_attr_quote_in_jsx_text() {
+    // Quotes and apostrophes in the JSX *text* of an element inside an
+    // attribute expression are literal — the expression scan consumes the
+    // element's children as text and must run through to the real closing `}`.
+    // Before the fix the scanner lexed those children as JS, so a quote (after
+    // a close tag `</b>'s`, after a `.` in `Inc.'s`, or a paired `"..."`)
+    // opened a phantom string literal and swallowed the rest of the line.
+    for src in [
+        "<Foo d={<p>a<b>x</b>'s</p>} />\n",
+        "<Foo d={<p>Sendbird<Tm />'s features</p>} />\n",
+        "<Foo d={<p>Stream.io, Inc.'s good-faith understanding</p>} />\n",
+        "<Foo d={<p>a \"!?\" icon to get in touch</p>} />\n",
+        "<Foo d={<p>say <b>\"hi\"</b> ok</p>} />\n",
+        "<Foo d={<p>nested {expr} and 'text'</p>} />\n",
+    ] {
+        let ev = mdx_events(src);
+        assert!(
+            has(&ev, |e| matches!(
+                e,
+                Event::Start(Tag::MdxJsxFlowElement(s)) if s.contains("Foo")
+            )),
+            "quote in JSX text after a value token must still parse: {src:?} -> {ev:?}"
+        );
+    }
+}
+
+#[test]
 fn jsx_flow_closing_fragment() {
     let ev = mdx_events("</>\n");
     assert!(


### PR DESCRIPTION
## Summary

Two related bugs in how MDX handles **JSX nested inside an attribute expression** (`prop={<p>…</p>}`, `title={<>…</>}`) — a common pattern for passing rich content to components. One is a code-generation bug, the other a parse error; both surface on the same construct, so they're fixed together.

```jsx
// 1. Codegen — compiles, but the inner JSX is emitted raw (invalid JS):
<Foo d={<p>hi there</p>} />
//    => _jsx(Foo, { d: <_components.p>hi there</_components.p> })   ❌  "Unexpected token '<'" at runtime

// 2. Parse — a quote/apostrophe in the JSX text aborts the scan:
<Foo d={<p>Inc.'s "best" tool</p>} />
//    => "Unexpected character after `<`, expected a valid JSX tag"   ❌
```

## Bug 1 — JSX in an attribute expression is not lowered

`jsx_element_to_call` recurses into an element's **children** (via `jsx_children_to_expressions`) but never runs its **attribute values** through `process_expression_jsx`. So JSX appearing in an attribute leaks through untransformed as a raw `JSXElement`/`JSXFragment` expression, producing invalid JavaScript (a literal `<` in the emitted function body).

**Fix:** thread the JSX-transform parameters into `jsx_attributes_to_props` and run each attribute value (and spread argument) through `process_expression_jsx`, exactly as children are handled. This recurses, so it also covers `{<>…</>}`, `{cond ? <a/> : <b/>}`, and deeper nesting.

```jsx
<Foo d={<p>hi there</p>} />
// => _jsx(Foo, { d: _jsx(_components.p, { children: "hi there" }) })   ✅
```

## Bug 2 — quotes in JSX text inside an expression are mis-lexed as JS strings

`scan_mdx_expression_end_inner` skips over a JSX **tag** (`scan_mdx_jsx_tag_end_inner`) but then resumes lexing the element's **children** as JavaScript. In JSX text a quote is literal, but the JS lexer treats `'`/`"` as a string opener, so it scans forward for a closing quote — past the real closing `}` — and the expression never terminates. An existing heuristic (treat `'` as text when preceded by an identifier char) patched the common `user's` case but missed quotes after a `.` (`Inc.'s`), after a child close tag (`</b>'s`), and paired double-quotes in text (`a "!?" b`).

**Fix:** add `scan_mdx_jsx_element_end`, which scans a whole element rather than a single tag — descending through its children, where text (including quotes and apostrophes) is consumed literally, nested `{…}` are scanned as expressions, and nested `<…>` as elements. The expression scanner calls it from the `<` arm. This removes the quote-in-JSX-text failure class at its root and makes the prior apostrophe heuristic unnecessary for these cases.

```jsx
<Foo d={<p>a<b>x</b>'s</p>} />
// => _jsx(Foo, { d: _jsxs(_components.p, { children: ["a", _jsx(_components.b, { children: "x" }), "'s"] }) })   ✅
```

## Testing

- New regression tests:
  - `crates/satteri-pulldown-cmark/tests/mdx.rs` — quotes/apostrophes in JSX text inside an attribute expression (`</b>'s`, `Inc.'s`, `a "!?" b`, nested `{expr}`, fragments) still parse.
  - `crates/satteri-mdxjs-rs/tests/test.rs` — end-to-end: JSX in element/fragment/conditional attribute values is lowered (no raw `<…>` survives), and the combined parse-then-lower path for the apostrophe case.
- `cargo test --all`, `cargo fmt --all`, `cargo clippy` all clean.

Sibling to #113 (same `scan_mdx_expression_end` area / quote handling).

A changeset is included (`patch` for `satteri-pulldown-cmark`, `satteri-mdxjs`, and `npm/satteri`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
