### PR TITLE
fix(mdxjs): preserve significant whitespace between JSX elements in expressions

### DIFF
--- a/.sampo/changesets/preserve-jsx-expression-whitespace.md
+++ b/.sampo/changesets/preserve-jsx-expression-whitespace.md
@@ -1,0 +1,9 @@
+---
+cargo/satteri-mdxjs: patch
+---
+
+Preserve significant whitespace between adjacent JSX elements (and inside
+whitespace-only elements like `<em> </em>`) when JSX is parsed inside an
+expression, such as an attribute expression. Previously a space-only text node
+with no newline was dropped, so `<C d={<><a/> <b/></>} />` lost the `" "` and
+rendered the two elements directly adjacent.

--- a/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
+++ b/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
@@ -2573,15 +2573,12 @@ fn jsx_text_to_value(value: &str) -> String {
     }
 
     if start != bytes.len() {
-        if result.is_empty() {
-            index = 0;
-            while index < bytes.len() && bytes[index] == b' ' {
-                index += 1;
-            }
-            if index == bytes.len() {
-                return result;
-            }
-        } else {
+        // A trailing segment that follows a newline-collapsed run gets a single
+        // separating space. A segment with no preceding newline (`result` is
+        // still empty) is kept verbatim, including a run that is only spaces,
+        // e.g. the significant whitespace in `<em> </em>` or between two
+        // elements on one line (`<a/> <b/>`), which JSX preserves as `" "`.
+        if !result.is_empty() {
             result.push(' ');
         }
         result.push_str(str::from_utf8(&bytes[start..]).unwrap());

--- a/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
+++ b/crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs
@@ -2573,11 +2573,7 @@ fn jsx_text_to_value(value: &str) -> String {
     }
 
     if start != bytes.len() {
-        // A trailing segment that follows a newline-collapsed run gets a single
-        // separating space. A segment with no preceding newline (`result` is
-        // still empty) is kept verbatim, including a run that is only spaces,
-        // e.g. the significant whitespace in `<em> </em>` or between two
-        // elements on one line (`<a/> <b/>`), which JSX preserves as `" "`.
+        // An all-spaces run with no newline is significant in JSX, so keep it rather than drop it.
         if !result.is_empty() {
             result.push(' ');
         }

--- a/crates/satteri-mdxjs-rs/tests/test.rs
+++ b/crates/satteri-mdxjs-rs/tests/test.rs
@@ -838,6 +838,26 @@ fn children_arrow_returning_jsx() -> Result<(), satteri_arena::mdx_types::Messag
 }
 
 #[test]
+fn jsx_in_expression_preserves_significant_whitespace()
+-> Result<(), satteri_arena::mdx_types::Message> {
+    // Whitespace between two elements on a single line is significant in JSX and
+    // must survive as a `" "` child (e.g. `<a/> <b/>`). The same applies to a
+    // whitespace-only element used as a spacer (`<em> </em>`). This only affects
+    // JSX parsed inside expressions (here, an attribute expression); a run that
+    // contains a newline still collapses.
+    let result = compile(
+        "<C d={<><x>a</x> <y>b</y><em> </em></>} />\n",
+        &Options::default(),
+        MDX_OPTS,
+    )?;
+    assert!(
+        result.matches("\" \"").count() >= 2,
+        "significant inter-element and spacer whitespace must be preserved: {result}"
+    );
+    Ok(())
+}
+
+#[test]
 fn jsx_inside_map_callback() -> Result<(), satteri_arena::mdx_types::Message> {
     // `items.map(x => <li>{x}</li>)` must produce _jsx calls in the callback,
     // not leave raw JSX in the compiled output.

--- a/crates/satteri-mdxjs-rs/tests/test.rs
+++ b/crates/satteri-mdxjs-rs/tests/test.rs
@@ -840,11 +840,7 @@ fn children_arrow_returning_jsx() -> Result<(), satteri_arena::mdx_types::Messag
 #[test]
 fn jsx_in_expression_preserves_significant_whitespace()
 -> Result<(), satteri_arena::mdx_types::Message> {
-    // Whitespace between two elements on a single line is significant in JSX and
-    // must survive as a `" "` child (e.g. `<a/> <b/>`). The same applies to a
-    // whitespace-only element used as a spacer (`<em> </em>`). This only affects
-    // JSX parsed inside expressions (here, an attribute expression); a run that
-    // contains a newline still collapses.
+    // JSX keeps a no-newline whitespace run as a significant `" "`, even via the expression path.
     let result = compile(
         "<C d={<><x>a</x> <y>b</y><em> </em></>} />\n",
         &Options::default(),

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -501,10 +501,7 @@ describe("MDX conformance: attribute values", () => {
     await assertMdxConformance('<Slot d={<p>a "!?" badge here</p>} />', { Slot });
   });
 
-  // Significant whitespace between adjacent elements was dropped inside an
-  // attribute expression, rendering them directly adjacent (`ab` not `a b`) (#129).
-  // `Pass` renders the inner elements transparently so the `" "` lands between
-  // text; `normalizeHtml` collapses whitespace between tags and would mask it.
+  // `Pass` renders inner elements transparently so the `" "` lands between text; `normalizeHtml` collapses whitespace between tags and would mask the difference.
   test("significant whitespace between JSX elements in attribute expression (#129)", async () => {
     const Slot = (props: any) => createElement("div", null, props.d);
     const Pass = (props: any) => props.children;

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -500,6 +500,17 @@ describe("MDX conformance: attribute values", () => {
     await assertMdxConformance("<Slot d={<p>Acme Corp.'s view</p>} />", { Slot });
     await assertMdxConformance('<Slot d={<p>a "!?" badge here</p>} />', { Slot });
   });
+
+  // Significant whitespace between adjacent elements was dropped inside an
+  // attribute expression, rendering them directly adjacent (`ab` not `a b`) (#129).
+  // `Pass` renders the inner elements transparently so the `" "` lands between
+  // text; `normalizeHtml` collapses whitespace between tags and would mask it.
+  test("significant whitespace between JSX elements in attribute expression (#129)", async () => {
+    const Slot = (props: any) => createElement("div", null, props.d);
+    const Pass = (props: any) => props.children;
+    await assertMdxConformance("<Slot d={<><x>a</x> <y>b</y></>} />", { Slot, x: Pass, y: Pass });
+    await assertMdxConformance("<Slot d={<>a<em> </em>b</>} />", { Slot, em: Pass });
+  });
 });
 
 describe("MDX conformance: markdown elements", () => {


### PR DESCRIPTION
## Problem

When JSX is parsed inside an **expression** (e.g. an attribute expression such as
`prop={<>…</>}`), a whitespace-only text node between two adjacent elements on a
single line is dropped. JSX treats that whitespace as significant; only runs that
*contain a newline* should collapse.

Minimal repro:

```jsx
<C d={<><x>a</x> <y>b</y></>} />
```

Compiled `children`, note the missing `" "` between the two elements:

```js
// before
{ children: [ _jsx(_components.x, { children: "a" }), _jsx(_components.y, { children: "b" }) ] }
// after
{ children: [ _jsx(_components.x, { children: "a" }), " ", _jsx(_components.y, { children: "b" }) ] }
```

The same applies to a whitespace-only element used as a spacer (`<em> </em>`),
whose `" "` child was dropped. At render time the two elements end up directly
adjacent (`ab` instead of `a b`). Regular Markdown/JSX body content is unaffected;
only JSX parsed through the expression path hits this.

## Cause

In `jsx_text_to_value` (`crates/satteri-mdxjs-rs/src/oxc_util_build_jsx.rs`) the
final-segment handling special-cased a text node that is *entirely spaces with no
newline* and returned an empty string, dropping it. Per JSX semantics
(`cleanJSXElementLiteralChild`), such a run is significant and must be preserved.

## Fix

Remove the all-spaces early return so a segment with no preceding newline is kept
verbatim. Newline-containing runs still collapse exactly as before, since they are
handled earlier in the function and never reach this branch.

## Tests

Added `jsx_in_expression_preserves_significant_whitespace`, which fails before the
change and passes after. Full suite: `cargo test -p satteri-mdxjs` reports 61
passed. `cargo fmt --check` and `cargo clippy` are clean.
