### PR TITLE
fix(satteri): Updated browser binding to export functions from `browser.js`

### DIFF
--- a/.sampo/changesets/venerable-baron-lempo.md
+++ b/.sampo/changesets/venerable-baron-lempo.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Updated `binding.browser.ts` to export functions from `browser.js`

--- a/packages/satteri/src/binding.browser.ts
+++ b/packages/satteri/src/binding.browser.ts
@@ -24,4 +24,4 @@ export {
   textContentHandle,
   walkHandle,
   walkMdastHandle,
-} from "../satteri_napi.wasi-browser.js";
+} from "../browser.js";


### PR DESCRIPTION
Fixes #120 

Not sure if this should be a patch or major change, let me know which is preferred and I'll update it.

I've tested the change and it seems to work.