### PR TITLE
fix(satteri): set the license field in the package.json

### DIFF
--- a/.sampo/changesets/fabled-duchess-vellamo.md
+++ b/.sampo/changesets/fabled-duchess-vellamo.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Set the license field in the package.json

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/bruits/satteri.git"
   },
+  "license": "MIT",
   "files": [
     "dist",
     "browser.js",


### PR DESCRIPTION
Adds the license field to the packument as most tooling won't try and parse the `LICENSE` file to identify the license name. The napi cli will also add this to the binary packages when it's present in the root manifest