### PR TITLE
fix(satteri-pulldown-cmark): don't let heading attribute blocks conflict with directives

### DIFF
--- a/.sampo/changesets/heading-attrs-directive-conflict.md
+++ b/.sampo/changesets/heading-attrs-directive-conflict.md
@@ -1,0 +1,9 @@
+---
+cargo/satteri-pulldown-cmark: patch
+---
+
+Fixed heading attribute blocks conflicting with text directives when both
+features are enabled. A trailing directive keeps its own `{...}` attributes
+instead of having them absorbed by the heading (`## H :badge[x]{variant=y}`),
+and a heading attribute block is now recognized whether it sits before or after
+a trailing directive (`## H {#id} :badge[x]` and `## H :badge[x] {#id}`).

--- a/.sampo/changesets/heading-attrs-directive-conflict.md
+++ b/.sampo/changesets/heading-attrs-directive-conflict.md
@@ -2,8 +2,4 @@
 cargo/satteri-pulldown-cmark: patch
 ---
 
-Fixed heading attribute blocks conflicting with text directives when both
-features are enabled. A trailing directive keeps its own `{...}` attributes
-instead of having them absorbed by the heading (`## H :badge[x]{variant=y}`),
-and a heading attribute block is now recognized whether it sits before or after
-a trailing directive (`## H {#id} :badge[x]` and `## H :badge[x] {#id}`).
+Fixed heading attribute blocks conflicting with text directives when both features are enabled.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1501,10 +1501,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             // of the parent) instead.
             let header_end = self.tree[cur_ix].item.end;
 
-            // Setext strips the block by truncating the tree to the block's
-            // opening `{`. A trailing run of text directives is dropped along
-            // with the block, then reparsed below as its own span so it keeps
-            // its `{...}` attributes (matching the ATX path).
+            // Truncating to the block's `{` (below) drops any trailing directive
+            // run with it, so reparse that run to keep its own `{...}` attributes.
             let (content_end, attrs_, tail_start) =
                 match self.extract_and_parse_heading_attribute_block(header_start, header_end) {
                     Some(block) => (block.block_open, Some(block.attrs), block.tail_start),

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1501,15 +1501,14 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             // of the parent) instead.
             let header_end = self.tree[cur_ix].item.end;
 
-            // Setext strips the block by truncating the tree, which drops only a
-            // suffix, so a block trailed by directives is left as-is rather than
-            // cut along with it.
-            let (content_end, attrs_) =
+            // Setext strips the block by truncating the tree to the block's
+            // opening `{`. A trailing run of text directives is dropped along
+            // with the block, then reparsed below as its own span so it keeps
+            // its `{...}` attributes (matching the ATX path).
+            let (content_end, attrs_, tail_start) =
                 match self.extract_and_parse_heading_attribute_block(header_start, header_end) {
-                    Some(block) if block.tail_start.is_none() => {
-                        (block.block_open, Some(block.attrs))
-                    }
-                    _ => (header_end, None),
+                    Some(block) => (block.block_open, Some(block.attrs), block.tail_start),
+                    None => (header_end, None, None),
                 };
             attrs = attrs_;
 
@@ -1548,6 +1547,10 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 
             if let Some(cur_ix) = self.tree.cur() {
                 self.tree[cur_ix].item.end = new_end;
+            }
+
+            if let Some(tail_start) = tail_start {
+                self.parse_line(tail_start, Some(header_end), TableParseMode::Disabled);
             }
         }
 

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1501,9 +1501,16 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             // of the parent) instead.
             let header_end = self.tree[cur_ix].item.end;
 
-            // extract the trailing attribute block
+            // Setext strips the block by truncating the tree, which drops only a
+            // suffix, so a block trailed by directives is left as-is rather than
+            // cut along with it.
             let (content_end, attrs_) =
-                self.extract_and_parse_heading_attribute_block(header_start, header_end);
+                match self.extract_and_parse_heading_attribute_block(header_start, header_end) {
+                    Some(block) if block.tail_start.is_none() => {
+                        (block.block_open, Some(block.attrs))
+                    }
+                    _ => (header_end, None),
+                };
             attrs = attrs_;
 
             // strip trailing whitespace
@@ -3115,10 +3122,25 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             // the start of the next line is the end of the header since the
             // header cannot have line breaks
             let header_end = header_start + scan_nextline(&bytes[header_start..]);
