### PR TITLE
test(positions): add astral conformance cases and tighten the cache test

### DIFF
--- a/crates/satteri-ast/src/walk.rs
+++ b/crates/satteri-ast/src/walk.rs
@@ -481,15 +481,16 @@ mod tests {
     #[test]
     fn walk_position_offsets_use_the_precomputed_cache() {
         let mut arena = build_multibyte_text_arena();
-        // Parallel to `nodes` (root, text); the walk must prefer it over a
-        // fresh LineIndex scan.
-        arena.utf16_offsets = vec![(0, 0), (5, 7)];
+        // Parallel to `nodes` (root, text). The values are deliberately not
+        // the ones a LineIndex scan would produce (5, 7), so this fails if
+        // the walk recomputes instead of reading the cache.
+        arena.utf16_offsets = vec![(0, 0), (99, 100)];
         let subs = vec![Subscription {
             node_type: 2,
             tag_filter: vec![],
         }];
         let buf = walk_hast(&arena, &subs);
-        assert_eq!(read_match_offsets(&buf, 0), (5, 7));
+        assert_eq!(read_match_offsets(&buf, 0), (99, 100));
     }
 
     fn build_hast_with_elements(tags: &[&str]) -> Arena<Hast> {

--- a/packages/satteri/test/conformance/mdast.test.ts
+++ b/packages/satteri/test/conformance/mdast.test.ts
@@ -515,6 +515,32 @@ describe("MDAST conformance: closing code fence whitespace", () => {
   });
 });
 
+// Astral characters are a single code point but two UTF-16 units, and
+// `position` counts UTF-16 units — so both columns and offsets advance by
+// two. BMP multibyte text can't catch a regression back to code points;
+// only these can.
+describe("MDAST conformance: astral characters in positions", () => {
+  test("astral before a link", () => {
+    assertMdastConformance("😀 [a](/x)");
+  });
+
+  test("astral in a heading", () => {
+    assertMdastConformance("# 😀 head");
+  });
+
+  test("astral across blocks and lines", () => {
+    assertMdastConformance("😀 one\n\n😀😀 **two**\n\n- 😀 item");
+  });
+
+  test("astral mixed with BMP multibyte", () => {
+    assertMdastConformance("❤️你好😀αβγ [mixed](/x)");
+  });
+
+  test("astral at end of document", () => {
+    assertMdastConformance("a [l](/x) 😀");
+  });
+});
+
 describe("MDAST conformance: fuzz regressions", () => {
   // GFM strikethrough requires the opening `~~` to be left-flanking per
   // CommonMark emphasis rules: a `~~` preceded by an alphanumeric and


### PR DESCRIPTION
Follow-up to #174: adds remark conformance cases for astral characters and makes the UTF-16 offset cache test non-vacuous.