### PR TITLE
fix: expose `children` on empty MDAST parents

### DIFF
--- a/.sampo/changesets/cantankerous-witch-loviatar.md
+++ b/.sampo/changesets/cantankerous-witch-loviatar.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Fixes an issue with MDAST plugin visitors receiving `undefined` instead of an empty array for the `children` property of empty parent nodes.

--- a/packages/satteri/src/mdast/mdast-visitor.ts
+++ b/packages/satteri/src/mdast/mdast-visitor.ts
@@ -1,4 +1,4 @@
-import { materializeNode } from "./mdast-materializer.js";
+import { LEAF_TYPES, materializeNode } from "./mdast-materializer.js";
 import { MdastReader } from "./mdast-reader.js";
 import {
   acquireCommandBuffer,
@@ -679,6 +679,23 @@ function readMdastMatchedNode(
     node.type = node.name as string;
     delete node.name;
     if (node.value === "") delete node.value;
+  }
+
+  /**
+   * A custom node is a leaf only when it has a value and no `children` or `data.h*`.
+   * @see {@link Custom}
+   */
+  const hProperties = initialData?.hProperties;
+  const hasHProperties =
+    hProperties !== null && typeof hProperties === "object" && !Array.isArray(hProperties);
+  const hasHData =
+    typeof initialData?.hName === "string" ||
+    hasHProperties ||
+    Array.isArray(initialData?.hChildren);
+  const isCustomLeaf = nodeType === MDAST_CUSTOM && typeof node.value === "string" && !hasHData;
+
+  if (childCount === 0 && !LEAF_TYPES.has(nodeType) && !isCustomLeaf) {
+    node.children = [];
   }
 
   mdastNodeIdMap.set(node as object, nodeId);

--- a/packages/satteri/test/custom-node.test.ts
+++ b/packages/satteri/test/custom-node.test.ts
@@ -166,6 +166,46 @@ test("custom parent node carries no spurious value field", () => {
   expect(hasValueKey).toBe(false);
 });
 
+test("custom parent node carries an empty children array", () => {
+  const create = defineMdastPlugin({
+    name: "create",
+    paragraph(node, ctx) {
+      ctx.replaceNode(node, { type: "section", children: [] });
+    },
+  });
+  let seenChildren: unknown = "UNSET";
+  const inspect = defineMdastPlugin({
+    name: "inspect",
+    custom(node) {
+      seenChildren = node.children;
+    },
+  });
+  markdownToHtml("placeholder", { mdastPlugins: [create, inspect] });
+  expect(seenChildren).toEqual([]);
+});
+
+test("custom parent node with `data.h*` carries an empty children array", () => {
+  const create = defineMdastPlugin({
+    name: "create",
+    paragraph(node, ctx) {
+      ctx.replaceNode(node, {
+        type: "section",
+        value: "text",
+        data: { hName: "aside" },
+      });
+    },
+  });
+  let seenChildren: unknown = "UNSET";
+  const inspect = defineMdastPlugin({
+    name: "inspect",
+    custom(node) {
+      seenChildren = node.children;
+    },
+  });
+  markdownToHtml("placeholder", { mdastPlugins: [create, inspect] });
+  expect(seenChildren).toEqual([]);
+});
+
 test("a node whose type is literally 'custom' round-trips its type", () => {
   // `"custom"` is the internal tag's own public name; a plugin may still pick
   // it as a user-defined type, and it must survive rather than emptying out.

--- a/packages/satteri/test/visitor.test.ts
+++ b/packages/satteri/test/visitor.test.ts
@@ -749,6 +749,19 @@ test("containerDirective visitor fires and exposes name + attributes", () => {
   expect(seen[0]!.attributes.class).toBe("note");
 });
 
+test("empty containerDirective visitor exposes empty children", () => {
+  const { handle, source } = setupDirective(":::tip\n:::\n");
+  let children: unknown;
+  const plugin = defineMdastPlugin({
+    name: "read-empty-container-directive-children",
+    containerDirective(node) {
+      children = [...node.children];
+    },
+  });
+  visitMdastHandle(handle, plugin, resolveMdastSubscriptions(plugin), source, undefined);
+  expect(children).toEqual([]);
+});
+
 test("containerDirective with [label] exposes directiveLabel marker on first child", () => {
   const { handle, source } = setupDirective(":::warning[Heads up]\ncontent\n:::\n");
   let labelChildHadMarker = false;

--- a/packages/satteri/test/walk-reader-parity.test.ts
+++ b/packages/satteri/test/walk-reader-parity.test.ts
@@ -349,3 +349,19 @@ test("P2: a false-valued element property reads the same from walk and reader pa
   expect(input.properties.checked).toBe(false);
   expect(walkChecked).toBe(false);
 });
+
+test("empty parent exposes children on the walk path, matching the reader", () => {
+  const { walked, materialized } = walkAndReader("<Component />", "mdxJsxFlowElement", true);
+  expect(walked).toHaveLength(1);
+  expect(materialized).toHaveLength(1);
+  expect(walked[0]!.children).toEqual([]);
+  expect(walked[0]!.children).toEqual(materialized[0]!.children);
+});
+
+test("leaf node omits children on the walk path, matching the reader", () => {
+  const { walked, materialized } = walkAndReader("test", "text");
+  expect(walked).toHaveLength(1);
+  expect(materialized).toHaveLength(1);
+  expect("children" in walked[0]!).toBe(false);
+  expect("children" in materialized[0]!).toBe(false);
+});


### PR DESCRIPTION
Initially [reported on Discord](https://discord.com/channels/830184174198718474/1070481941863878697/1531348488657567814) with Starlight asides, this PR fixes an issue where empty MDAST parent nodes would not have a `children` property as expected.

- I added a check for non-leaf empty nodes that are not custom leaf nodes (using [these rules](https://github.com/bruits/satteri/blob/c9ea0c9e59d7e71afb6be97b378e787b0f3c96a8/packages/satteri/src/types.ts#L94-L95)).
- As this is more generic than just container directives, I added more generic tests, e.g. in `packages/satteri/test/walk-reader-parity.test.ts` altho I have no idea what the `C4`, `C2`, `P1`, `S1`, etc. are in the test names, so I just ommited them. Let me know if you want me to change them somehow.