-            let (content_end, attrs) =
-                self.extract_and_parse_heading_attribute_block(header_start, header_end);
-            self.parse_line(ix, Some(content_end), TableParseMode::Disabled);
-            (header_end, content_end, attrs)
+            match self.extract_and_parse_heading_attribute_block(header_start, header_end) {
+                Some(block) => {
+                    self.parse_line(ix, Some(block.block_open), TableParseMode::Disabled);
+                    // Parse the trailing directive run as a second span so the
+                    // directive keeps its own `{...}` attributes.
+                    let content_end = match block.tail_start {
+                        Some(tail_start) => {
+                            self.parse_line(tail_start, Some(header_end), TableParseMode::Disabled);
+                            header_end
+                        }
+                        None => block.block_open,
+                    };
+                    (header_end, content_end, Some(block.attrs))
+                }
+                None => {
+                    self.parse_line(ix, Some(header_end), TableParseMode::Disabled);
+                    (header_end, header_end, None)
+                }
+            }
         } else {
             // ATX headings can't span lines. In MDX mode bound the inline
             // scan to the current line so an unclosed expression body like
@@ -3600,38 +3622,82 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         alignment.len() == header_count
     }
 
-    /// Extracts and parses a heading attribute block if exists.
-    ///
-    /// Returns `(end_offset_of_heading_content, (id, classes))`.
-    ///
-    /// If `header_end` is less than or equal to `header_start`, the given
-    /// input is considered as empty.
+    /// Extracts and parses a heading's trailing attribute block, with its span.
     fn extract_and_parse_heading_attribute_block(
-        &mut self,
+        &self,
         header_start: usize,
         header_end: usize,
-    ) -> (usize, Option<HeadingAttributes<'a>>) {
+    ) -> Option<HeadingAttrBlock<'a>> {
         if !self.options.contains(Options::ENABLE_HEADING_ATTRIBUTES)
             || self.options.contains(Options::ENABLE_MDX)
         {
-            return (header_end, None);
+            return None;
         }
 
