### PR TITLE
fix(directive): treat colon-directive fragment inside a code span as literal

### DIFF
--- a/.sampo/changesets/directive-fragment-in-code-span.md
+++ b/.sampo/changesets/directive-fragment-in-code-span.md
@@ -3,4 +3,4 @@ cargo/satteri-pulldown-cmark: patch
 npm/satteri: patch
 ---
 
-With directives enabled, a `:`-directive fragment inside a code span — like `` `:foo[` `` — is now treated as literal code. Previously the directive was recognized and its label scan reached past the code span's backticks, collapsing a following inline code span into the first one and dropping a backtick. Code spans now correctly bind tighter than text directives.
+Fixes inline code being mangled when it contains directive-like syntax. With directives enabled, writing something like `` `:foo[` `` followed by more inline code no longer merges the two code spans or drops a backtick — a `:` inside a code span is now treated as literal text, so you can safely show directive syntax in code.

--- a/.sampo/changesets/directive-fragment-in-code-span.md
+++ b/.sampo/changesets/directive-fragment-in-code-span.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-pulldown-cmark: patch
+npm/satteri: patch
+---
+
+With directives enabled, a `:`-directive fragment inside a code span — like `` `:foo[` `` — is now treated as literal code. Previously the directive was recognized and its label scan reached past the code span's backticks, collapsing a following inline code span into the first one and dropping a backtick. Code spans now correctly bind tighter than text directives.

--- a/crates/satteri-pulldown-cmark/specs/container_extensions.txt
+++ b/crates/satteri-pulldown-cmark/specs/container_extensions.txt
@@ -238,3 +238,19 @@ Leaf directive name only:
 ::break
 .
 ````````````````````````````````
+
+Colon-directive fragment inside a code span is literal (issue #158):
+
+```````````````````````````````` example_container_extensions
+`:foo[` and `bar]`
+.
+<p><code>:foo[</code> and <code>bar]</code></p>
+````````````````````````````````
+
+Same, mid-paragraph:
+
+```````````````````````````````` example_container_extensions
+text `:link[` more `code]` after
+.
+<p>text <code>:link[</code> more <code>code]</code> after</p>
+````````````````````````````````

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -2299,6 +2299,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     // Must not be preceded by another colon (to avoid ::, :::)
                     if ix > 0 && bytes[ix - 1] == b':' {
                         LoopInstruction::ContinueAndSkip(0)
+                    } else if is_inside_code_span(bytes, ix) {
+                        // Code spans bind tighter: a `:` inside one is literal, not
+                        // a directive whose label scan would reach past the span's
+                        // backticks and swallow them (issue #158).
+                        LoopInstruction::ContinueAndSkip(0)
                     } else if let Some((dir_data, end_pos)) =
                         parse_directive_after_colons(self.text, bytes, ix + 1)
                     {

--- a/crates/satteri-pulldown-cmark/tests/directive_inline.rs
+++ b/crates/satteri-pulldown-cmark/tests/directive_inline.rs
@@ -166,3 +166,24 @@ fn text_directive_label_is_inline_parsed() {
         ]
     );
 }
+
+// Issue 158: code spans bind tighter than directives, so a `:`-fragment
+// inside one is literal and must not swallow a later code span's backticks.
+#[test]
+fn directive_fragment_inside_code_span_does_not_swallow_later_code() {
+    let input = "`:foo[` and `bar]`";
+    let (arena, _) = parse(input, dir_options());
+
+    let para = arena.get_children(0)[0];
+    assert_eq!(
+        types_of(&arena, para),
+        vec![
+            MdastNodeType::InlineCode as u8, // `:foo[`
+            MdastNodeType::Text as u8,       // " and "
+            MdastNodeType::InlineCode as u8, // `bar]`
+        ]
+    );
+    let children = arena.get_children(para);
+    assert_eq!(node_value(&arena, children[0]), ":foo[");
+    assert_eq!(node_value(&arena, children[2]), "bar]");
+}

--- a/crates/satteri-pulldown-cmark/tests/suite/container_extensions.rs
+++ b/crates/satteri-pulldown-cmark/tests/suite/container_extensions.rs
@@ -287,3 +287,23 @@ fn container_extensions_test_24() {
 
     test_markdown_html(original, expected, 0, false, false, false, false, false, true);
 }
+
+#[test]
+fn container_extensions_test_25() {
+    let original = r##"`:foo[` and `bar]`
+"##;
+    let expected = r##"<p><code>:foo[</code> and <code>bar]</code></p>
+"##;
+
+    test_markdown_html(original, expected, 0, false, false, false, false, false, true);
+}
+
+#[test]
+fn container_extensions_test_26() {
+    let original = r##"text `:link[` more `code]` after
+"##;
+    let expected = r##"<p>text <code>:link[</code> more <code>code]</code> after</p>
+"##;
+
+    test_markdown_html(original, expected, 0, false, false, false, false, false, true);
+}


### PR DESCRIPTION
Fixes #158