### PR TITLE
feat(playground): share button

### DIFF
--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -60,6 +60,8 @@ const outputTabButton = $<HTMLButtonElement>('[data-tab="output"]');
 const renderedTabButton = $<HTMLButtonElement>('[data-tab="rendered"]');
 const alertBar = $<HTMLElement>("#alert-bar");
 const alertBarMessage = $<HTMLElement>("#alert-bar-message");
+const alertBarRunScripts = $<HTMLButtonElement>("#alert-bar-run-scripts");
+const alertBarResetScripts = $<HTMLButtonElement>("#alert-bar-reset-scripts");
 const alertBarDismiss = $<HTMLButtonElement>("#alert-bar-dismiss");
 const statusBar = $<HTMLElement>("#status-bar");
 const shareButton = $<HTMLButtonElement>("#pg-share");
@@ -397,7 +399,21 @@ async function loadSharedState(): Promise<PlaygroundState | null> {
   }
 }
 
-async function applySharedStateFromHash(): Promise<boolean> {
+const defaultMdastPluginSource = inputMdastPlugin.value;
+const defaultHastPluginSource = inputHastPlugin.value;
+let hasPendingScripts = false;
+
+function sharedStateHasUnsafePlugins(state: PlaygroundState): boolean {
+  const mdastPlugin = state.mdastPlugin ?? "";
+  const hastPlugin = state.hastPlugin ?? "";
+
+  return (
+    (mdastPlugin.trim() !== "" && mdastPlugin !== defaultMdastPluginSource) ||
+    (hastPlugin.trim() !== "" && hastPlugin !== defaultHastPluginSource)
+  );
+}
+
+async function applySharedState(): Promise<boolean> {
   if (!location.hash.startsWith(SHARE_HASH_PREFIX)) return false;
 
   const shared = await loadSharedState();
@@ -408,12 +424,38 @@ async function applySharedStateFromHash(): Promise<boolean> {
 
   if (!shared) return false;
 
+  hasPendingScripts = sharedStateHasUnsafePlugins(shared);
+  if (hasPendingScripts) compileGeneration++;
+
   applyState(shared);
-  hideAlert();
   highlightAllInputs();
-  compile();
+
+  if (hasPendingScripts) {
+    showUnsafePluginAlert();
+  } else {
+    dismissAlert();
+    compile();
+  }
 
   return true;
+}
+
+function runPendingPlugins() {
+  hasPendingScripts = false;
+  dismissAlert();
+  compile();
+}
+
+function resetPendingPlugins() {
+  hasPendingScripts = false;
+  dismissAlert();
+
+  inputMdastPlugin.value = defaultMdastPluginSource;
+  inputHastPlugin.value = defaultHastPluginSource;
+  highlightInput(inputMdastPlugin, highlightMdastPlugin, "typescript");
+  highlightInput(inputHastPlugin, highlightHastPlugin, "typescript");
+
+  compile();
 }
 
 // TODO(HiDeoo) still needed
@@ -429,7 +471,7 @@ function flashShareLabel(label: string) {
 }
 
 async function shareCurrentState() {
-  hideAlert();
+  if (!hasPendingScripts) dismissAlert();
   let url: string;
   try {
     url = await buildShareUrl();
@@ -449,21 +491,41 @@ async function shareCurrentState() {
 }
 
 shareButton.addEventListener("click", () => void shareCurrentState());
-alertBarDismiss.addEventListener("click", hideAlert);
+alertBarRunScripts.addEventListener("click", runPendingPlugins);
+alertBarResetScripts.addEventListener("click", resetPendingPlugins);
+alertBarDismiss.addEventListener("click", dismissAlert);
 
 function showAlert(message: string, opts?: { html?: boolean; dismissible?: boolean }) {
+  if (hasPendingScripts) return;
+
   if (opts?.html) {
     alertBarMessage.innerHTML = message;
   } else {
     alertBarMessage.textContent = message;
   }
+  alertBarRunScripts.hidden = true;
+  alertBarResetScripts.hidden = true;
   alertBarDismiss.hidden = opts?.dismissible !== true;
   alertBar.hidden = false;
 }
 
-function hideAlert() {
+function showUnsafePluginAlert() {
+  statusBar.innerHTML = `<span class="error">Review plugin scripts before running the playground.</span>`;
+
+  alertBarMessage.textContent =
+    "The shared playground link includes plugin scripts. Please review them before running the playground.";
+
+  alertBarDismiss.hidden = true;
+  alertBarRunScripts.hidden = false;
+  alertBarResetScripts.hidden = false;
+  alertBar.hidden = false;
+}
+
+function dismissAlert() {
   alertBar.hidden = true;
   alertBarMessage.textContent = "";
+  alertBarRunScripts.hidden = true;
+  alertBarResetScripts.hidden = true;
   alertBarDismiss.hidden = true;
 }
 
@@ -551,6 +613,11 @@ async function getHastPlugins(): Promise<HastPluginDefinition[]> {
 }
 
 async function compile() {
+  if (hasPendingScripts) {
+    compileGeneration++;
+    return;
+  }
+
   const gen = ++compileGeneration;
   const source = input.value;
   const isMdx = currentMode === "mdx";
@@ -565,6 +632,9 @@ async function compile() {
     statusBar.innerHTML = `<span class="error">mdast plugin: ${escapeHtml(String(e))}</span>`;
     return;
   }
+
+  if (gen !== compileGeneration || hasPendingScripts) return;
+
   try {
     hastPlugins = await getHastPlugins();
   } catch (e) {
@@ -572,7 +642,7 @@ async function compile() {
     return;
   }
 
-  if (gen !== compileGeneration) return;
+  if (gen !== compileGeneration || hasPendingScripts) return;
 
   const activeMdastCount = mdastPlugins.filter(
     (p) => resolveMdastSubscriptions(p).length > 0,
@@ -905,10 +975,10 @@ pgSidebarToggle?.addEventListener("click", () => {
 loadingOverlay.classList.add("hidden");
 
 window.addEventListener("hashchange", () => {
-  void applySharedStateFromHash();
+  void applySharedState();
 });
 
-void applySharedStateFromHash().then((applied) => {
+void applySharedState().then((applied) => {
   if (!applied) {
     highlightAllInputs();
     compile();

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -58,6 +58,7 @@ const osWrapPropValue = $<HTMLInputElement>("#os-wrap-prop-value");
 const osIgnoreElements = $<HTMLInputElement>("#os-ignore-elements");
 const outputTabButton = $<HTMLButtonElement>('[data-tab="output"]');
 const renderedTabButton = $<HTMLButtonElement>('[data-tab="rendered"]');
+const alertBar = $<HTMLElement>("#alert-bar");
 const statusBar = $<HTMLElement>("#status-bar");
 const shareButton = $<HTMLButtonElement>("#pg-share");
 const mdastPluginTab = $<HTMLButtonElement>('[data-input-tab="mdast-plugin"]');
@@ -390,6 +391,25 @@ async function loadSharedState(): Promise<PlaygroundState | null> {
   }
 }
 
+async function applySharedStateFromHash(): Promise<boolean> {
+  const shared = await loadSharedState();
+  if (!shared) return false;
+
+  applyState(shared);
+
+  const url = new URL(location.href);
+  url.hash = "";
+  history.replaceState(null, "", url);
+
+  hideAlert();
+  highlightAllInputs();
+  compile();
+
+  return true;
+}
+
+// TODO(HiDeoo) still needed
+// TODO(HiDeoo) better flash
 let shareResetTimer: ReturnType<typeof setTimeout> | null = null;
 function flashShareLabel(label: string) {
   shareButton.textContent = label;
@@ -401,24 +421,40 @@ function flashShareLabel(label: string) {
 }
 
 async function shareCurrentState() {
+  hideAlert();
   let url: string;
   try {
     url = await buildShareUrl();
   } catch {
-    flashShareLabel("Error");
+    showAlert("Could not create a share link with the current playground state.");
     return;
   }
-  // Reflect the state in the address bar so a plain refresh keeps it too.
-  history.replaceState(null, "", url);
   try {
     await navigator.clipboard.writeText(url);
     flashShareLabel("Copied!");
   } catch {
-    flashShareLabel("URL updated");
+    showAlert(
+      `Could not copy the <a href="${escapeHtml(url)}" rel="noopener noreferrer">share link</a> to the clipboard. You can still copy it manually.`,
+      { html: true },
+    );
   }
 }
 
 shareButton.addEventListener("click", () => void shareCurrentState());
+
+function showAlert(message: string, opts?: { html?: boolean }) {
+  if (opts?.html) {
+    alertBar.innerHTML = message;
+  } else {
+    alertBar.textContent = message;
+  }
+  alertBar.classList.remove("hidden");
+}
+
+function hideAlert() {
+  alertBar.textContent = "";
+  alertBar.classList.add("hidden");
+}
 
 function updateModeUI() {
   currentMode = getMode();
@@ -660,7 +696,12 @@ function updatePluginBadges(mdastCount: number, hastCount: number) {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function scheduleCompile() {
@@ -852,8 +893,13 @@ pgSidebarToggle?.addEventListener("click", () => {
 // Reaching this line means the import chain resolved; hide the overlay.
 loadingOverlay.classList.add("hidden");
 
-void loadSharedState().then((shared) => {
-  if (shared) applyState(shared);
-  highlightAllInputs();
-  compile();
+window.addEventListener("hashchange", () => {
+  void applySharedStateFromHash();
+});
+
+void applySharedStateFromHash().then((applied) => {
+  if (!applied) {
+    highlightAllInputs();
+    compile();
+  }
 });

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -551,7 +551,7 @@ async function compile() {
           plugin,
           subs,
           handleSource,
-          "<playground>",
+          undefined,
         );
         if (gen !== compileGeneration) return;
         if (result.hasMutations) {
@@ -583,7 +583,7 @@ async function compile() {
       const pluginStart = performance.now();
       for (const plugin of hastPlugins) {
         const subs = resolveHastSubscriptions(plugin);
-        await visitHastHandle(hastHandle, plugin, subs, source, "<playground>");
+        await visitHastHandle(hastHandle, plugin, subs, source, undefined);
         if (gen !== compileGeneration) return;
       }
       timings.push(`hast plugins <span>${fmt(performance.now() - pluginStart)}</span>`);

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -29,6 +29,9 @@ import langHtml from "shiki/langs/html.mjs";
 import langJavascript from "shiki/langs/javascript.mjs";
 import themeVitesseLight from "shiki/themes/vitesse-light.mjs";
 import themeVitesseDark from "shiki/themes/vitesse-dark.mjs";
+import satteriPkg from "../../packages/satteri/package.json" with { type: "json" };
+
+const SATTERI_VERSION = satteriPkg.version;
 
 type Mode = "markdown" | "mdx";
 type Tab = "mdast" | "hast" | "output" | "rendered";
@@ -257,6 +260,7 @@ interface OptimizeStaticState {
 }
 
 interface PlaygroundState {
+  version: string;
   mode?: Mode;
   source?: string;
   mdastPlugin?: string;
@@ -268,6 +272,7 @@ interface PlaygroundState {
 
 function getState(): PlaygroundState {
   return {
+    version: SATTERI_VERSION,
     mode: getMode(),
     source: input.value,
     mdastPlugin: inputMdastPlugin.value,
@@ -402,6 +407,7 @@ async function loadSharedState(): Promise<PlaygroundState | null> {
 const defaultMdastPluginSource = inputMdastPlugin.value;
 const defaultHastPluginSource = inputHastPlugin.value;
 let hasPendingScripts = false;
+let pendingVersionWarning: string | undefined;
 
 function sharedStateHasUnsafePlugins(state: PlaygroundState): boolean {
   const mdastPlugin = state.mdastPlugin ?? "";
@@ -424,6 +430,8 @@ async function applySharedState(): Promise<boolean> {
 
   if (!shared) return false;
 
+  pendingVersionWarning = shared.version !== SATTERI_VERSION ? shared.version : undefined;
+
   hasPendingScripts = sharedStateHasUnsafePlugins(shared);
   if (hasPendingScripts) compileGeneration++;
 
@@ -433,7 +441,7 @@ async function applySharedState(): Promise<boolean> {
   if (hasPendingScripts) {
     showUnsafePluginAlert();
   } else {
-    dismissAlert();
+    showVersionWarning();
     compile();
   }
 
@@ -442,7 +450,7 @@ async function applySharedState(): Promise<boolean> {
 
 function runPendingPlugins() {
   hasPendingScripts = false;
-  dismissAlert();
+  showVersionWarning();
   compile();
 }
 
@@ -455,6 +463,7 @@ function resetPendingPlugins() {
   highlightInput(inputMdastPlugin, highlightMdastPlugin, "typescript");
   highlightInput(inputHastPlugin, highlightHastPlugin, "typescript");
 
+  showVersionWarning();
   compile();
 }
 
@@ -519,6 +528,21 @@ function showUnsafePluginAlert() {
   alertBarRunScripts.hidden = false;
   alertBarResetScripts.hidden = false;
   alertBar.hidden = false;
+}
+
+function showVersionWarning() {
+  if (!pendingVersionWarning) {
+    dismissAlert();
+    return;
+  }
+
+  showAlert(
+    `This shared playground link was created with Sätteri ${pendingVersionWarning}, but this playground uses
+ Sätteri ${SATTERI_VERSION}. Some options and behavior may differ.`,
+    { dismissible: true },
+  );
+
+  pendingVersionWarning = undefined;
 }
 
 function dismissAlert() {

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -362,11 +362,41 @@ async function compress(text: string): Promise<Uint8Array> {
 
 async function decompress(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
   const stream = new DecompressionStream("deflate-raw");
-  const read = new Response(stream.readable).arrayBuffer();
+  const reader = stream.readable.getReader();
   const writer = stream.writable.getWriter();
-  await writer.write(bytes);
-  await writer.close();
-  return new TextDecoder().decode(await read);
+  const decoder = new TextDecoder();
+
+  let result = "";
+  let size = 0;
+
+  const read = async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      size += value.byteLength;
+      if (size > MAX_SHARE_STATE_BYTES) {
+        await reader.cancel();
+        throw new ShareStateTooLargeError();
+      }
+
+      result += decoder.decode(value, { stream: true });
+    }
+
+    result += decoder.decode();
+  };
+
+  const write = async () => {
+    await writer.write(bytes);
+    await writer.close();
+  };
+
+  const [readResult, writeResult] = await Promise.allSettled([read(), write()]);
+
+  if (readResult.status === "rejected") throw readResult.reason;
+  if (writeResult.status === "rejected") throw writeResult.reason;
+
+  return result;
 }
 
 function bytesToBase64Url(bytes: Uint8Array): string {
@@ -384,20 +414,35 @@ function base64UrlToBytes(value: string): Uint8Array<ArrayBuffer> {
 }
 
 const SHARE_HASH_PREFIX = "#s=";
+// Keep share links far below browser URL length limits but still in a reasonable range.
+// https://source.chromium.org/chromium/chromium/src/+/main:url/mojom/url.mojom;l=14?q=url%2Fmojom%2Furl.mojom&ss=chromium%2Fchromium%2Fsrc
+const MAX_SHARE_URL_LENGTH = 64 * 1024;
+// Limit decompressed state size to a 4:1 ratio of the URL length limit.
+const MAX_SHARE_STATE_BYTES = 256 * 1024;
+
+class ShareUrlTooLongError extends Error {}
+class ShareStateTooLargeError extends Error {}
 
 async function buildShareUrl(): Promise<string> {
   const payload = bytesToBase64Url(await compress(JSON.stringify(getState())));
-  return `${location.origin}${location.pathname}${SHARE_HASH_PREFIX}${payload}`;
+  const url = `${location.origin}${location.pathname}${SHARE_HASH_PREFIX}${payload}`;
+  if (url.length > MAX_SHARE_URL_LENGTH) throw new ShareUrlTooLongError();
+  return url;
 }
 
 async function loadSharedState(): Promise<PlaygroundState | null> {
   if (!location.hash.startsWith(SHARE_HASH_PREFIX)) return null;
   try {
+    if (location.href.length > MAX_SHARE_URL_LENGTH) throw new ShareStateTooLargeError();
     const json = await decompress(base64UrlToBytes(location.hash.slice(SHARE_HASH_PREFIX.length)));
     return JSON.parse(json) as PlaygroundState;
-  } catch {
+  } catch (error) {
     showAlert(
-      "Could not restore the shared playground state. Using the default playground instead.",
+      `${
+        error instanceof ShareStateTooLargeError
+          ? "This shared playground link is too large to restore."
+          : "Could not restore the shared playground state."
+      } Using the default playground instead.`,
       { dismissible: true },
     );
     return null;
@@ -484,8 +529,12 @@ async function shareCurrentState() {
   let url: string;
   try {
     url = await buildShareUrl();
-  } catch {
-    showAlert("Could not create a share link with the current playground state.");
+  } catch (error) {
+    showAlert(
+      error instanceof ShareUrlTooLongError
+        ? "This playground state is too large to share as a link."
+        : "Could not create a share link with the current playground state.",
+    );
     return;
   }
   try {

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -68,6 +68,7 @@ const alertBarResetScripts = $<HTMLButtonElement>("#alert-bar-reset-scripts");
 const alertBarDismiss = $<HTMLButtonElement>("#alert-bar-dismiss");
 const statusBar = $<HTMLElement>("#status-bar");
 const shareButton = $<HTMLButtonElement>("#pg-share");
+const shareButtonStatus = $<HTMLElement>("#pg-share-status");
 const mdastPluginTab = $<HTMLButtonElement>('[data-input-tab="mdast-plugin"]');
 const hastPluginTab = $<HTMLButtonElement>('[data-input-tab="hast-plugin"]');
 const mdxOptionsFieldset = $<HTMLElement>("#mdx-options-fieldset");
@@ -524,6 +525,13 @@ function flashShareLabel(label: string) {
   }, 1500);
 }
 
+function announceShareStatus(message: string) {
+  shareButtonStatus.textContent = "";
+  requestAnimationFrame(() => {
+    shareButtonStatus.textContent = message;
+  });
+}
+
 async function shareCurrentState() {
   if (!hasPendingScripts) dismissAlert();
   let url: string;
@@ -540,6 +548,7 @@ async function shareCurrentState() {
   try {
     await navigator.clipboard.writeText(url);
     flashShareLabel("Copied!");
+    announceShareStatus("Share link copied to clipboard.");
   } catch {
     showAlert(
       `Could not copy the <a href="${escapeHtml(url)}" rel="noopener noreferrer">share link</a> to the clipboard. You can still copy it manually.`,

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -59,6 +59,8 @@ const osIgnoreElements = $<HTMLInputElement>("#os-ignore-elements");
 const outputTabButton = $<HTMLButtonElement>('[data-tab="output"]');
 const renderedTabButton = $<HTMLButtonElement>('[data-tab="rendered"]');
 const alertBar = $<HTMLElement>("#alert-bar");
+const alertBarMessage = $<HTMLElement>("#alert-bar-message");
+const alertBarDismiss = $<HTMLButtonElement>("#alert-bar-dismiss");
 const statusBar = $<HTMLElement>("#status-bar");
 const shareButton = $<HTMLButtonElement>("#pg-share");
 const mdastPluginTab = $<HTMLButtonElement>('[data-input-tab="mdast-plugin"]');
@@ -387,20 +389,26 @@ async function loadSharedState(): Promise<PlaygroundState | null> {
     const json = await decompress(base64UrlToBytes(location.hash.slice(SHARE_HASH_PREFIX.length)));
     return JSON.parse(json) as PlaygroundState;
   } catch {
+    showAlert(
+      "Could not restore the shared playground state. Using the default playground instead.",
+      { dismissible: true },
+    );
     return null;
   }
 }
 
 async function applySharedStateFromHash(): Promise<boolean> {
-  const shared = await loadSharedState();
-  if (!shared) return false;
+  if (!location.hash.startsWith(SHARE_HASH_PREFIX)) return false;
 
-  applyState(shared);
+  const shared = await loadSharedState();
 
   const url = new URL(location.href);
   url.hash = "";
   history.replaceState(null, "", url);
 
+  if (!shared) return false;
+
+  applyState(shared);
   hideAlert();
   highlightAllInputs();
   compile();
@@ -441,19 +449,22 @@ async function shareCurrentState() {
 }
 
 shareButton.addEventListener("click", () => void shareCurrentState());
+alertBarDismiss.addEventListener("click", hideAlert);
 
-function showAlert(message: string, opts?: { html?: boolean }) {
+function showAlert(message: string, opts?: { html?: boolean; dismissible?: boolean }) {
   if (opts?.html) {
-    alertBar.innerHTML = message;
+    alertBarMessage.innerHTML = message;
   } else {
-    alertBar.textContent = message;
+    alertBarMessage.textContent = message;
   }
-  alertBar.classList.remove("hidden");
+  alertBarDismiss.hidden = opts?.dismissible !== true;
+  alertBar.hidden = false;
 }
 
 function hideAlert() {
-  alertBar.textContent = "";
-  alertBar.classList.add("hidden");
+  alertBar.hidden = true;
+  alertBarMessage.textContent = "";
+  alertBarDismiss.hidden = true;
 }
 
 function updateModeUI() {

--- a/website/assets/playground.ts
+++ b/website/assets/playground.ts
@@ -513,14 +513,14 @@ function resetPendingPlugins() {
   compile();
 }
 
-// TODO(HiDeoo) still needed
-// TODO(HiDeoo) better flash
 let shareResetTimer: ReturnType<typeof setTimeout> | null = null;
 function flashShareLabel(label: string) {
   shareButton.textContent = label;
+  shareButton.classList.add("copied");
   if (shareResetTimer !== null) clearTimeout(shareResetTimer);
   shareResetTimer = setTimeout(() => {
     shareButton.textContent = "Share";
+    shareButton.classList.remove("copied");
     shareResetTimer = null;
   }, 1500);
 }

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -47,6 +47,7 @@
     --color-ink: #14110c;
     --color-error: #b53737;
     --color-error-bg: color-mix(in srgb, var(--color-paper) 96%, var(--color-error));
+    --color-success: #6f8358;
 
     color-scheme: light;
   }
@@ -61,6 +62,7 @@
     --color-ink: #f2ead3;
     --color-error: #e66a6a;
     --color-error-bg: color-mix(in srgb, var(--color-paper) 88%, var(--color-error));
+    --color-success: #8fae91;
 
     color-scheme: dark;
   }
@@ -546,11 +548,21 @@ pre#demo-highlight code {
   letter-spacing: var(--tracking-widest);
   padding-block: calc(var(--spacing) * 2) calc(var(--spacing) * 1.5);
   text-transform: uppercase;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
 }
 
 .pg-input-button:hover {
   background: color-mix(in srgb, var(--color-paper) 65%, var(--color-surface));
   border-color: var(--color-secondary);
+}
+
+.pg-input-button.copied {
+  background: color-mix(in srgb, var(--color-paper) 82%, var(--color-success));
+  border-color: var(--color-success);
+  color: var(--color-success);
 }
 
 /* Output tab panes (mdast / hast / html JSON dump). */

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -461,6 +461,19 @@ pre#demo-highlight code {
   padding: 0;
 }
 
+.pg-input-button {
+  cursor: pointer;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-widest);
+  padding-block: calc(var(--spacing) * 2) calc(var(--spacing) * 1.5);
+  text-transform: uppercase;
+}
+
+.pg-input-button:hover {
+  background: color-mix(in srgb, var(--color-paper) 65%, var(--color-surface));
+  border-color: var(--color-secondary);
+}
+
 /* Output tab panes (mdast / hast / html JSON dump). */
 .tab-pane {
   position: absolute;

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -45,8 +45,8 @@
     --color-secondary: #5c5446;
     --color-body: #2a2620;
     --color-ink: #14110c;
-    --color-error: #b53737;
-    --color-error-bg: color-mix(in srgb, var(--color-paper) 96%, var(--color-error));
+    --color-error: #a83f3f;
+    --color-error-bg: color-mix(in srgb, var(--color-paper) 90%, var(--color-error));
     --color-success: #6f8358;
 
     color-scheme: light;
@@ -60,8 +60,8 @@
     --color-secondary: #b5ab95;
     --color-body: #d8d0be;
     --color-ink: #f2ead3;
-    --color-error: #e66a6a;
-    --color-error-bg: color-mix(in srgb, var(--color-paper) 88%, var(--color-error));
+    --color-error: #d87a72;
+    --color-error-bg: color-mix(in srgb, var(--color-paper) 86%, var(--color-error));
     --color-success: #8fae91;
 
     color-scheme: dark;
@@ -302,7 +302,7 @@ pre#demo-highlight code {
 .pg-alert-bar {
   align-items: start;
   background-color: var(--color-error-bg);
-  border-bottom: 1px solid color-mix(in srgb, var(--color-paper) 65%, var(--color-error));
+  border-bottom: 1px solid color-mix(in srgb, var(--color-paper) 55%, var(--color-error));
   color: var(--color-error);
   display: grid;
   font-family: var(--font-mono);
@@ -312,13 +312,12 @@ pre#demo-highlight code {
   grid-auto-flow: column;
   grid-auto-columns: max-content;
   line-height: 1.5;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 4);
 }
 
 .pg-alert-message {
-  align-items: center;
-  display: flex;
-  min-block-size: 2.5em;
+  align-self: center;
+  line-height: 1.65;
   min-width: 0;
 }
 
@@ -332,15 +331,37 @@ pre#demo-highlight code {
 }
 
 .pg-alert-action {
-  border: 1px solid currentColor;
-  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--color-paper) 94%, var(--color-error));
+  border: 1px solid color-mix(in srgb, var(--color-paper) 72%, var(--color-error));
+  border-radius: 3px;
+  color: color-mix(in srgb, var(--color-error) 58%, var(--color-body));
   font-weight: var(--font-weight-bold);
   padding-inline: calc(var(--spacing) * 4);
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.pg-alert-action:hover {
+  background: color-mix(in srgb, var(--color-paper) 88%, var(--color-error));
+  border-color: color-mix(in srgb, var(--color-paper) 45%, var(--color-error));
+}
+
+.pg-alert-action.primary {
+  background: color-mix(in srgb, var(--color-paper) 78%, var(--color-error));
+  border-color: color-mix(in srgb, var(--color-paper) 32%, var(--color-error));
+}
+
+.pg-alert-action.primary:hover {
+  background: color-mix(in srgb, var(--color-paper) 74%, var(--color-error));
+  border-color: color-mix(in srgb, var(--color-paper) 24%, var(--color-error));
 }
 
 @media (max-width: 40rem) {
   .pg-alert-bar {
     grid-template-columns: 1fr auto;
+    padding-block-end: calc(var(--spacing) * 3);
   }
 
   .pg-alert-message {
@@ -355,6 +376,11 @@ pre#demo-highlight code {
   .pg-alert-action {
     grid-column: 1 / -1;
   }
+}
+
+.pg-alert-dismiss {
+  color: color-mix(in srgb, var(--color-error) 82%, var(--color-body));
+  opacity: 0.9;
 }
 
 .pg-alert-dismiss svg {

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -46,6 +46,7 @@
     --color-body: #2a2620;
     --color-ink: #14110c;
     --color-error: #b53737;
+    --color-error-bg: color-mix(in srgb, var(--color-paper) 96%, var(--color-error));
 
     color-scheme: light;
   }
@@ -59,6 +60,7 @@
     --color-body: #d8d0be;
     --color-ink: #f2ead3;
     --color-error: #e66a6a;
+    --color-error-bg: color-mix(in srgb, var(--color-paper) 88%, var(--color-error));
 
     color-scheme: dark;
   }
@@ -294,6 +296,28 @@ pre#demo-highlight code {
 }
 
 /* ---------- Playground ---------- */
+
+.pg-alert-bar {
+  background-color: var(--color-error-bg);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-paper) 65%, var(--color-error));
+  color: var(--color-error);
+
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+}
+
+.pg-alert-bar a {
+  color: inherit;
+  font-weight: var(--font-weight-bold);
+  text-decoration-color: currentColor;
+}
+
+.pg-alert-bar a:hover {
+  color: var(--color-ink);
+  text-decoration-color: currentColor;
+}
 
 /* Sidebar form controls. The playground sticks to mono everywhere because
    the form labels and tab labels are technical (feature names, option keys)

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -298,14 +298,34 @@ pre#demo-highlight code {
 /* ---------- Playground ---------- */
 
 .pg-alert-bar {
+  align-items: flex-start;
   background-color: var(--color-error-bg);
   border-bottom: 1px solid color-mix(in srgb, var(--color-paper) 65%, var(--color-error));
   color: var(--color-error);
-
+  display: flex;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
+  gap: calc(var(--spacing) * 3);
   line-height: 1.5;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+}
+
+.pg-alert-message {
+  flex: 1;
+  min-width: 0;
+  padding: calc(var(--spacing) * 2) 0 calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+}
+
+.pg-alert-dismiss {
+  cursor: pointer;
+  flex: none;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4) calc(var(--spacing) * 2)
+    calc(var(--spacing) * 2);
+}
+
+.pg-alert-dismiss svg {
+  display: block;
+  height: calc(var(--spacing) * 5);
+  width: calc(var(--spacing) * 5);
 }
 
 .pg-alert-bar a {
@@ -314,7 +334,7 @@ pre#demo-highlight code {
   text-decoration-color: currentColor;
 }
 
-.pg-alert-bar a:hover {
+.pg-alert-bar :is(a, button):hover {
   color: var(--color-ink);
   text-decoration-color: currentColor;
 }

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -45,6 +45,7 @@
     --color-secondary: #5c5446;
     --color-body: #2a2620;
     --color-ink: #14110c;
+    --color-error: #b53737;
 
     color-scheme: light;
   }
@@ -57,6 +58,7 @@
     --color-secondary: #b5ab95;
     --color-body: #d8d0be;
     --color-ink: #f2ead3;
+    --color-error: #e66a6a;
 
     color-scheme: dark;
   }
@@ -531,11 +533,11 @@ pre#demo-highlight code {
 }
 
 .pg-status-bar .error {
-  color: #b53737;
+  color: var(--color-error);
 }
 
 .tab-pane.error {
-  color: #b53737;
+  color: var(--color-error);
 }
 
 .pg-loading-overlay {

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -298,34 +298,67 @@ pre#demo-highlight code {
 /* ---------- Playground ---------- */
 
 .pg-alert-bar {
-  align-items: flex-start;
+  align-items: start;
   background-color: var(--color-error-bg);
   border-bottom: 1px solid color-mix(in srgb, var(--color-paper) 65%, var(--color-error));
   color: var(--color-error);
-  display: flex;
+  display: grid;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   gap: calc(var(--spacing) * 3);
+  grid-template-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   line-height: 1.5;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
 }
 
 .pg-alert-message {
-  flex: 1;
+  align-items: center;
+  display: flex;
+  min-block-size: 2.5em;
   min-width: 0;
-  padding: calc(var(--spacing) * 2) 0 calc(var(--spacing) * 2) calc(var(--spacing) * 4);
 }
 
+.pg-alert-action,
 .pg-alert-dismiss {
   cursor: pointer;
-  flex: none;
-  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4) calc(var(--spacing) * 2)
-    calc(var(--spacing) * 2);
+  display: grid;
+  min-block-size: 2.5em;
+  min-inline-size: 2.5em;
+  place-items: center;
+}
+
+.pg-alert-action {
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  font-weight: var(--font-weight-bold);
+  padding-inline: calc(var(--spacing) * 4);
+}
+
+@media (max-width: 40rem) {
+  .pg-alert-bar {
+    grid-template-columns: 1fr auto;
+  }
+
+  .pg-alert-message {
+    grid-column: 1;
+  }
+
+  .pg-alert-dismiss {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .pg-alert-action {
+    grid-column: 1 / -1;
+  }
 }
 
 .pg-alert-dismiss svg {
   display: block;
-  height: calc(var(--spacing) * 5);
-  width: calc(var(--spacing) * 5);
+  height: 1.25rem;
+  width: 1.25rem;
 }
 
 .pg-alert-bar a {

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -61,7 +61,13 @@ fn playground_body() -> Markup {
         div .flex.flex-col."min-h-0"."md:h-full" {
             div #alert-bar.pg-alert-bar hidden {
                 span #alert-bar-message.pg-alert-message role="status" aria-live="polite" {}
-                button #alert-bar-dismiss.pg-alert-dismiss type="button" aria-label="Dismiss alert" {
+                button #alert-bar-reset-scripts.pg-alert-action type="button" hidden {
+                    "Reset scripts"
+                }
+                button #alert-bar-run-scripts.pg-alert-action type="button" hidden {
+                    "Run playground"
+                }
+                button #alert-bar-dismiss.pg-alert-dismiss type="button" aria-label="Dismiss alert" hidden {
                     svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" {
                         path fill="currentColor" d="M15.71 8.29a1 1 0 0 0-1.42 0L12 10.59l-2.29-2.3a1 1 0 0 0-1.42 1.42l2.3 2.29-2.3 2.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l2.29-2.3 2.29 2.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42L13.41 12l2.3-2.29a1 1 0 0 0 0-1.42m3.36-3.36A10 10 0 1 0 4.93 19.07 10 10 0 1 0 19.07 4.93m-1.41 12.73A8 8 0 1 1 20 12a7.95 7.95 0 0 1-2.34 5.66" {}
                     }

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -218,9 +218,11 @@ fn share_button() -> Markup {
         button #pg-share
             type="button"
             title="Copy a shareable link to your clipboard with the current playground content"
+            aria-label="Copy share link"
             class="pg-input pg-input-button pt-3.5 pb-2.5" {
             "Share"
         }
+        span #pg-share-status .sr-only role="status" {}
     }
 }
 

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -59,7 +59,14 @@ impl Route for Playground {
 fn playground_body() -> Markup {
     html! {
         div .flex.flex-col."min-h-0"."md:h-full" {
-            div #alert-bar.pg-alert-bar.hidden role="status" aria-live="polite" {}
+            div #alert-bar.pg-alert-bar hidden {
+                span #alert-bar-message.pg-alert-message role="status" aria-live="polite" {}
+                button #alert-bar-dismiss.pg-alert-dismiss type="button" aria-label="Dismiss alert" {
+                    svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" {
+                        path fill="currentColor" d="M15.71 8.29a1 1 0 0 0-1.42 0L12 10.59l-2.29-2.3a1 1 0 0 0-1.42 1.42l2.3 2.29-2.3 2.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l2.29-2.3 2.29 2.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42L13.41 12l2.3-2.29a1 1 0 0 0 0-1.42m3.36-3.36A10 10 0 1 0 4.93 19.07 10 10 0 1 0 19.07 4.93m-1.41 12.73A8 8 0 1 1 20 12a7.95 7.95 0 0 1-2.34 5.66" {}
+                    }
+                }
+            }
             div #playground.flex.flex-col."md:grid"."md:grid-cols-[16rem_1fr_1fr]"."flex-1".min-h-0 {
                 (sidebar())
                 (editor_panel())

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -80,7 +80,7 @@ fn sidebar() -> Markup {
                     path d="M6 9l6 6 6-6" {}
                 }
             }
-            div #pg-sidebar-content .hidden."md:flex".flex-col.gap-4.p-4 {
+            div #pg-sidebar-content .hidden.flex."md:flex".flex-col.gap-4.p-4 {
                 (mode_fieldset())
                 (features_fieldset())
                 (mdx_options_fieldset())

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -85,6 +85,7 @@ fn sidebar() -> Markup {
                 (features_fieldset())
                 (mdx_options_fieldset())
                 (optimize_static_fieldset())
+                (share_button())
             }
         }
     }
@@ -196,6 +197,17 @@ fn optimize_static_fieldset() -> Markup {
     }
 }
 
+fn share_button() -> Markup {
+    html! {
+        button #pg-share
+            type="button"
+            title="Copy a shareable link to your clipboard with the current playground content"
+            class="pg-input pg-input-button pt-3.5 pb-2.5" {
+            "Share"
+        }
+    }
+}
+
 fn editor_panel() -> Markup {
     html! {
         section #editor-panel.flex.flex-col."md:border-r".border-b."md:border-b-0".border-border."min-w-0"."min-h-[60vh]"."md:min-h-0" {
@@ -203,7 +215,6 @@ fn editor_panel() -> Markup {
                 button.pg-tab.active data-input-tab="source" { "Source" }
                 button.pg-tab data-input-tab="mdast-plugin" { "mdast plugin" }
                 button.pg-tab data-input-tab="hast-plugin" { "hast plugin" }
-                button #pg-share.pg-tab.ml-auto type="button" title="Copy a shareable link with the current playground state" { "Share" }
             }
             div #input-content .relative.flex-1.min-h-0.overflow-hidden {
                 div.input-pane.active data-input-pane="source" {

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -64,7 +64,7 @@ fn playground_body() -> Markup {
                 button #alert-bar-reset-scripts.pg-alert-action type="button" hidden {
                     "Reset scripts"
                 }
-                button #alert-bar-run-scripts.pg-alert-action type="button" hidden {
+                button #alert-bar-run-scripts.pg-alert-action.primary type="button" hidden {
                     "Run playground"
                 }
                 button #alert-bar-dismiss.pg-alert-dismiss type="button" aria-label="Dismiss alert" hidden {

--- a/website/src/routes/playground.rs
+++ b/website/src/routes/playground.rs
@@ -58,12 +58,15 @@ impl Route for Playground {
 
 fn playground_body() -> Markup {
     html! {
-        div #playground.flex.flex-col."md:grid"."md:grid-cols-[16rem_1fr_1fr]"."md:h-full".min-h-0 {
-            (sidebar())
-            (editor_panel())
-            (output_panel())
+        div .flex.flex-col."min-h-0"."md:h-full" {
+            div #alert-bar.pg-alert-bar.hidden role="status" aria-live="polite" {}
+            div #playground.flex.flex-col."md:grid"."md:grid-cols-[16rem_1fr_1fr]"."flex-1".min-h-0 {
+                (sidebar())
+                (editor_panel())
+                (output_panel())
+            }
+            (loading_overlay())
         }
-        (loading_overlay())
     }
 }
 


### PR DESCRIPTION
This PR continues the work started in https://github.com/bruits/satteri/pull/84 (and targets it) about adding a share button to the playground.

Most of the feature was implemented in the previous PR, so this PR mostly builds on top of that. As suggested, the Rust playground was used as a reference for the implementation, where the URL is never updated to avoid a potential confusion for the user having to guess if it's updated live or not or mess with the history.

Here is a summary of some of the changes made in this PR:

- Move the button to the sidebar as the initial position in the tab bar was confusing and not very discoverable.
- The feedback of the copy button after a successful copy was improved to be more visible and accessible.
- An alert bar was implemented to surface various errors to the user, which can optionally be dismissed.
  - An alert is shown when we fail to copy the share link to the clipboard but still provide the link so it can be manually copied
     <img width="849" height="208" alt="SCR-20260702-ldvx" src="https://github.com/user-attachments/assets/bb7cf3e4-36fd-417c-b65f-f7cd544f0453" />
  - An alert is shown when we fail to restore the playground state
     <img width="849" height="208" alt="SCR-20260702-leeh" src="https://github.com/user-attachments/assets/479d11a2-742f-494d-8837-47b381995da7" />
  - I added size limits to both compression and decompression and an alert is shown when a limit is exceeded
     <img width="849" height="208" alt="SCR-20260702-lezi" src="https://github.com/user-attachments/assets/02ab2031-510e-47b3-8d83-395e022115f0" />
  - The Sätteri version is now saved in the state and we show an alert when the version of the playground state is different from the current version (fake screenshot where I inverted the condition so version numbers are identical in the message)
     <img width="849" height="208" alt="SCR-20260702-lfvk" src="https://github.com/user-attachments/assets/de6cc3d6-41a7-4ca4-b5c8-1355498d2e8c" />
- When restoring a playground that includes scripts and these scripts are not the default ones, we no longer compile them automatically (as they could do anything) and we show an alert to the user for them to review them and choose to either dismiss or run them.
  <img width="849" height="208" alt="SCR-20260702-lglz" src="https://github.com/user-attachments/assets/8c15e17c-b73b-4475-8b76-f4bb55cc65ab" />

Happy to drop anything that you don't like or want, change anything, add missing things, or drop the PR entirely if you think it's not good.

A few notes:

- I tried to match as much as possible the existing code to minimize the changes (but some parts are meh imo)
- I'm not the best when it comes to UI and colors
- I had formatting issues for TS and CSS files in the `website/` directory so I only committed formatted code that I changed and ignored formatting changes for the rest of the code I did not change. I'll investigate that later
- A potential missing feature is schema versioning that I did not add to this PR. I thought it could be done if the schema is ever changed in a breaking way