-        // extract the trailing attribute block
-        let header_bytes = &self.text.as_bytes()[header_start..header_end];
-        let (content_len, attr_block_range_rel) =
-            extract_attribute_block_content_from_header_text(header_bytes);
-        let attrs = attr_block_range_rel.and_then(|r| {
-            parse_inside_attribute_block(
-                &self.text[(header_start + r.start)..(header_start + r.end)],
-            )
-        });
-        let content_end = if attrs.is_some() {
-            header_start + content_len
+        let bytes = self.text.as_bytes();
+        let search_end = if self.options.contains(Options::ENABLE_DIRECTIVE) {
+            self.heading_attr_block_search_end(header_start, header_end)
         } else {
             header_end
         };
-        (content_end, attrs)
+
+        let header_bytes = &bytes[header_start..search_end];
+        let (content_len, attr_block_range_rel) =
+            extract_attribute_block_content_from_header_text(header_bytes);
+        let range = attr_block_range_rel?;
+        let attrs = parse_inside_attribute_block(
+            &self.text[(header_start + range.start)..(header_start + range.end)],
+        )?;
+
+        let block_open = header_start + content_len;
+        let block_close = header_start + range.end + 1;
+        let tail_has_content = bytes[block_close..header_end]
+            .iter()
+            .any(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'));
+        Some(HeadingAttrBlock {
+            attrs,
+            block_open,
+            tail_start: if tail_has_content {
+                Some(block_close)
+            } else {
+                None
+            },
+        })
+    }
+
+    /// The offset up to which a heading's trailing attribute block is searched.
+    /// A trailing run of text directives (each `:name[label]{attrs}`, separated
+    /// only by whitespace) is heading content and owns any `{...}` it contains,
+    /// so the search stops before that run.
+    fn heading_attr_block_search_end(&self, header_start: usize, header_end: usize) -> usize {
+        let bytes = self.text.as_bytes();
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+        let mut i = header_start;
+        while i < header_end {
+            if bytes[i] == b':' {
+                if let Some(end) = scan_heading_text_directive(self.text, bytes, i, header_end) {
+                    spans.push((i, end));
+                    i = end;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+
+        let mut pos = header_end;
+        pos -= scan_rev_while(&bytes[header_start..pos], |b| {
+            matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+        });
+        for &(start, end) in spans.iter().rev() {
+            if end != pos {
+                break;
+            }
+            pos = start;
+            pos -= scan_rev_while(&bytes[header_start..pos], |b| {
+                matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+            });
+        }
+        pos
     }
 }
 
@@ -5267,6 +5333,39 @@ fn is_directive_name_start_ascii(c: u8) -> bool {
 
 fn is_directive_name_char_ascii(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'-' || c == b'_'
+}
+
+/// A heading's trailing attribute block, with where it sits in the line.
+struct HeadingAttrBlock<'a> {
+    attrs: HeadingAttributes<'a>,
+    /// Absolute offset of the opening `{`.
+    block_open: usize,
+    /// Absolute offset just past the closing `}`, set only when a trailing run
+    /// of text directives follows the block and must be parsed as content.
+    tail_start: Option<usize>,
+}
+
+/// Extent of a text directive starting at `colon` (`bytes[colon] == b':'`), or
+/// `None`. Mirrors the inline text-directive scanner's guards so a heading's
+/// trailing directive run is recognized the same way it will later be parsed.
+fn scan_heading_text_directive(
+    text: &str,
+    bytes: &[u8],
+    colon: usize,
+    limit: usize,
+) -> Option<usize> {
+    if colon > 0 && bytes[colon - 1] == b':' {
+        return None;
+    }
+    let (dir, end_pos) = parse_directive_after_colons(text, bytes, colon + 1)?;
+    if end_pos > limit {
+        return None;
+    }
+    // `:name:` (bare name closed by a colon) is an emoji, not a directive.
+    if end_pos < limit && bytes[end_pos] == b':' && colon + 1 + dir.name.len() == end_pos {
+        return None;
+    }
+    Some(end_pos)
 }
 
 /// True when the char at `ix` is a valid directive-name character.

--- a/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
+++ b/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
@@ -1,0 +1,112 @@
+//! Heading attributes interacting with text directives (issues #134, #135).
+//! Both features share `{...}` syntax: a heading's trailing attribute block
+//! must not swallow a directive's own attributes, and must still be found when
+//! a directive trails it.
+
+use satteri_arena::{Arena, Mdast, StringRef};
+use satteri_ast::mdast::codec::{decode_directive_attr, decode_directive_attr_count};
+use satteri_ast::mdast::MdastNodeType;
+use satteri_pulldown_cmark::arena_build::{parse, DEFAULT_OPTIONS};
+use satteri_pulldown_cmark::Options;
+
+fn options() -> Options {
+    DEFAULT_OPTIONS | Options::ENABLE_DIRECTIVE | Options::ENABLE_HEADING_ATTRIBUTES
+}
+
+fn heading(arena: &Arena<Mdast>) -> u32 {
+    let roots = arena.get_children(0);
+    assert_eq!(roots.len(), 1, "expected a single heading");
+    let h = roots[0];
+    assert_eq!(
+        arena.get_node(h).node_type,
+        MdastNodeType::Heading as u8,
+        "root child should be a heading"
+    );
+    h
+}
+
+fn heading_data(arena: &Arena<Mdast>, heading: u32) -> String {
+    arena
+        .get_node_data(heading)
+        .map(|d| String::from_utf8_lossy(d).into_owned())
+        .unwrap_or_default()
+}
+
+fn find_directive(arena: &Arena<Mdast>, parent: u32) -> u32 {
+    arena
+        .get_children(parent)
+        .iter()
+        .copied()
+        .find(|&id| arena.get_node(id).node_type == MdastNodeType::TextDirective as u8)
+        .expect("expected a text directive child")
+}
+
+fn directive_name(arena: &Arena<Mdast>, id: u32) -> String {
+    let data = arena.get_type_data(id);
+    arena.get_str(StringRef::from_bytes(&data[..8])).to_string()
+}
+
+fn directive_attrs(arena: &Arena<Mdast>, id: u32) -> Vec<(String, String)> {
+    let data = arena.get_type_data(id);
+    (0..decode_directive_attr_count(data))
+        .map(|i| {
+            let (k, v) = decode_directive_attr(data, i);
+            (arena.get_str(k).to_string(), arena.get_str(v).to_string())
+        })
+        .collect()
+}
+
+// #134: `{variant=caution}` is the directive's attribute block, not the heading's.
+#[test]
+fn directive_attributes_are_not_stolen_by_heading() {
+    let (arena, _) = parse("## Heading :badge[New]{variant=caution}\n", options());
+    let h = heading(&arena);
+
+    assert!(
+        !heading_data(&arena, h).contains("variant"),
+        "heading must not absorb the directive's attribute block"
+    );
+
+    let dir = find_directive(&arena, h);
+    assert_eq!(directive_name(&arena, dir), "badge");
+    assert_eq!(
+        directive_attrs(&arena, dir),
+        vec![("variant".to_string(), "caution".to_string())]
+    );
+}
+
+// #135: the attribute block is recognized whether it comes before or after a
+// trailing directive.
+#[test]
+fn heading_attribute_is_recognized_around_a_trailing_directive() {
+    let before = "## Heading with a badge {#custom} :badge[Custom]\n";
+    let after = "## Heading with a badge :badge[Custom] {#custom}\n";
+    for input in [before, after] {
+        let (arena, _) = parse(input, options());
+        let h = heading(&arena);
+        assert!(
+            heading_data(&arena, h).contains(r#""id":"custom""#),
+            "expected id=custom for input {input:?}, got {:?}",
+            heading_data(&arena, h)
+        );
+        assert_eq!(directive_name(&arena, find_directive(&arena, h)), "badge");
+    }
+}
+
+// A directive that owns its block AND is preceded by a real heading block:
+// the heading keeps `#custom`, the directive keeps `variant=caution`.
+#[test]
+fn heading_block_and_directive_block_coexist() {
+    let (arena, _) = parse(
+        "## Heading {#custom} :badge[New]{variant=caution}\n",
+        options(),
+    );
+    let h = heading(&arena);
+    assert!(heading_data(&arena, h).contains(r#""id":"custom""#));
+
+    let dir = find_directive(&arena, h);
+    assert_eq!(
+        directive_attrs(&arena, dir),
+        vec![("variant".to_string(), "caution".to_string())]
+    );
+}

--- a/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
+++ b/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
@@ -111,9 +111,8 @@ fn heading_block_and_directive_block_coexist() {
     );
 }
 
-// Setext headings strip the block by truncating the tree, so a block sitting
-// before a trailing directive is the tricky case: the directive must survive
-// the truncation with its own attributes intact.
+// The tricky setext case: a block sitting *before* a trailing directive, which
+// the directive must survive with its own attributes intact.
 #[test]
 fn setext_heading_attribute_is_recognized_around_a_trailing_directive() {
     let before = "Heading with a badge {#custom} :badge[Custom]\n===\n";

--- a/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
+++ b/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
@@ -110,3 +110,40 @@ fn heading_block_and_directive_block_coexist() {
         vec![("variant".to_string(), "caution".to_string())]
     );
 }
+
+// Setext headings strip the block by truncating the tree, so a block sitting
+// before a trailing directive is the tricky case: the directive must survive
+// the truncation with its own attributes intact.
+#[test]
+fn setext_heading_attribute_is_recognized_around_a_trailing_directive() {
+    let before = "Heading with a badge {#custom} :badge[Custom]\n===\n";
+    let after = "Heading with a badge :badge[Custom] {#custom}\n===\n";
+    for input in [before, after] {
+        let (arena, _) = parse(input, options());
+        let h = heading(&arena);
+        assert!(
+            heading_data(&arena, h).contains(r#""id":"custom""#),
+            "expected id=custom for input {input:?}, got {:?}",
+            heading_data(&arena, h)
+        );
+        assert_eq!(directive_name(&arena, find_directive(&arena, h)), "badge");
+    }
+}
+
+// Setext counterpart of `heading_block_and_directive_block_coexist`: the block
+// before the directive must not swallow the directive's own `{variant=...}`.
+#[test]
+fn setext_heading_block_and_directive_block_coexist() {
+    let (arena, _) = parse(
+        "Heading {#custom} :badge[New]{variant=caution}\n===\n",
+        options(),
+    );
+    let h = heading(&arena);
+    assert!(heading_data(&arena, h).contains(r#""id":"custom""#));
+
+    let dir = find_directive(&arena, h);
+    assert_eq!(
+        directive_attrs(&arena, dir),
+        vec![("variant".to_string(), "caution".to_string())]
+    );
+}


### PR DESCRIPTION
Fixes #134
Fixes #135