### PR TITLE
Export `MdastVisitorContext` type

### DIFF
--- a/.sampo/changesets/jovial-shaman-hiisi.md
+++ b/.sampo/changesets/jovial-shaman-hiisi.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Exposes the `MdastVisitorContext` type from the `satteri` package.

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -67,7 +67,11 @@ export type {
 
 // Visitor pipeline (for manual plugin execution)
 export { visitMdastHandle, resolveMdastSubscriptions } from "./mdast/mdast-visitor.js";
-export type { MdastPluginInstance, MdastContent } from "./mdast/mdast-visitor.js";
+export type {
+  MdastPluginInstance,
+  MdastVisitorContext,
+  MdastContent,
+} from "./mdast/mdast-visitor.js";
 export {
   visitHastHandle,
   resolveSubscriptions as resolveHastSubscriptions,


### PR DESCRIPTION
Closes #127 

This PR exposes the `MdastVisitorContext` type to match the currently exported `HastVisitorContext` which is pretty handful if plugin authors create helper functions consuming the visitor context.