### PR TITLE
feat(plugins): adds ctx.sourceFormat on plugin contexts

### DIFF
--- a/.sampo/changesets/ctx-source-format.md
+++ b/.sampo/changesets/ctx-source-format.md
@@ -2,7 +2,4 @@
 npm/satteri: patch
 ---
 
-Expose `ctx.sourceFormat` on both mdast and hast plugin contexts. It is
-`"markdown"` when the plugin runs during a Markdown compile (`markdownToHtml`)
-and `"mdx"` during an MDX compile (`mdxToJs`), letting a plugin shared between
-both pipelines branch on which format it is handling.
+Expose `ctx.sourceFormat` on both mdast and hast plugin contexts. It is `"markdown"` when the plugin runs during a Markdown compile (`markdownToHtml`) and `"mdx"` during an MDX compile (`mdxToJs`), letting a plugin shared between both pipelines branch on which format it is handling.

--- a/.sampo/changesets/ctx-source-format.md
+++ b/.sampo/changesets/ctx-source-format.md
@@ -1,0 +1,8 @@
+---
+npm/satteri: patch
+---
+
+Expose `ctx.sourceFormat` on both mdast and hast plugin contexts. It is
+`"markdown"` when the plugin runs during a Markdown compile (`markdownToHtml`)
+and `"mdx"` during an MDX compile (`mdxToJs`), letting a plugin shared between
+both pipelines branch on which format it is handling.

--- a/.sampo/changesets/ctx-source-format.md
+++ b/.sampo/changesets/ctx-source-format.md
@@ -2,4 +2,4 @@
 npm/satteri: patch
 ---
 
-Expose `ctx.sourceFormat` on both mdast and hast plugin contexts. It is `"markdown"` when the plugin runs during a Markdown compile (`markdownToHtml`) and `"mdx"` during an MDX compile (`mdxToJs`), letting a plugin shared between both pipelines branch on which format it is handling.
+Exposes a `ctx.sourceFormat` property on both mdast and hast plugin contexts. It is `"markdown"` when the plugin runs during a Markdown compile (`markdownToHtml`) and `"mdx"` during an MDX compile (`mdxToJs`), letting a plugin shared between both pipelines branch on which format it is handling.

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -30,7 +30,7 @@ import { materializeMdastTree } from "./mdast/mdast-materializer.js";
 import { markHandleMutated } from "./lazy-child-resolver.js";
 import { HastReader } from "./hast/hast-reader.js";
 import { materializeHastTree } from "./hast/hast-materializer.js";
