### PR TITLE
fix(satteri): declare WASI runtime deps as optionalDependencies

### DIFF
--- a/.sampo/changesets/wasi-runtime-deps.md
+++ b/.sampo/changesets/wasi-runtime-deps.md
@@ -2,4 +2,4 @@
 npm/satteri: patch
 ---
 
-Fixed `satteri` failing to bundle (esbuild, wrangler, Vite) when used as a production dependency.
+Fixed `satteri` failing to bundle due to wasm dependencies

--- a/.sampo/changesets/wasi-runtime-deps.md
+++ b/.sampo/changesets/wasi-runtime-deps.md
@@ -2,10 +2,4 @@
 npm/satteri: patch
 ---
 
-Fixed bundlers (esbuild/wrangler/Vite) failing to resolve `@napi-rs/wasm-runtime`
-when `satteri` is a production dependency. The shipped WASI loaders
-(`satteri_napi.wasi.cjs`, `satteri_napi.wasi-browser.js`) import `@napi-rs/wasm-runtime`
-(which in turn pulls `@emnapi/core` and `@emnapi/runtime`), but those were declared
-only as `devDependencies`, so they were never installed for consumers. They are now
-`optionalDependencies`, so the WASM fallback path resolves while native-only users are
-unaffected if installation is skipped.
+Fixed `satteri` failing to bundle (esbuild, wrangler, Vite) when used as a production dependency.

--- a/.sampo/changesets/wasi-runtime-deps.md
+++ b/.sampo/changesets/wasi-runtime-deps.md
@@ -1,0 +1,11 @@
+---
+npm/satteri: patch
+---
+
+Fixed bundlers (esbuild/wrangler/Vite) failing to resolve `@napi-rs/wasm-runtime`
+when `satteri` is a production dependency. The shipped WASI loaders
+(`satteri_napi.wasi.cjs`, `satteri_napi.wasi-browser.js`) import `@napi-rs/wasm-runtime`
+(which in turn pulls `@emnapi/core` and `@emnapi/runtime`), but those were declared
+only as `devDependencies`, so they were never installed for consumers. They are now
+`optionalDependencies`, so the WASM fallback path resolves while native-only users are
+unaffected if installation is skipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -60,12 +60,14 @@
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.3"
   },
-  "devDependencies": {
-    "@codspeed/vitest-plugin": "^5.4.0",
+  "optionalDependencies": {
     "@emnapi/core": "^1.11.1",
     "@emnapi/runtime": "^1.11.1",
+    "@napi-rs/wasm-runtime": "^1.1.5"
+  },
+  "devDependencies": {
+    "@codspeed/vitest-plugin": "^5.4.0",
     "@mdx-js/mdx": "^3.1.1",
-    "@napi-rs/wasm-runtime": "^1.1.5",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -11,10 +11,6 @@
     "browser.js",
     "index.js",
     "index.d.ts",
-    "satteri_napi.wasi.cjs",
-    "satteri_napi.wasi-browser.js",
-    "wasi-worker.mjs",
-    "wasi-worker-browser.mjs",
     "webcontainer-fallback.cjs"
   ],
   "type": "module",
@@ -60,14 +56,12 @@
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.3"
   },
-  "optionalDependencies": {
-    "@emnapi/core": "^1.11.1",
-    "@emnapi/runtime": "^1.11.1",
-    "@napi-rs/wasm-runtime": "^1.1.5"
-  },
   "devDependencies": {
     "@codspeed/vitest-plugin": "^5.4.0",
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
     "@mdx-js/mdx": "^3.1.1",
+    "@napi-rs/wasm-runtime": "^1.1.5",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
### What

Fixes bundlers failing to resolve `@napi-rs/wasm-runtime` when `satteri` is a production dependency.

### Problem

```
✘ [ERROR] Could not resolve "@napi-rs/wasm-runtime"
  satteri/satteri_napi.wasi-browser.js:6:7
```

`wrangler deploy` (and any esbuild/Vite/webpack build that follows the WASI path) dies at **bundle time**.

### Cause

The root package ships the WASI loaders via its `files` array. They import `@napi-rs/wasm-runtime`, whose `runtime.cjs` re-exports from `@emnapi/core` and `@emnapi/runtime` (it only declares `@tybys/wasm-util` itself). All three were declared only as `devDependencies`, so a consumer never installs them.

### Fix

Move `@napi-rs/wasm-runtime`, `@emnapi/core`, `@emnapi/runtime` from `devDependencies` to `optionalDependencies`. `optional` is deliberate - it matches the set the generated `@bruits/satteri-wasm32-wasi` sidecar already declares, is only needed on the WASM fallback path, and stays non-fatal for native-only installs.

### Testing

`pnpm pack` the package, install the tarball into a clean project:

- `require.resolve` of all three (+ transitive `@tybys/wasm-util`) -> resolves.
- `esbuild --bundle --platform=node` of `import "satteri"` -> bundles, no `Could not resolve` error.

Both fail before this change.

### Scope

This addresses **bundling only**. Running Sätteri in the Cloudflare Workers *runtime* is a separate issue, blocked upstream on napi-rs/emnapi shipping a non-threaded WASM runtime (the generated bootstrap requires shared memory + `new Worker`, which Workers don't support). See https://github.com/napi-rs/napi-rs/issues/1897.

### Closes

- #132 

_Co-Authored by Claude Code._