-import type { MdastNode, HastNode, Data } from "./types.js";
+import type { MdastNode, HastNode, Data, SourceFormat } from "./types.js";
 
 type NativeFeaturesPair = {
   features: Record<string, unknown> | undefined;
@@ -125,6 +125,7 @@ function runMdastPluginsOnHandle(
   plugins: MdastPluginInput[],
   fileURL: URL | undefined,
   data: Data,
+  sourceFormat: SourceFormat,
 ): MdastPipelineResult | Promise<MdastPipelineResult> {
   // Each plugin runs once over the tree. A transform that passes a child
   // through (returning it inside the replacement) keeps that child's identity,
@@ -140,6 +141,7 @@ function runMdastPluginsOnHandle(
       () => getHandleSource(handle),
       fileURL,
       data,
+      sourceFormat,
     );
     const apply = (r: { commandBuffer: Uint8Array; hasMutations: boolean }): void => {
       if (!r.hasMutations) return;
@@ -170,6 +172,7 @@ function runHastPluginsOnHandle(
   source: string,
   fileURL: URL | undefined,
   data: Data,
+  sourceFormat: SourceFormat,
 ): void | Promise<void> {
   if (plugins.length === 0) return;
 
@@ -181,7 +184,7 @@ function runHastPluginsOnHandle(
       const plugin: HastPluginDefinition = typeof raw === "function" ? raw() : raw;
 
       const subs = resolveSubscriptions(plugin);
-      const result = visitHastHandle(handle, plugin, subs, source, fileURL, data);
+      const result = visitHastHandle(handle, plugin, subs, source, fileURL, data, sourceFormat);
       const warnIfDropped = (dropped: number): void => {
         if (dropped) warnDroppedTransforms(plugin, dropped, "hast");
       };
@@ -557,7 +560,14 @@ export function markdownToHtml(
   ): MarkdownToHtmlResult | Promise<MarkdownToHtmlResult> => {
     let hastResult: void | Promise<void>;
     try {
-      hastResult = runHastPluginsOnHandle(r.hastHandle, hastPlugins, source, fileURL, data);
+      hastResult = runHastPluginsOnHandle(
+        r.hastHandle,
+        hastPlugins,
+        source,
+        fileURL,
+        data,
+        "markdown",
+      );
     } catch (err) {
       releaseHandle(r.hastHandle, hastMayHaveStubs);
       throw err;
@@ -621,7 +631,7 @@ export function mdxToJs(
   const runHastThenCompile = (r: HastWithFrontmatter): MdxToJsResult | Promise<MdxToJsResult> => {
     let hastResult: void | Promise<void>;
     try {
-      hastResult = runHastPluginsOnHandle(r.hastHandle, hastPlugins, source, fileURL, data);
+      hastResult = runHastPluginsOnHandle(r.hastHandle, hastPlugins, source, fileURL, data, "mdx");
     } catch (err) {
       releaseHandle(r.hastHandle, hastMayHaveStubs);
       throw err;
@@ -708,6 +718,7 @@ function createHastHandleFromMdast(
   const mdastHandle = mdx
     ? createMdxMdastHandle(source, nativeFeatures)
     : createMdastHandle(source, nativeFeatures);
+  const sourceFormat: SourceFormat = mdx ? "mdx" : "markdown";
 
   const mdastMayHaveStubs = mdastPlugins.length > 0;
 
@@ -730,7 +741,13 @@ function createHastHandleFromMdast(
       return finalize({ handle: mdastHandle });
     }
 
-    const mdastResult = runMdastPluginsOnHandle(mdastHandle, mdastPlugins, fileURL, data);
+    const mdastResult = runMdastPluginsOnHandle(
+      mdastHandle,
+      mdastPlugins,
+      fileURL,
+      data,
+      sourceFormat,
+    );
 
     if (mdastResult instanceof Promise) {
       return mdastResult.then(finalize, (err) => {

--- a/packages/satteri/src/hast/hast-visitor.ts
+++ b/packages/satteri/src/hast/hast-visitor.ts
@@ -1,5 +1,5 @@
 import { materializeHastNode, type HastNode } from "./hast-materializer.js";
-import type { HastRaw, MdxJsxAttributeUnion, Position, Data } from "../types.js";
+import type { HastRaw, MdxJsxAttributeUnion, Position, Data, SourceFormat } from "../types.js";
 import type {
   Element,
   Text,
@@ -114,6 +114,12 @@ export interface HastVisitorContext {
    * instances. Returned to the caller as `result.data`.
    */
   readonly data: Data;
+  /**
+   * The source format this compile is processing: `"markdown"` for a plain
+   * Markdown compile, `"mdx"` for an MDX one. Lets a plugin shared between both
+   * pipelines branch on which it is handling.
+   */
+  readonly sourceFormat: SourceFormat;
   removeNode(node: Readonly<HastNode>): void;
   replaceNode(node: Readonly<HastNode>, newNode: HastContent): void;
   insertBefore(node: Readonly<HastNode>, newNode: HastContent | HastContent[]): void;
@@ -318,6 +324,7 @@ class HastVisitorContextImpl implements HastVisitorContext {
   #parentsById: Map<number, HastNode> | null = null;
   readonly fileURL: URL | undefined;
   readonly data: Data;
+  readonly sourceFormat: SourceFormat;
 
   constructor(
     handle: HastHandle,
@@ -325,12 +332,14 @@ class HastVisitorContextImpl implements HastVisitorContext {
     fileURL: URL | undefined,
     resolver: LazyChildResolver<HastReader, HastNode>,
     data: Data,
+    sourceFormat: SourceFormat,
   ) {
     this.#handle = handle;
     this.#getSource = getSource;
     this.fileURL = fileURL;
     this.#resolver = resolver;
     this.data = data;
+    this.sourceFormat = sourceFormat;
   }
 
   get source(): string {
@@ -1049,10 +1058,11 @@ export function visitHastHandle(
   source: string | (() => string),
   fileURL: URL | undefined,
   data: Data = {},
+  sourceFormat: SourceFormat = "markdown",
 ): number | Promise<number> {
   const getSource = typeof source === "function" ? source : () => source;
   const resolver = new HastLazyChildResolver(handle);
-  const ctx = new HastVisitorContextImpl(handle, getSource, fileURL, resolver, data);
+  const ctx = new HastVisitorContextImpl(handle, getSource, fileURL, resolver, data, sourceFormat);
   const returnBuffer = new CommandBuffer();
   const rustSubs = subs.map((s) => ({ nodeType: s.nodeType, tagFilter: s.tagFilter }));
   const deferred = dispatchMatches(walkHandle(handle, rustSubs), subs, ctx, returnBuffer, resolver);

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -45,6 +45,7 @@ export type {
   HastNode,
   DataMap,
   Data,
+  SourceFormat,
   Position,
   Point,
   MdxJsxAttributeNode,

--- a/packages/satteri/src/mdast/mdast-visitor.ts
+++ b/packages/satteri/src/mdast/mdast-visitor.ts
@@ -38,6 +38,7 @@ import type {
   Superscript,
   Subscript,
   Data,
+  SourceFormat,
 } from "../types.js";
 import { walkMdastHandle, mdastTextContentHandle } from "#binding";
 import {
@@ -136,6 +137,12 @@ export class MdastVisitorContext {
    * instances. Returned to the caller as `result.data`.
    */
   readonly data: Data;
+  /**
+   * The source format this compile is processing: `"markdown"` for a plain
+   * Markdown compile, `"mdx"` for an MDX one. Lets a plugin shared between both
+   * pipelines branch on which it is handling.
+   */
+  readonly sourceFormat: SourceFormat;
 
   constructor(
     handle: MdastHandle,
@@ -143,12 +150,14 @@ export class MdastVisitorContext {
     fileURL: URL | undefined,
     resolver: LazyChildResolver<MdastReader, MdastNode>,
     data: Data,
+    sourceFormat: SourceFormat,
   ) {
     this.#handle = handle;
     this.#getSource = getSource;
     this.fileURL = fileURL;
     this.#resolver = resolver;
     this.data = data;
+    this.sourceFormat = sourceFormat;
   }
 
   get source(): string {
@@ -773,10 +782,11 @@ export function visitMdastHandle(
   source: string | (() => string),
   fileURL: URL | undefined,
   data: Data = {},
+  sourceFormat: SourceFormat = "markdown",
 ): MdastVisitResult | Promise<MdastVisitResult> {
   const getSource = typeof source === "function" ? source : () => source;
   const resolver = new MdastLazyChildResolver(handle);
-  const context = new MdastVisitorContext(handle, getSource, fileURL, resolver, data);
+  const context = new MdastVisitorContext(handle, getSource, fileURL, resolver, data, sourceFormat);
   const returnBuffer = new CommandBuffer();
   const rustSubs = subs.map((s) => ({ nodeType: s.nodeType, tagFilter: [] as string[] }));
   const matchBuf: Uint8Array = walkMdastHandle(handle, rustSubs);

--- a/packages/satteri/src/types.ts
+++ b/packages/satteri/src/types.ts
@@ -137,6 +137,13 @@ export interface DataMap {}
  */
 export type Data = Record<string, unknown> & Partial<DataMap>;
 
+/**
+ * The source format a plugin is running against, surfaced as `ctx.sourceFormat`:
+ * `"markdown"` for a plain Markdown compile, `"mdx"` for an MDX one. Lets a
+ * plugin shared between both pipelines branch on which it is handling.
+ */
+export type SourceFormat = "markdown" | "mdx";
+
 /** @internal Node with arena tracking ID, only used inside the library. */
 export type MdastNodeInternal = MdastStdNodes & { _nodeId: number };
 /** @internal */

--- a/packages/satteri/test/ctx-source-format.test.ts
+++ b/packages/satteri/test/ctx-source-format.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { markdownToHtml, mdxToJs } from "../src/compile.js";
+import { defineMdastPlugin, defineHastPlugin } from "../src/plugin.js";
+import type { SourceFormat } from "../src/types.js";
+
+describe("ctx.sourceFormat", () => {
+  it('is "markdown" for an mdast plugin under markdownToHtml', () => {
+    let seen: SourceFormat | undefined;
+    const inspect = defineMdastPlugin({
+      name: "inspect",
+      paragraph(_node, ctx) {
+        seen = ctx.sourceFormat;
+      },
+    });
+
+    markdownToHtml("hi", { mdastPlugins: [inspect] });
+    expect(seen).toBe("markdown");
+  });
+
+  it('is "markdown" for a hast plugin under markdownToHtml', () => {
+    let seen: SourceFormat | undefined;
+    const inspect = defineHastPlugin({
+      name: "inspect",
+      element: {
+        filter: ["p"],
+        visit(_node, ctx) {
+          seen = ctx.sourceFormat;
+        },
+      },
+    });
+
+    markdownToHtml("hi", { hastPlugins: [inspect] });
+    expect(seen).toBe("markdown");
+  });
+
+  it('is "mdx" for an mdast plugin under mdxToJs', () => {
+    let seen: SourceFormat | undefined;
+    const inspect = defineMdastPlugin({
+      name: "inspect",
+      paragraph(_node, ctx) {
+        seen = ctx.sourceFormat;
+      },
+    });
+
+    mdxToJs("hi", { mdastPlugins: [inspect] });
+    expect(seen).toBe("mdx");
+  });
+
+  it('is "mdx" for a hast plugin under mdxToJs', () => {
+    let seen: SourceFormat | undefined;
+    const inspect = defineHastPlugin({
+      name: "inspect",
+      element: {
+        filter: ["p"],
+        visit(_node, ctx) {
+          seen = ctx.sourceFormat;
+        },
+      },
+    });
+
+    mdxToJs("hi", { hastPlugins: [inspect] });
+    expect(seen).toBe("mdx");
+  });
+});

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -227,6 +227,7 @@ heading(node, ctx) {
 | `source` | `string` | Original markdown source. |
 | `fileURL` | `URL \| undefined` | URL of the document being processed, or `undefined` when none given. |
 | `data` | `Data` | Document-scoped data bag shared across every plugin in the pipeline. Survives the mdast→hast boundary. Returned to the caller as `result.data`. Kept on the JS side, so any value is allowed (functions, class instances, etc.). |
+| `sourceFormat` | `"markdown" \| "mdx"` | Which kind of file the plugin is currently running on. |
 
 Keys on `data` are typed as `unknown` by default. Register a key's type by augmenting `DataMap`:
 


### PR DESCRIPTION
This adds a way for plugins to know if they're running on a Markdown or MDX file, as they sometimes need to append different nodes based on that.