### PR TITLE
fix(plugin-api): reject un-wrappable wrapNode parents, add {rawHtml} wrappers in HAST

### DIFF
--- a/.sampo/changesets/hast-wrap-raw-html.md
+++ b/.sampo/changesets/hast-wrap-raw-html.md
@@ -1,6 +1,7 @@
 ---
 cargo/satteri-ast: minor
 cargo/satteri-plugin-api: minor
+cargo/satteri-napi: patch
 npm/satteri: minor
 ---
 

--- a/.sampo/changesets/hast-wrap-raw-html.md
+++ b/.sampo/changesets/hast-wrap-raw-html.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-ast: minor
+cargo/satteri-plugin-api: minor
+npm/satteri: minor
+---
+
+Adds `{ rawHtml }` support to `wrapNode()` in HAST plugins: the HTML is parsed and the node is wrapped in the resulting element.

--- a/.sampo/changesets/wrap-node-leaf-parents.md
+++ b/.sampo/changesets/wrap-node-leaf-parents.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-ast: patch
+npm/satteri: patch
+---
+
+Fixed `wrapNode()` silently misplacing or dropping the node when given a parent that cannot hold children (an `html` node or raw content); it now throws an error explaining what to use instead.

--- a/.sampo/changesets/wrap-node-leaf-parents.md
+++ b/.sampo/changesets/wrap-node-leaf-parents.md
@@ -1,6 +1,9 @@
 ---
 cargo/satteri-ast: patch
+cargo/satteri-plugin-api: patch
 npm/satteri: patch
 ---
 
-Fixed `wrapNode()` silently misplacing or dropping the node when given a parent that cannot hold children (an `html` node or raw content); it now throws an error explaining what to use instead.
+Fixed `wrapNode()` silently misplacing or dropping the node when given a parent that cannot hold children — an `html` node, raw content, a leaf-shaped custom node, or a void element like `<img>`. These now throw an error explaining what to use instead, and `parentNode` only accepts parent-capable nodes in TypeScript, so most of them are caught before running.
+
+Wrapping in a container is unchanged: `blockquote` and friends, a HAST element, an MDX JSX element, a custom node declaring a `children` array, and the root itself all keep working.

--- a/crates/satteri-ast/src/commands.rs
+++ b/crates/satteri-ast/src/commands.rs
@@ -56,12 +56,11 @@ pub enum CommandError {
     /// A structurally valid but re-entrant patch shape (e.g. a payload ref
     /// naming its own anchor's ancestor) that in-place application rejects.
     UnsupportedPatchShape(&'static str),
-    /// `wrapNode` was given `{rawHtml}` content that doesn't yield a usable
-    /// wrapper; the message says why (not a single element, void element, or
-    /// a build without HTML parsing).
+    /// A `wrapNode` `{rawHtml}` payload with no usable wrapper; the string
+    /// says why.
     InvalidWrapHtml(String),
-    /// `wrapNode` was given a void element as the wrapper, which renders
-    /// without children and would drop the wrapped node. Holds the tag name.
+    /// A void element (the tag) as the wrapper would render without children,
+    /// dropping the wrapped node.
     VoidWrapParent(String),
 }
 

--- a/crates/satteri-ast/src/commands.rs
+++ b/crates/satteri-ast/src/commands.rs
@@ -56,6 +56,10 @@ pub enum CommandError {
     /// A structurally valid but re-entrant patch shape (e.g. a payload ref
     /// naming its own anchor's ancestor) that in-place application rejects.
     UnsupportedPatchShape(&'static str),
+    /// `wrapNode` was given `{rawHtml}` content that doesn't yield a usable
+    /// wrapper; the message says why (not a single element, void element, or
+    /// a build without HTML parsing).
+    InvalidWrapHtml(String),
 }
 
 impl std::fmt::Display for CommandError {
@@ -116,6 +120,9 @@ impl std::fmt::Display for CommandError {
             ),
             Self::PatchOnRemovedSubtree(id) => {
                 write!(f, "patch targets node {id} inside a removed subtree")
+            }
+            Self::InvalidWrapHtml(reason) => {
+                write!(f, "wrapNode: {{rawHtml}} wrapper {reason}")
             }
         }
     }

--- a/crates/satteri-ast/src/commands.rs
+++ b/crates/satteri-ast/src/commands.rs
@@ -60,6 +60,9 @@ pub enum CommandError {
     /// wrapper; the message says why (not a single element, void element, or
     /// a build without HTML parsing).
     InvalidWrapHtml(String),
+    /// `wrapNode` was given a void element as the wrapper, which renders
+    /// without children and would drop the wrapped node. Holds the tag name.
+    VoidWrapParent(String),
 }
 
 impl std::fmt::Display for CommandError {
@@ -124,6 +127,10 @@ impl std::fmt::Display for CommandError {
             Self::InvalidWrapHtml(reason) => {
                 write!(f, "wrapNode: {{rawHtml}} wrapper {reason}")
             }
+            Self::VoidWrapParent(tag) => write!(
+                f,
+                "wrapNode: <{tag}> is a void element, which cannot hold the wrapped node"
+            ),
         }
     }
 }

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -20,7 +20,7 @@ use crate::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
     encode_element_data,
 };
-use crate::hast::render::render_node_inner;
+use crate::hast::render::{is_void_element, render_node_inner};
 use crate::hast::HastNodeType;
 #[cfg(feature = "mdx")]
 use crate::mdast::codec::{
@@ -724,6 +724,38 @@ pub fn html_to_hast_arena(html: &str) -> Arena<Hast> {
     builder.finish()
 }
 
+/// Parse an HTML fragment into a wrap-payload arena: the fragment's single
+/// element becomes node 0, the shape `Patch::Wrap` takes as the wrapper.
+/// Whitespace-only text around the element is ignored; anything else —
+/// no element, extra top-level nodes, or a void element (whose children
+/// never render) — errors with the reason, so a wrapper that cannot hold
+/// the wrapped node is rejected instead of silently dropping it.
+pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
+    let (nodes, roots, _) = parse_fragment_nodes(html, None);
+    let mut wrapper: Option<usize> = None;
+    for &r in &roots {
+        match &nodes[r].data {
+            NodeData::Text { contents } if contents.trim().is_empty() => {}
+            NodeData::Element { name, .. } if wrapper.is_none() => {
+                if is_void_element(&name.local) {
+                    return Err(format!(
+                        "is a void element (<{}>), which cannot hold the wrapped node",
+                        name.local
+                    ));
+                }
+                wrapper = Some(r);
+            }
+            _ => return Err("must parse to exactly one element".to_string()),
+        }
+    }
+    let Some(wrapper) = wrapper else {
+        return Err("must parse to exactly one element".to_string());
+    };
+    let mut builder = ArenaBuilder::<Hast>::new(String::new());
+    emit(&nodes, &[wrapper], &mut builder, None, &[], &[]);
+    Ok(builder.finish())
+}
+
 /// Reparse the raw HTML embedded in a HAST arena into real HAST nodes.
 ///
 /// The whole tree is rendered back to HTML (raw nodes verbatim) and reparsed
@@ -1335,5 +1367,53 @@ mod tests {
             reparsed.get_str(decode_text_data(reparsed.get_type_data(comment))),
             "oops "
         );
+    }
+
+    /// A single element becomes node 0 of the wrap arena, with its attributes
+    /// and declared children intact; surrounding whitespace is tolerated.
+    #[test]
+    fn wrap_arena_single_element() {
+        let arena = html_fragment_to_wrap_arena("  <div class=\"x\"><a href=\"#\">#</a></div>\n")
+            .expect("single element must parse");
+        assert_eq!(arena.get_node(0).node_type, HastNodeType::Element as u8);
+        assert_eq!(
+            arena.get_str(decode_element_tag(arena.get_type_data(0))),
+            "div"
+        );
+        let children = arena.get_children(0);
+        assert_eq!(children.len(), 1);
+        assert_eq!(
+            arena.get_str(decode_element_tag(arena.get_type_data(children[0]))),
+            "a"
+        );
+    }
+
+    /// Table parts survive as wrappers thanks to the template-context
+    /// fragment parse (document parsing would foster-parent them away).
+    #[test]
+    fn wrap_arena_accepts_table_parts() {
+        let arena = html_fragment_to_wrap_arena("<tr></tr>").expect("tr must parse");
+        assert_eq!(
+            arena.get_str(decode_element_tag(arena.get_type_data(0))),
+            "tr"
+        );
+    }
+
+    /// Anything but exactly one element is rejected: bare text, multiple
+    /// top-level nodes, comments, empty input.
+    #[test]
+    fn wrap_arena_rejects_non_single_element() {
+        for html in ["hello", "<i></i><b></b>", "<!--x--><div></div>", "", "   "] {
+            let err = html_fragment_to_wrap_arena(html).expect_err(html);
+            assert!(err.contains("exactly one element"), "{html}: {err}");
+        }
+    }
+
+    /// A void wrapper's children never render, so the wrapped node would be
+    /// silently dropped — rejected instead.
+    #[test]
+    fn wrap_arena_rejects_void_elements() {
+        let err = html_fragment_to_wrap_arena("<img src=\"x.png\">").expect_err("void");
+        assert!(err.contains("void element"), "{err}");
     }
 }

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -724,12 +724,10 @@ pub fn html_to_hast_arena(html: &str) -> Arena<Hast> {
     builder.finish()
 }
 
-/// Parse an HTML fragment into a wrap-payload arena: the fragment's single
-/// element becomes node 0, the shape `Patch::Wrap` takes as the wrapper.
-/// Whitespace-only text around the element is ignored; anything else —
-/// no element, extra top-level nodes, or a void element (whose children
-/// never render) — errors with the reason, so a wrapper that cannot hold
-/// the wrapped node is rejected instead of silently dropping it.
+/// Parse an HTML fragment into a wrap-payload arena: the single element
+/// becomes node 0, the shape `Patch::Wrap` takes as the wrapper. Whitespace
+/// around it is ignored; anything else (no element, extra top-level nodes, a
+/// void element) errors with the reason.
 pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
     let (nodes, roots, _) = parse_fragment_nodes(html, None);
     let mut wrapper: Option<usize> = None;
@@ -1369,8 +1367,6 @@ mod tests {
         );
     }
 
-    /// A single element becomes node 0 of the wrap arena, with its attributes
-    /// and declared children intact; surrounding whitespace is tolerated.
     #[test]
     fn wrap_arena_single_element() {
         let arena = html_fragment_to_wrap_arena("  <div class=\"x\"><a href=\"#\">#</a></div>\n")
@@ -1388,8 +1384,8 @@ mod tests {
         );
     }
 
-    /// Table parts survive as wrappers thanks to the template-context
-    /// fragment parse (document parsing would foster-parent them away).
+    /// Template-context parsing keeps table parts; document parsing would
+    /// foster-parent them away.
     #[test]
     fn wrap_arena_accepts_table_parts() {
         let arena = html_fragment_to_wrap_arena("<tr></tr>").expect("tr must parse");
@@ -1399,8 +1395,6 @@ mod tests {
         );
     }
 
-    /// Anything but exactly one element is rejected: bare text, multiple
-    /// top-level nodes, comments, empty input.
     #[test]
     fn wrap_arena_rejects_non_single_element() {
         for html in ["hello", "<i></i><b></b>", "<!--x--><div></div>", "", "   "] {
@@ -1409,8 +1403,6 @@ mod tests {
         }
     }
 
-    /// A void wrapper's children never render, so the wrapped node would be
-    /// silently dropped — rejected instead.
     #[test]
     fn wrap_arena_rejects_void_elements() {
         let err = html_fragment_to_wrap_arena("<img src=\"x.png\">").expect_err("void");

--- a/crates/satteri-ast/src/hast/mod.rs
+++ b/crates/satteri-ast/src/hast/mod.rs
@@ -13,7 +13,7 @@ pub use crate::convert::{
     mdast_arena_to_hast_arena_with_options, Backref, ConvertOptions,
 };
 #[cfg(feature = "from-html")]
-pub use from_html::{html_to_hast_arena, raw_to_hast_arena};
+pub use from_html::{html_fragment_to_wrap_arena, html_to_hast_arena, raw_to_hast_arena};
 pub use node::HastNodeType;
 pub use render::{hast_arena_to_html, render_node};
 

--- a/crates/satteri-ast/src/hast/mod.rs
+++ b/crates/satteri-ast/src/hast/mod.rs
@@ -15,7 +15,7 @@ pub use crate::convert::{
 #[cfg(feature = "from-html")]
 pub use from_html::{html_fragment_to_wrap_arena, html_to_hast_arena, raw_to_hast_arena};
 pub use node::HastNodeType;
-pub use render::{hast_arena_to_html, render_node};
+pub use render::{hast_arena_to_html, is_void_element, render_node};
 
 /// Collect concatenated text content from a HAST arena.
 ///

--- a/crates/satteri-ast/src/hast/render.rs
+++ b/crates/satteri-ast/src/hast/render.rs
@@ -210,8 +210,7 @@ pub(crate) fn render_node_inner<'cb>(
     }
 }
 
-/// A void element renders as a single tag, so any children it is given never
-/// reach the output.
+/// Void elements render as a single tag; any children never reach the output.
 pub fn is_void_element(tag: &str) -> bool {
     matches!(
         tag,

--- a/crates/satteri-ast/src/hast/render.rs
+++ b/crates/satteri-ast/src/hast/render.rs
@@ -210,7 +210,9 @@ pub(crate) fn render_node_inner<'cb>(
     }
 }
 
-pub(crate) fn is_void_element(tag: &str) -> bool {
+/// A void element renders as a single tag, so any children it is given never
+/// reach the output.
+pub fn is_void_element(tag: &str) -> bool {
     matches!(
         tag,
         "area"

--- a/crates/satteri-ast/src/hast/render.rs
+++ b/crates/satteri-ast/src/hast/render.rs
@@ -210,7 +210,7 @@ pub(crate) fn render_node_inner<'cb>(
     }
 }
 
-fn is_void_element(tag: &str) -> bool {
+pub(crate) fn is_void_element(tag: &str) -> bool {
     matches!(
         tag,
         "area"

--- a/crates/satteri-ast/src/patch.rs
+++ b/crates/satteri-ast/src/patch.rs
@@ -679,8 +679,8 @@ fn apply_patches_impl<K: ArenaKind>(
                 return Err(CommandError::WrapOnRemovedNode(*node_id));
             }
             // A ROOT-typed wrapper only arises from a parsed raw payload;
-            // treating it as the wrapper would silently degrade the wrap
-            // into sibling insertion (the root serializes transparently).
+            // treating it as the wrapper silently degrades the wrap into
+            // sibling insertion.
             Patch::Wrap { parent_tree, .. }
                 if match parent_tree {
                     PatchContent::Tree(t) => {
@@ -1958,9 +1958,7 @@ mod tests {
         );
     }
 
-    /// A root-wrapped wrap payload (the shape a parsed raw string produces)
-    /// is rejected up front instead of silently wrapping in a transparent
-    /// root and pushing the parsed content after the anchor.
+    /// A root-wrapped payload is the shape a parsed raw string produces.
     #[test]
     fn wrap_with_root_payload_is_rejected() {
         let orig = build_hello_world();

--- a/crates/satteri-ast/src/patch.rs
+++ b/crates/satteri-ast/src/patch.rs
@@ -678,6 +678,21 @@ fn apply_patches_impl<K: ArenaKind>(
             Patch::Wrap { node_id, .. } if plans[node_id].deleted => {
                 return Err(CommandError::WrapOnRemovedNode(*node_id));
             }
+            // A ROOT-typed wrapper only arises from a parsed raw payload;
+            // treating it as the wrapper would silently degrade the wrap
+            // into sibling insertion (the root serializes transparently).
+            Patch::Wrap { parent_tree, .. }
+                if match parent_tree {
+                    PatchContent::Tree(t) => {
+                        !t.is_empty() && t.get_node(0).node_type == K::ROOT_TAG
+                    }
+                    PatchContent::Grafted(roots) => roots
+                        .first()
+                        .is_some_and(|&r| arena.get_node(r).node_type == K::ROOT_TAG),
+                } =>
+            {
+                return Err(unsupported("wrap parent is a document root"));
+            }
             Patch::PrependChild { node_id, .. } | Patch::AppendChild { node_id, .. }
                 if plans[node_id].deleted =>
             {
@@ -1941,6 +1956,31 @@ mod tests {
             rebuilt.get_node(h1_id).node_type,
             HastNodeType::Element as u8
         );
+    }
+
+    /// A root-wrapped wrap payload (the shape a parsed raw string produces)
+    /// is rejected up front instead of silently wrapping in a transparent
+    /// root and pushing the parsed content after the anchor.
+    #[test]
+    fn wrap_with_root_payload_is_rejected() {
+        let orig = build_hello_world();
+        let heading_id = orig.get_children(0)[0];
+
+        let mut wb = ArenaBuilder::<Mdast>::new(String::new());
+        wb.open_node(MdastNodeType::Root as u8);
+        wb.open_node(MdastNodeType::Html as u8);
+        wb.close_node();
+        wb.close_node();
+        let payload = wb.finish();
+
+        let patches = vec![Patch::Wrap {
+            node_id: heading_id,
+            parent_tree: PatchContent::Tree(payload),
+        }];
+        match rebuild(&orig, &patches) {
+            Err(CommandError::UnsupportedPatchShape(_)) => {}
+            other => panic!("expected UnsupportedPatchShape, got {other:?}"),
+        }
     }
 
     /// Build a single-node arena rooted at `node_type`, with no data and no

--- a/crates/satteri-napi-binding/Cargo.toml
+++ b/crates/satteri-napi-binding/Cargo.toml
@@ -28,7 +28,7 @@ mdx = [
 ]
 # HTML -> HAST parsing via html5ever. Included in the full (default) build like
 # `mdx`; dropped from `--no-default-features` (lite) builds to keep them small.
-from-html = ["satteri-ast/from-html"]
+from-html = ["satteri-ast/from-html", "satteri-plugin-api/from-html"]
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/satteri-plugin-api/Cargo.toml
+++ b/crates/satteri-plugin-api/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = { workspace = true }
 [features]
 default = ["mdx"]
 mdx = ["satteri-ast/mdx"]
+# HTML fragment parsing for HAST `wrapNode` `{rawHtml}` payloads; without it
+# those payloads error at apply time.
+from-html = ["satteri-ast/from-html"]

--- a/crates/satteri-plugin-api/src/js_commands.rs
+++ b/crates/satteri-plugin-api/src/js_commands.rs
@@ -1077,11 +1077,9 @@ fn replay_hast_opstream(
     replay_opstream::<HastFieldCollector>(ops, builder, original_len, anchor)
 }
 
-/// Returns (arena, keep_children) for a HAST sub-tree payload. Payloads are
-/// `PAYLOAD_OPSTREAM` (declarative-compiled), plus — for wrap only —
-/// `PAYLOAD_RAW`, parsed as an HTML fragment into the wrapper element. Other
-/// ops take real hast nodes (`raw` covers opaque HTML), so raw stays rejected
-/// there.
+/// Returns (arena, keep_children) for a HAST sub-tree payload: an op-stream,
+/// or — wrap only — `PAYLOAD_RAW` parsed as an HTML fragment. Other ops don't
+/// need raw: the `raw` node type covers opaque HTML.
 fn read_hast_payload(
     reader: &mut BufReader<'_>,
     builder: &mut ArenaBuilder<Hast>,
@@ -1101,8 +1099,8 @@ fn read_hast_payload(
             ))
         }
         PAYLOAD_RAW if for_wrap => {
-            // The flags byte (RAW_LITERAL_BRACES) is an MDX parsing concern;
-            // HAST fragment parsing has no expressions, so it is ignored.
+            // Flags (RAW_LITERAL_BRACES) are an MDX concern; HTML parsing has
+            // no expressions to escape.
             let _flags = reader.read_u8()?;
             let len = reader.read_u32()? as usize;
             let raw = reader.read_str(len)?;
@@ -1125,9 +1123,8 @@ fn hast_wrap_arena_from_html(_raw: &str) -> Result<Arena<Hast>, CommandError> {
     ))
 }
 
-/// A void wrapper renders as a lone tag, so the wrapped node would never reach
-/// the output. The `{rawHtml}` parser rejects these at parse time; element
-/// payloads carry their tag too, so the same rule applies here.
+/// A void wrapper would drop the wrapped node at render. `{rawHtml}` payloads
+/// are rejected at parse time; this covers op-stream element payloads.
 fn reject_void_wrap_parent(
     parent_tree: &PatchContent<Hast>,
     grafted: &Arena<Hast>,
@@ -2315,7 +2312,6 @@ mod tests {
         b.finish()
     }
 
-    /// Push a `PAYLOAD_RAW` structural command (cmd, anchor, flags, string).
     fn push_raw_command(buf: &mut Vec<u8>, cmd: u8, node_id: u32, raw: &str) {
         buf.push(cmd);
         push_u32(buf, node_id);
@@ -2325,8 +2321,6 @@ mod tests {
         buf.extend_from_slice(raw.as_bytes());
     }
 
-    /// A HAST wrap with a `{rawHtml}` payload parses the fragment into the
-    /// wrapper element: root > section > div.
     #[cfg(feature = "from-html")]
     #[test]
     fn hast_wrap_with_raw_html_payload() {
@@ -2348,8 +2342,6 @@ mod tests {
         );
     }
 
-    /// A `{rawHtml}` wrap payload that isn't a single element errors instead
-    /// of silently mis-wrapping.
     #[cfg(feature = "from-html")]
     #[test]
     fn hast_wrap_with_invalid_raw_html_errors() {
@@ -2361,8 +2353,7 @@ mod tests {
         assert!(matches!(err, CommandError::InvalidWrapHtml(_)), "{err:?}");
     }
 
-    /// Push a wrap command whose payload is an op-stream for a single element
-    /// with `tag` — the shape a `{type: "element"}` wrapper compiles to.
+    /// The op-stream shape a `{type: "element"}` wrapper compiles to.
     fn push_element_wrap_command(buf: &mut Vec<u8>, node_id: u32, tag: &str) {
         let mut ops = Vec::new();
         ops.push(OP_OPEN);
@@ -2377,8 +2368,6 @@ mod tests {
         buf.extend_from_slice(&ops);
     }
 
-    /// A void element wrapper renders without children, so it is rejected the
-    /// same way a `{rawHtml}` void wrapper is — the wrapped node would vanish.
     #[test]
     fn hast_wrap_with_void_element_payload_errors() {
         let arena = build_hast_element(&[]);
@@ -2392,7 +2381,6 @@ mod tests {
         );
     }
 
-    /// The void check leaves ordinary element wrappers alone.
     #[test]
     fn hast_wrap_with_element_payload_wraps() {
         let arena = build_hast_element(&[]);
@@ -2413,7 +2401,6 @@ mod tests {
         );
     }
 
-    /// Raw payloads stay rejected for every HAST command except wrap.
     #[test]
     fn hast_raw_payload_rejected_outside_wrap() {
         let arena = build_hast_element(&[]);

--- a/crates/satteri-plugin-api/src/js_commands.rs
+++ b/crates/satteri-plugin-api/src/js_commands.rs
@@ -1076,28 +1076,52 @@ fn replay_hast_opstream(
     replay_opstream::<HastFieldCollector>(ops, builder, original_len, anchor)
 }
 
-/// Returns (arena, keep_children) for a HAST sub-tree payload. Only
-/// `PAYLOAD_OPSTREAM` (declarative-compiled) is accepted — HAST has no source
-/// grammar, so raw markdown / HTML are not, and there is no JSON path.
+/// Returns (arena, keep_children) for a HAST sub-tree payload. Payloads are
+/// `PAYLOAD_OPSTREAM` (declarative-compiled), plus — for wrap only —
+/// `PAYLOAD_RAW`, parsed as an HTML fragment into the wrapper element. Other
+/// ops take real hast nodes (`raw` covers opaque HTML), so raw stays rejected
+/// there.
 fn read_hast_payload(
     reader: &mut BufReader<'_>,
     builder: &mut ArenaBuilder<Hast>,
     original_len: u32,
     anchor: u32,
+    for_wrap: bool,
 ) -> Result<(PatchContent<Hast>, bool), CommandError> {
     let payload_type = reader.read_u8()?;
-    let len = reader.read_u32()? as usize;
 
     match payload_type {
         PAYLOAD_OPSTREAM => {
+            let len = reader.read_u32()? as usize;
             let ops = reader.read_bytes(len)?;
             Ok((
                 PatchContent::Grafted(replay_hast_opstream(ops, builder, original_len, anchor)?),
                 false,
             ))
         }
+        PAYLOAD_RAW if for_wrap => {
+            // The flags byte (RAW_LITERAL_BRACES) is an MDX parsing concern;
+            // HAST fragment parsing has no expressions, so it is ignored.
+            let _flags = reader.read_u8()?;
+            let len = reader.read_u32()? as usize;
+            let raw = reader.read_str(len)?;
+            Ok((PatchContent::Tree(hast_wrap_arena_from_html(raw)?), false))
+        }
         other => Err(CommandError::UnknownPayloadType(other)),
     }
+}
+
+#[cfg(feature = "from-html")]
+fn hast_wrap_arena_from_html(raw: &str) -> Result<Arena<Hast>, CommandError> {
+    satteri_ast::hast::html_fragment_to_wrap_arena(raw).map_err(CommandError::InvalidWrapHtml)
+}
+
+/// Erroring beats silently mis-wrapping when the parser was compiled out.
+#[cfg(not(feature = "from-html"))]
+fn hast_wrap_arena_from_html(_raw: &str) -> Result<Arena<Hast>, CommandError> {
+    Err(CommandError::InvalidWrapHtml(
+        "requires HTML parsing, which this build omits (from-html feature)".to_string(),
+    ))
 }
 
 /// Apply a command buffer to an MDAST arena. Set-property mutations are
@@ -1400,21 +1424,21 @@ pub fn apply_hast_commands_lenient(
             CMD_INSERT_BEFORE => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (new_tree, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::InsertBefore { node_id, new_tree });
             }
 
             CMD_INSERT_AFTER => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (new_tree, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::InsertAfter { node_id, new_tree });
             }
 
             CMD_PREPEND_CHILD => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (child_tree, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::PrependChild {
                     node_id,
                     child_tree,
@@ -1424,7 +1448,7 @@ pub fn apply_hast_commands_lenient(
             CMD_APPEND_CHILD => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (child_tree, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::AppendChild {
                     node_id,
                     child_tree,
@@ -1434,7 +1458,7 @@ pub fn apply_hast_commands_lenient(
             CMD_WRAP => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (parent_tree, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, true)?;
                 patches.push(Patch::Wrap {
                     node_id,
                     parent_tree,
@@ -1444,7 +1468,7 @@ pub fn apply_hast_commands_lenient(
             CMD_REPLACE => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (new_tree, keep_children) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::Replace {
                     node_id,
                     new_tree,
@@ -1455,7 +1479,7 @@ pub fn apply_hast_commands_lenient(
             CMD_SET_CHILDREN => {
                 let node_id = reader.read_anchor(original_len)?;
                 let (new_children, _) =
-                    read_hast_payload(&mut reader, &mut builder, original_len, node_id)?;
+                    read_hast_payload(&mut reader, &mut builder, original_len, node_id, false)?;
                 patches.push(Patch::SetChildren {
                     node_id,
                     new_children,
@@ -2262,5 +2286,67 @@ mod tests {
         b.close_node();
         b.close_node();
         b.finish()
+    }
+
+    /// Push a `PAYLOAD_RAW` structural command (cmd, anchor, flags, string).
+    fn push_raw_command(buf: &mut Vec<u8>, cmd: u8, node_id: u32, raw: &str) {
+        buf.push(cmd);
+        push_u32(buf, node_id);
+        buf.push(PAYLOAD_RAW);
+        buf.push(0); // flags
+        push_u32(buf, raw.len() as u32);
+        buf.extend_from_slice(raw.as_bytes());
+    }
+
+    /// A HAST wrap with a `{rawHtml}` payload parses the fragment into the
+    /// wrapper element: root > section > div.
+    #[cfg(feature = "from-html")]
+    #[test]
+    fn hast_wrap_with_raw_html_payload() {
+        use satteri_ast::hast::codec::decode_element_tag;
+
+        let arena = build_hast_element(&[]);
+        let mut buf = Vec::new();
+        push_raw_command(&mut buf, CMD_WRAP, 1, "<section class=\"wrap\"></section>");
+
+        let result = apply_hast_commands(arena, &buf).unwrap();
+        let section = result.get_children(0)[0];
+        assert_eq!(
+            result.get_str(decode_element_tag(result.get_type_data(section))),
+            "section"
+        );
+        let wrapped = result.get_children(section);
+        assert_eq!(wrapped.len(), 1);
+        assert_eq!(
+            result.get_str(decode_element_tag(result.get_type_data(wrapped[0]))),
+            "div"
+        );
+    }
+
+    /// A `{rawHtml}` wrap payload that isn't a single element errors instead
+    /// of silently mis-wrapping.
+    #[cfg(feature = "from-html")]
+    #[test]
+    fn hast_wrap_with_invalid_raw_html_errors() {
+        let arena = build_hast_element(&[]);
+        let mut buf = Vec::new();
+        push_raw_command(&mut buf, CMD_WRAP, 1, "just text");
+
+        let err = apply_hast_commands(arena, &buf).unwrap_err();
+        assert!(matches!(err, CommandError::InvalidWrapHtml(_)), "{err:?}");
+    }
+
+    /// Raw payloads stay rejected for every HAST command except wrap.
+    #[test]
+    fn hast_raw_payload_rejected_outside_wrap() {
+        let arena = build_hast_element(&[]);
+        let mut buf = Vec::new();
+        push_raw_command(&mut buf, CMD_INSERT_BEFORE, 1, "<span></span>");
+
+        let err = apply_hast_commands(arena, &buf).unwrap_err();
+        assert!(
+            matches!(err, CommandError::UnknownPayloadType(p) if p == PAYLOAD_RAW),
+            "{err:?}"
+        );
     }
 }

--- a/crates/satteri-plugin-api/src/js_commands.rs
+++ b/crates/satteri-plugin-api/src/js_commands.rs
@@ -22,7 +22,8 @@
 
 use satteri_arena::{Arena, ArenaBuilder, ArenaKind, Hast, Mdast, StringRef};
 use satteri_ast::commands::CommandError;
-use satteri_ast::hast::HastNodeType;
+use satteri_ast::hast::codec::decode_element_tag;
+use satteri_ast::hast::{is_void_element, HastNodeType};
 use satteri_ast::mdast::codec::*;
 use satteri_ast::mdast::MdastNodeType;
 use satteri_ast::patch::{Patch, PatchContent, REF_NODE_TYPE};
@@ -1124,6 +1125,31 @@ fn hast_wrap_arena_from_html(_raw: &str) -> Result<Arena<Hast>, CommandError> {
     ))
 }
 
+/// A void wrapper renders as a lone tag, so the wrapped node would never reach
+/// the output. The `{rawHtml}` parser rejects these at parse time; element
+/// payloads carry their tag too, so the same rule applies here.
+fn reject_void_wrap_parent(
+    parent_tree: &PatchContent<Hast>,
+    grafted: &Arena<Hast>,
+) -> Result<(), CommandError> {
+    let (source, wrapper) = match parent_tree {
+        PatchContent::Tree(tree) if !tree.is_empty() => (tree, 0),
+        PatchContent::Grafted(roots) => match roots.first() {
+            Some(&root) => (grafted, root),
+            None => return Ok(()),
+        },
+        PatchContent::Tree(_) => return Ok(()),
+    };
+    if source.get_node(wrapper).node_type != HastNodeType::Element as u8 {
+        return Ok(());
+    }
+    let tag = source.get_str(decode_element_tag(source.get_type_data(wrapper)));
+    if is_void_element(tag) {
+        return Err(CommandError::VoidWrapParent(tag.to_string()));
+    }
+    Ok(())
+}
+
 /// Apply a command buffer to an MDAST arena. Set-property mutations are
 /// applied in-place; structural mutations are collected as `Patch<Mdast>`
 /// objects and applied in place via `apply_patches_in_place`.
@@ -1459,6 +1485,7 @@ pub fn apply_hast_commands_lenient(
                 let node_id = reader.read_anchor(original_len)?;
                 let (parent_tree, _) =
                     read_hast_payload(&mut reader, &mut builder, original_len, node_id, true)?;
+                reject_void_wrap_parent(&parent_tree, builder.arena_mut())?;
                 patches.push(Patch::Wrap {
                     node_id,
                     parent_tree,
@@ -2303,8 +2330,6 @@ mod tests {
     #[cfg(feature = "from-html")]
     #[test]
     fn hast_wrap_with_raw_html_payload() {
-        use satteri_ast::hast::codec::decode_element_tag;
-
         let arena = build_hast_element(&[]);
         let mut buf = Vec::new();
         push_raw_command(&mut buf, CMD_WRAP, 1, "<section class=\"wrap\"></section>");
@@ -2334,6 +2359,58 @@ mod tests {
 
         let err = apply_hast_commands(arena, &buf).unwrap_err();
         assert!(matches!(err, CommandError::InvalidWrapHtml(_)), "{err:?}");
+    }
+
+    /// Push a wrap command whose payload is an op-stream for a single element
+    /// with `tag` — the shape a `{type: "element"}` wrapper compiles to.
+    fn push_element_wrap_command(buf: &mut Vec<u8>, node_id: u32, tag: &str) {
+        let mut ops = Vec::new();
+        ops.push(OP_OPEN);
+        ops.push(HastNodeType::Element as u8);
+        op_str(&mut ops, OF_TAGNAME, tag);
+        ops.push(OP_CLOSE);
+
+        buf.push(CMD_WRAP);
+        push_u32(buf, node_id);
+        buf.push(PAYLOAD_OPSTREAM);
+        push_u32(buf, ops.len() as u32);
+        buf.extend_from_slice(&ops);
+    }
+
+    /// A void element wrapper renders without children, so it is rejected the
+    /// same way a `{rawHtml}` void wrapper is — the wrapped node would vanish.
+    #[test]
+    fn hast_wrap_with_void_element_payload_errors() {
+        let arena = build_hast_element(&[]);
+        let mut buf = Vec::new();
+        push_element_wrap_command(&mut buf, 1, "img");
+
+        let err = apply_hast_commands(arena, &buf).unwrap_err();
+        assert!(
+            matches!(&err, CommandError::VoidWrapParent(tag) if tag == "img"),
+            "{err:?}"
+        );
+    }
+
+    /// The void check leaves ordinary element wrappers alone.
+    #[test]
+    fn hast_wrap_with_element_payload_wraps() {
+        let arena = build_hast_element(&[]);
+        let mut buf = Vec::new();
+        push_element_wrap_command(&mut buf, 1, "section");
+
+        let result = apply_hast_commands(arena, &buf).unwrap();
+        let section = result.get_children(0)[0];
+        assert_eq!(
+            result.get_str(decode_element_tag(result.get_type_data(section))),
+            "section"
+        );
+        let wrapped = result.get_children(section);
+        assert_eq!(wrapped.len(), 1);
+        assert_eq!(
+            result.get_str(decode_element_tag(result.get_type_data(wrapped[0]))),
+            "div"
+        );
     }
 
     /// Raw payloads stay rejected for every HAST command except wrap.

--- a/packages/satteri/src/hast/hast-visitor.ts
+++ b/packages/satteri/src/hast/hast-visitor.ts
@@ -145,11 +145,9 @@ export interface HastVisitorContext {
   /**
    * Wrap `node` in `parentNode`, making it `parentNode`'s first child. Any
    * children `parentNode` declares are kept after it, so a `div` with an anchor
-   * child wraps a heading as `div > [heading, anchor]`. `parentNode` must be a
-   * node type that can hold children (an element or MDX JSX element), or a
-   * `{ rawHtml }` string that parses to exactly one element. Either way the
-   * element must not be a void one (`img`, `br`, …), since a void tag renders
-   * without children and would drop the wrapped node.
+   * child wraps a heading as `div > [heading, anchor]`. `parentNode` is an
+   * element, an MDX JSX element, or `{ rawHtml }` parsing to exactly one
+   * element — never a void element, whose children would not render.
    */
   wrapNode(node: Readonly<HastNode>, parentNode: HastParentContent | RawHtmlHastContent): void;
   prependChild(node: Readonly<HastNode>, childNode: HastContent | HastContent[]): void;
@@ -212,25 +210,21 @@ const requireNid = makeRequireNid(nid);
  *  a `raw` node type, so it needs no raw/rawHtml escape hatch. */
 export type HastContent = HastNode;
 
-/** A `wrapNode` wrapper: a node type that can hold children. Leaves (`text`,
- *  `comment`, `raw`, …) have no slot for the wrapped node, so they cannot wrap. */
+/** A `wrapNode` wrapper: node types that can hold children. */
 export type HastParentContent = Exclude<Extract<HastNode, { children: unknown[] }>, HastRoot>;
 
-/** Raw HTML `wrapNode` wrapper: parsed as an HTML fragment in Rust when the
- *  command applies; must yield exactly one non-void element, which becomes the
- *  wrapper. A fragment that can't wrap fails the apply with the reason. */
+/** Raw HTML `wrapNode` wrapper: parsed at apply time (not call time); must
+ *  yield exactly one non-void element, which becomes the wrapper. */
 export interface RawHtmlHastContent {
   rawHtml: string;
 }
 
-/** HAST node types that can hold children. `wrapNode` allowlist — an
- *  unlisted (new or leaf) type fails loud instead of silently mis-wrapping. */
+/** `wrapNode` allowlist: an unlisted type fails loud instead of silently
+ *  mis-wrapping. */
 const HAST_PARENT_TYPES = ["element", "mdxJsxFlowElement", "mdxJsxTextElement"] as const;
 const HAST_PARENT_TYPE_SET = new Set<string>(HAST_PARENT_TYPES);
 
-/** Fails to compile if the allowlist and {@link HastParentContent} drift apart,
- *  in either direction — a new parent-capable hast type must be listed, and a
- *  listed type must really be parent-capable. */
+/** Compile error if the allowlist and {@link HastParentContent} drift apart. */
 type AssertNever<T extends never> = T;
 type _EveryHastParentIsListed = AssertNever<
   Exclude<HastParentContent["type"], (typeof HAST_PARENT_TYPES)[number]>
@@ -239,8 +233,7 @@ type _EveryListedTypeIsAParent = AssertNever<
   Exclude<(typeof HAST_PARENT_TYPES)[number], HastParentContent["type"]>
 >;
 
-/** Reject wrappers with no place for the wrapped node (leaves) — the patch
- *  engine would degrade them into sibling inserts or drop the node. */
+/** A leaf wrapper would make the patch engine drop or displace the wrapped node. */
 function assertHastWrapParent(parentNode: HastContent): void {
   const type = (parentNode as { type?: unknown }).type;
   if (typeof type === "string" && HAST_PARENT_TYPE_SET.has(type)) return;

--- a/packages/satteri/src/hast/hast-visitor.ts
+++ b/packages/satteri/src/hast/hast-visitor.ts
@@ -147,7 +147,9 @@ export interface HastVisitorContext {
    * children `parentNode` declares are kept after it, so a `div` with an anchor
    * child wraps a heading as `div > [heading, anchor]`. `parentNode` must be a
    * node type that can hold children (an element or MDX JSX element), or a
-   * `{ rawHtml }` string that parses to exactly one non-void element.
+   * `{ rawHtml }` string that parses to exactly one element. Either way the
+   * element must not be a void one (`img`, `br`, …), since a void tag renders
+   * without children and would drop the wrapped node.
    */
   wrapNode(node: Readonly<HastNode>, parentNode: HastParentContent | RawHtmlHastContent): void;
   prependChild(node: Readonly<HastNode>, childNode: HastContent | HastContent[]): void;
@@ -223,13 +225,25 @@ export interface RawHtmlHastContent {
 
 /** HAST node types that can hold children. `wrapNode` allowlist — an
  *  unlisted (new or leaf) type fails loud instead of silently mis-wrapping. */
-const HAST_PARENT_TYPES = new Set<string>(["element", "mdxJsxFlowElement", "mdxJsxTextElement"]);
+const HAST_PARENT_TYPES = ["element", "mdxJsxFlowElement", "mdxJsxTextElement"] as const;
+const HAST_PARENT_TYPE_SET = new Set<string>(HAST_PARENT_TYPES);
+
+/** Fails to compile if the allowlist and {@link HastParentContent} drift apart,
+ *  in either direction — a new parent-capable hast type must be listed, and a
+ *  listed type must really be parent-capable. */
+type AssertNever<T extends never> = T;
+type _EveryHastParentIsListed = AssertNever<
+  Exclude<HastParentContent["type"], (typeof HAST_PARENT_TYPES)[number]>
+>;
+type _EveryListedTypeIsAParent = AssertNever<
+  Exclude<(typeof HAST_PARENT_TYPES)[number], HastParentContent["type"]>
+>;
 
 /** Reject wrappers with no place for the wrapped node (leaves) — the patch
  *  engine would degrade them into sibling inserts or drop the node. */
 function assertHastWrapParent(parentNode: HastContent): void {
   const type = (parentNode as { type?: unknown }).type;
-  if (typeof type === "string" && HAST_PARENT_TYPES.has(type)) return;
+  if (typeof type === "string" && HAST_PARENT_TYPE_SET.has(type)) return;
   throw new Error(
     `wrapNode: "${String(type)}" nodes cannot hold children, so they cannot wrap a node. ` +
       'Wrap in an element instead, e.g. { type: "element", tagName: "div", properties: {}, children: [] } ' +

--- a/packages/satteri/src/hast/hast-visitor.ts
+++ b/packages/satteri/src/hast/hast-visitor.ts
@@ -145,9 +145,11 @@ export interface HastVisitorContext {
   /**
    * Wrap `node` in `parentNode`, making it `parentNode`'s first child. Any
    * children `parentNode` declares are kept after it, so a `div` with an anchor
-   * child wraps a heading as `div > [heading, anchor]`.
+   * child wraps a heading as `div > [heading, anchor]`. `parentNode` must be a
+   * node type that can hold children (an element or MDX JSX element), or a
+   * `{ rawHtml }` string that parses to exactly one non-void element.
    */
-  wrapNode(node: Readonly<HastNode>, parentNode: HastContent): void;
+  wrapNode(node: Readonly<HastNode>, parentNode: HastParentContent | RawHtmlHastContent): void;
   prependChild(node: Readonly<HastNode>, childNode: HastContent | HastContent[]): void;
   appendChild(node: Readonly<HastNode>, childNode: HastContent | HastContent[]): void;
   /** Insert one node or an array at `index`; clamps (`0` or less prepends, past the end appends). */
@@ -207,6 +209,33 @@ const requireNid = makeRequireNid(nid);
 /** New content for a HAST structural mutation. Unlike [`MdastContent`], HAST has
  *  a `raw` node type, so it needs no raw/rawHtml escape hatch. */
 export type HastContent = HastNode;
+
+/** A `wrapNode` wrapper: a node type that can hold children. Leaves (`text`,
+ *  `comment`, `raw`, …) have no slot for the wrapped node, so they cannot wrap. */
+export type HastParentContent = Exclude<Extract<HastNode, { children: unknown[] }>, HastRoot>;
+
+/** Raw HTML `wrapNode` wrapper: parsed as an HTML fragment in Rust when the
+ *  command applies; must yield exactly one non-void element, which becomes the
+ *  wrapper. A fragment that can't wrap fails the apply with the reason. */
+export interface RawHtmlHastContent {
+  rawHtml: string;
+}
+
+/** HAST node types that can hold children. `wrapNode` allowlist — an
+ *  unlisted (new or leaf) type fails loud instead of silently mis-wrapping. */
+const HAST_PARENT_TYPES = new Set<string>(["element", "mdxJsxFlowElement", "mdxJsxTextElement"]);
+
+/** Reject wrappers with no place for the wrapped node (leaves) — the patch
+ *  engine would degrade them into sibling inserts or drop the node. */
+function assertHastWrapParent(parentNode: HastContent): void {
+  const type = (parentNode as { type?: unknown }).type;
+  if (typeof type === "string" && HAST_PARENT_TYPES.has(type)) return;
+  throw new Error(
+    `wrapNode: "${String(type)}" nodes cannot hold children, so they cannot wrap a node. ` +
+      'Wrap in an element instead, e.g. { type: "element", tagName: "div", properties: {}, children: [] } ' +
+      'or { rawHtml: "<div></div>" }.',
+  );
+}
 
 function hastReusedId(node: unknown): number | undefined {
   if (node === null || typeof node !== "object") return undefined;
@@ -369,9 +398,14 @@ class HastVisitorContextImpl implements HastVisitorContext {
     for (const n of asArray(newNode)) emitHastTree(this.#commandBuffer, "insertAfter", id, n);
   }
 
-  wrapNode(node: HastNode, parentNode: HastContent): void {
+  wrapNode(node: HastNode, parentNode: HastParentContent | RawHtmlHastContent): void {
     const id = requireNid(node, "wrapNode");
-    emitHastTree(this.#commandBuffer, "wrapNode", id, parentNode);
+    if (typeof (parentNode as RawHtmlHastContent).rawHtml === "string") {
+      this.#commandBuffer.wrapNode(id, parentNode as RawHtmlHastContent);
+      return;
+    }
+    assertHastWrapParent(parentNode as HastContent);
+    emitHastTree(this.#commandBuffer, "wrapNode", id, parentNode as HastContent);
   }
 
   prependChild(node: HastNode, childNode: HastContent | HastContent[]): void {

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -37,6 +37,8 @@ export type {
   HastVisitorContext,
   HastFilteredVisitor,
   HastContent,
+  HastParentContent,
+  RawHtmlHastContent,
   EstreeProgram,
 } from "./hast/hast-visitor.js";
 
@@ -75,6 +77,7 @@ export type {
   MdastVisitorContext,
   MdastContent,
   MdastTarget,
+  MdastParentContent,
 } from "./mdast/mdast-visitor.js";
 export {
   visitHastHandle,

--- a/packages/satteri/src/mdast/mdast-visitor.ts
+++ b/packages/satteri/src/mdast/mdast-visitor.ts
@@ -123,9 +123,8 @@ export type MdastContent = MdastNode | Custom | RawMdastContent | RawHtmlMdastCo
  *  reached through the `custom` visitor can be passed straight back in. */
 export type MdastTarget = MdastNode | Custom;
 
-/** A `wrapNode` wrapper: a node type that can hold children — a built-in
- *  parent, or a user-defined node declaring a children array. Leaves and raw
- *  strings have no slot for the wrapped node, so they cannot wrap. */
+/** A `wrapNode` wrapper: a built-in parent, or a user-defined node declaring
+ *  a children array. */
 export type MdastParentContent =
   | Exclude<Extract<MdastNode, { children: unknown[] }>, MdastRoot>
   | (Custom & { children: NonNullable<Custom["children"]> });
@@ -880,11 +879,7 @@ function emitMdastTree(
   if (!ok) throw unencodableContentError(content);
 }
 
-/** Reject wrappers with no place for the wrapped node — the patch engine
- *  would degrade them into sibling inserts or drop the node. Built-in leaves
- *  come from the materializer's `LEAF_TYPES`; a user-defined wrapper must be
- *  parent-shaped (declare a children array) so it renders as an element
- *  rather than a text leaf. */
+/** A leaf wrapper would make the patch engine drop or displace the wrapped node. */
 function assertMdastWrapParent(parentNode: MdastContent): void {
   const sandwich =
     'replaceNode(node, [{ type: "html", value: "<div>" }, node, { type: "html", value: "</div>" }])';
@@ -898,8 +893,8 @@ function assertMdastWrapParent(parentNode: MdastContent): void {
   const type = (parentNode as { type?: unknown }).type;
   const tag = typeof type === "string" ? NAME_TO_TYPE[type] : undefined;
   if (tag === undefined) {
-    // User-defined custom node: any string type is valid content, so only the
-    // declared shape distinguishes a parent from a text leaf.
+    // User-defined type: only the declared shape distinguishes a parent from
+    // a text leaf.
     if (Array.isArray((parentNode as Custom).children)) return;
     throw new Error(
       `wrapNode: a user-defined "${String(type)}" wrapper must declare a children array — ` +

--- a/packages/satteri/src/mdast/mdast-visitor.ts
+++ b/packages/satteri/src/mdast/mdast-visitor.ts
@@ -123,6 +123,13 @@ export type MdastContent = MdastNode | Custom | RawMdastContent | RawHtmlMdastCo
  *  reached through the `custom` visitor can be passed straight back in. */
 export type MdastTarget = MdastNode | Custom;
 
+/** A `wrapNode` wrapper: a node type that can hold children — a built-in
+ *  parent, or a user-defined node declaring a children array. Leaves and raw
+ *  strings have no slot for the wrapped node, so they cannot wrap. */
+export type MdastParentContent =
+  | Exclude<Extract<MdastNode, { children: unknown[] }>, MdastRoot>
+  | (Custom & { children: NonNullable<Custom["children"]> });
+
 export interface MdastDiagnostic {
   message: string;
   nodeId?: number | undefined;
@@ -216,10 +223,13 @@ export class MdastVisitorContext {
 
   /**
    * Wrap `node` in `parentNode`, making it `parentNode`'s first child. Any
-   * children `parentNode` declares are kept after it.
+   * children `parentNode` declares are kept after it. `parentNode` must be a
+   * node type that can hold children; to surround a node with raw HTML tags,
+   * use `replaceNode(node, [openTag, node, closeTag])` instead.
    */
-  wrapNode(node: Readonly<MdastTarget>, parentNode: MdastContent): void {
+  wrapNode(node: Readonly<MdastTarget>, parentNode: MdastParentContent): void {
     const id = requireNid(node as MdastNode, "wrapNode");
+    assertMdastWrapParent(parentNode);
     emitMdastTree(this.#commandBuffer, "wrapNode", id, parentNode);
   }
 
@@ -868,6 +878,40 @@ function emitMdastTree(
     emitMdastOp(buffer, content, true, forReplace),
   );
   if (!ok) throw unencodableContentError(content);
+}
+
+/** Reject wrappers with no place for the wrapped node — the patch engine
+ *  would degrade them into sibling inserts or drop the node. Built-in leaves
+ *  come from the materializer's `LEAF_TYPES`; a user-defined wrapper must be
+ *  parent-shaped (declare a children array) so it renders as an element
+ *  rather than a text leaf. */
+function assertMdastWrapParent(parentNode: MdastContent): void {
+  const sandwich =
+    'replaceNode(node, [{ type: "html", value: "<div>" }, node, { type: "html", value: "</div>" }])';
+  if (isRawMdastContent(parentNode)) {
+    throw new Error(
+      "wrapNode: raw content cannot wrap a node. Pass a parent node such as " +
+        `{ type: "blockquote", children: [] }, surround the node with tags: ${sandwich}, ` +
+        "or wrap at the HAST phase, where wrapNode accepts { rawHtml }.",
+    );
+  }
+  const type = (parentNode as { type?: unknown }).type;
+  const tag = typeof type === "string" ? NAME_TO_TYPE[type] : undefined;
+  if (tag === undefined) {
+    // User-defined custom node: any string type is valid content, so only the
+    // declared shape distinguishes a parent from a text leaf.
+    if (Array.isArray((parentNode as Custom).children)) return;
+    throw new Error(
+      `wrapNode: a user-defined "${String(type)}" wrapper must declare a children array — ` +
+        "a leaf-shaped custom node renders as text and cannot hold the wrapped node.",
+    );
+  }
+  if (!LEAF_TYPES.has(tag)) return;
+  throw new Error(
+    `wrapNode: "${String(type)}" nodes cannot hold children, so they cannot wrap a node. ` +
+      `Surround the node with tags instead: ${sandwich}, or wrap at the HAST phase, ` +
+      "where wrapNode accepts elements and { rawHtml }.",
+  );
 }
 
 /** MDAST node types whose `value` Rust can set in place via setProperty. A

--- a/packages/satteri/test/hast-visitor.test.ts
+++ b/packages/satteri/test/hast-visitor.test.ts
@@ -13,7 +13,7 @@ import { defineHastPlugin } from "../src/plugin.js";
 import { dropHandle } from "../src/index.js";
 import { collect } from "./fixtures.js";
 import type { HastNode } from "../src/hast/hast-materializer.js";
-import type { HastVisitorContext } from "../src/hast/hast-visitor.js";
+import type { HastParentContent, HastVisitorContext } from "../src/hast/hast-visitor.js";
 import type { Element, ElementContent, Text } from "hast";
 import type { Position } from "unist";
 
@@ -375,6 +375,73 @@ describe("visitHastHandle - mutations", () => {
     };
     const subs = resolveSubscriptions(plugin);
     expect(() => visitHastHandle(handle, plugin, subs, source, undefined)).toThrow(/void element/);
+  });
+
+  // Same rule as the rawHtml wrapper: a void tag renders without children, so
+  // the wrapped node would never reach the output.
+  test("context.wrapNode() rejects a void element node as the wrapper", () => {
+    for (const tagName of ["img", "br"]) {
+      const { handle, source } = setup("# Hello");
+      const plugin = {
+        element: {
+          filter: ["h1"],
+          visit(node: HastNode, ctx: HastVisitorContext) {
+            ctx.wrapNode(node, { type: "element", tagName, properties: {}, children: [] });
+          },
+        },
+      };
+      const subs = resolveSubscriptions(plugin);
+      expect(() => visitHastHandle(handle, plugin, subs, source, undefined)).toThrow(
+        /void element/,
+      );
+    }
+  });
+
+  // Runtime companion to the compile-time parity check in hast-visitor.ts:
+  // every parent-capable type is accepted by the wrapNode allowlist.
+  test("context.wrapNode() accepts every parent-capable HAST type", () => {
+    const wrappers: HastParentContent[] = [
+      { type: "element", tagName: "div", properties: {}, children: [] },
+      { type: "mdxJsxFlowElement", name: "Box", attributes: [], children: [] },
+      { type: "mdxJsxTextElement", name: "Badge", attributes: [], children: [] },
+    ];
+    for (const wrapper of wrappers) {
+      const { handle, source } = setup("# Hello");
+      const plugin = {
+        element: {
+          filter: ["h1"],
+          visit(node: HastNode, ctx: HastVisitorContext) {
+            expect(() => ctx.wrapNode(node, wrapper)).not.toThrow();
+          },
+        },
+      };
+      visitHastHandle(handle, plugin, resolveSubscriptions(plugin), source, undefined);
+    }
+  });
+
+  test("context.wrapNode() wraps a node in an MDX JSX element", () => {
+    const handle = createMdxHastHandle("# Hello\n");
+    const source = getHandleSource(handle);
+    const plugin = {
+      element: {
+        filter: ["h1"],
+        visit(node: HastNode, ctx: HastVisitorContext) {
+          ctx.wrapNode(node, {
+            type: "mdxJsxFlowElement",
+            name: "Callout",
+            attributes: [],
+            children: [],
+          });
+        },
+      },
+    };
+    visitHastHandle(handle, plugin, resolveSubscriptions(plugin), source, undefined);
+    const tree = materializeHastTree(new HastReader(serializeHandle(handle)));
+    const jsx = findHastNode(tree, "mdxJsxFlowElement");
+    if (jsx?.type !== "mdxJsxFlowElement") throw new Error("expected mdxJsxFlowElement");
+    expect(jsx.name).toBe("Callout");
+    const wrapped = jsx.children[0];
+    expect(wrapped?.type === "element" && wrapped.tagName).toBe("h1");
   });
 
   // Regression (issue #182): a leaf wrapper (raw/text) has no slot for the

--- a/packages/satteri/test/hast-visitor.test.ts
+++ b/packages/satteri/test/hast-visitor.test.ts
@@ -309,6 +309,99 @@ describe("visitHastHandle - mutations", () => {
     );
   });
 
+  test("context.wrapNode() accepts a rawHtml wrapper, parsed to an element", () => {
+    const { handle, source } = setup("# Hello");
+    const plugin = {
+      element: {
+        filter: ["h1"],
+        visit(node: HastNode, ctx: HastVisitorContext) {
+          ctx.wrapNode(node, { rawHtml: '<div class="callout"></div>' });
+        },
+      },
+    };
+    const subs = resolveSubscriptions(plugin);
+    visitHastHandle(handle, plugin, subs, source, undefined);
+    const html = renderHandle(handle);
+    expect(html).toContain('<div class="callout"><h1>Hello</h1></div>');
+  });
+
+  test("context.wrapNode() keeps a rawHtml wrapper's own children after the wrapped node", () => {
+    const { handle, source } = setup("# Hello");
+    const plugin = {
+      element: {
+        filter: ["h1"],
+        visit(node: HastNode, ctx: HastVisitorContext) {
+          ctx.wrapNode(node, { rawHtml: '<div><a href="#hello">#</a></div>' });
+        },
+      },
+    };
+    const subs = resolveSubscriptions(plugin);
+    visitHastHandle(handle, plugin, subs, source, undefined);
+    const html = renderHandle(handle);
+    expect(html).toContain('<div><h1>Hello</h1><a href="#hello">#</a></div>');
+  });
+
+  // The wrapper must be a single element: anything else has no defined slot
+  // for the wrapped node, so the apply fails with the reason.
+  test("context.wrapNode() rejects rawHtml that is not exactly one element", () => {
+    for (const rawHtml of ["just text", "<i></i><b></b>", ""]) {
+      const { handle, source } = setup("# Hello");
+      const plugin = {
+        element: {
+          filter: ["h1"],
+          visit(node: HastNode, ctx: HastVisitorContext) {
+            ctx.wrapNode(node, { rawHtml });
+          },
+        },
+      };
+      const subs = resolveSubscriptions(plugin);
+      expect(() => visitHastHandle(handle, plugin, subs, source, undefined)).toThrow(
+        /exactly one element/,
+      );
+    }
+  });
+
+  // A void wrapper's children never render, which would silently drop the
+  // wrapped node at output time.
+  test("context.wrapNode() rejects a void element as rawHtml wrapper", () => {
+    const { handle, source } = setup("# Hello");
+    const plugin = {
+      element: {
+        filter: ["h1"],
+        visit(node: HastNode, ctx: HastVisitorContext) {
+          ctx.wrapNode(node, { rawHtml: '<img src="x.png">' });
+        },
+      },
+    };
+    const subs = resolveSubscriptions(plugin);
+    expect(() => visitHastHandle(handle, plugin, subs, source, undefined)).toThrow(/void element/);
+  });
+
+  // Regression (issue #182): a leaf wrapper (raw/text) has no slot for the
+  // wrapped node — it used to silently drop or displace it.
+  test("context.wrapNode() rejects a leaf node as the wrapper", () => {
+    const { handle, source } = setup("# Hello");
+    const plugin = {
+      element: {
+        filter: ["h1"],
+        visit(node: HastNode, ctx: HastVisitorContext) {
+          expect(() =>
+            // @ts-expect-error raw is a leaf, not a wrapNode parent
+            ctx.wrapNode(node, { type: "raw", value: "<div></div>" }),
+          ).toThrow(/cannot hold children/);
+          expect(() =>
+            // @ts-expect-error text is a leaf, not a wrapNode parent
+            ctx.wrapNode(node, { type: "text", value: "x" }),
+          ).toThrow(/cannot hold children/);
+        },
+      },
+    };
+    const subs = resolveSubscriptions(plugin);
+    visitHastHandle(handle, plugin, subs, source, undefined);
+    const html = renderHandle(handle);
+    expect(html).toContain("<h1>Hello</h1>");
+  });
+
   test("context.appendChild() adds a child to an element", () => {
     const { handle, source } = setup("# Hello");
     const plugin = {

--- a/packages/satteri/test/hast-visitor.test.ts
+++ b/packages/satteri/test/hast-visitor.test.ts
@@ -341,8 +341,6 @@ describe("visitHastHandle - mutations", () => {
     expect(html).toContain('<div><h1>Hello</h1><a href="#hello">#</a></div>');
   });
 
-  // The wrapper must be a single element: anything else has no defined slot
-  // for the wrapped node, so the apply fails with the reason.
   test("context.wrapNode() rejects rawHtml that is not exactly one element", () => {
     for (const rawHtml of ["just text", "<i></i><b></b>", ""]) {
       const { handle, source } = setup("# Hello");
@@ -361,8 +359,6 @@ describe("visitHastHandle - mutations", () => {
     }
   });
 
-  // A void wrapper's children never render, which would silently drop the
-  // wrapped node at output time.
   test("context.wrapNode() rejects a void element as rawHtml wrapper", () => {
     const { handle, source } = setup("# Hello");
     const plugin = {
@@ -377,8 +373,6 @@ describe("visitHastHandle - mutations", () => {
     expect(() => visitHastHandle(handle, plugin, subs, source, undefined)).toThrow(/void element/);
   });
 
-  // Same rule as the rawHtml wrapper: a void tag renders without children, so
-  // the wrapped node would never reach the output.
   test("context.wrapNode() rejects a void element node as the wrapper", () => {
     for (const tagName of ["img", "br"]) {
       const { handle, source } = setup("# Hello");
@@ -397,8 +391,7 @@ describe("visitHastHandle - mutations", () => {
     }
   });
 
-  // Runtime companion to the compile-time parity check in hast-visitor.ts:
-  // every parent-capable type is accepted by the wrapNode allowlist.
+  // Runtime companion to the compile-time parity check in hast-visitor.ts.
   test("context.wrapNode() accepts every parent-capable HAST type", () => {
     const wrappers: HastParentContent[] = [
       { type: "element", tagName: "div", properties: {}, children: [] },
@@ -444,8 +437,7 @@ describe("visitHastHandle - mutations", () => {
     expect(wrapped?.type === "element" && wrapped.tagName).toBe("h1");
   });
 
-  // Regression (issue #182): a leaf wrapper (raw/text) has no slot for the
-  // wrapped node — it used to silently drop or displace it.
+  // Regression #182: a leaf wrapper silently dropped or displaced the node.
   test("context.wrapNode() rejects a leaf node as the wrapper", () => {
     const { handle, source } = setup("# Hello");
     const plugin = {

--- a/packages/satteri/test/visitor.test.ts
+++ b/packages/satteri/test/visitor.test.ts
@@ -304,8 +304,7 @@ test("context.wrapNode() wraps a node in a parent", () => {
   expect(html).toMatch(/<blockquote>.*<h1>/s);
 });
 
-// Regression (issue #182): an html leaf as the wrapper used to silently drop
-// or displace the wrapped node instead of wrapping it.
+// Regression #182: a leaf wrapper silently dropped or displaced the node.
 test("context.wrapNode() rejects a leaf node as the wrapper", () => {
   const html = visitAndRender("# Hello\n\nWorld", {
     heading(node: MdastNode, ctx: MdastVisitorContext) {
@@ -322,8 +321,8 @@ test("context.wrapNode() rejects a leaf node as the wrapper", () => {
   expect(html).toMatch(/<h1>Hello<\/h1>/);
 });
 
-// Regression (issue #182): a raw payload used to wrap in the parse root,
-// placing the parsed content after the node instead of around it.
+// Regression #182: a raw payload wrapped in the parse root, landing the
+// parsed content after the node.
 test("context.wrapNode() rejects raw content as the wrapper", () => {
   const html = visitAndRender("# Hello\n\nWorld", {
     heading(node: MdastNode, ctx: MdastVisitorContext) {
@@ -340,8 +339,6 @@ test("context.wrapNode() rejects raw content as the wrapper", () => {
   expect(html).toMatch(/<h1>Hello<\/h1>/);
 });
 
-// A parent-shaped custom node is a valid wrapper: it renders as an element
-// through data.hName with the wrapped node inside.
 test("context.wrapNode() accepts a user-defined parent node", () => {
   const html = visitAndRender("# Hello\n\nWorld", {
     heading(node: MdastNode, ctx: MdastVisitorContext) {
@@ -355,8 +352,6 @@ test("context.wrapNode() accepts a user-defined parent node", () => {
   expect(html).toContain('<aside class="callout"><h1>Hello</h1></aside>');
 });
 
-// The plain shape issue #182 asked for: a custom wrapper with no hName still
-// renders as a <div> around the node.
 test("context.wrapNode() wraps a node in a bare user-defined parent", () => {
   const html = visitAndRender("# Hello", {
     heading(node: MdastNode, ctx: MdastVisitorContext) {
@@ -366,9 +361,8 @@ test("context.wrapNode() wraps a node in a bare user-defined parent", () => {
   expect(html).toContain("<div><h1>Hello</h1></div>");
 });
 
-// Hand-written lists rather than the materializer's LEAF_TYPES the check reads,
-// so a type misclassified for wrapping surfaces here instead of as a dropped
-// node at render time.
+// Lists are hand-written on purpose — independent of the LEAF_TYPES the check
+// reads, so a misclassified type surfaces here.
 test("context.wrapNode() accepts built-in parents and rejects built-in leaves", () => {
   const parents: MdastParentContent[] = [
     { type: "paragraph", children: [] },

--- a/packages/satteri/test/visitor.test.ts
+++ b/packages/satteri/test/visitor.test.ts
@@ -3,6 +3,7 @@ import {
   visitMdastHandle,
   resolveMdastSubscriptions,
   type MdastHandle,
+  type MdastParentContent,
   type MdastVisitorContext,
 } from "../src/mdast/mdast-visitor.js";
 import type { HastHandle } from "../src/hast/hast-visitor.js";
@@ -352,6 +353,70 @@ test("context.wrapNode() accepts a user-defined parent node", () => {
     },
   });
   expect(html).toContain('<aside class="callout"><h1>Hello</h1></aside>');
+});
+
+// The plain shape issue #182 asked for: a custom wrapper with no hName still
+// renders as a <div> around the node.
+test("context.wrapNode() wraps a node in a bare user-defined parent", () => {
+  const html = visitAndRender("# Hello", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      ctx.wrapNode(node, { type: "wrapper", children: [] });
+    },
+  });
+  expect(html).toContain("<div><h1>Hello</h1></div>");
+});
+
+// Hand-written lists rather than the materializer's LEAF_TYPES the check reads,
+// so a type misclassified for wrapping surfaces here instead of as a dropped
+// node at render time.
+test("context.wrapNode() accepts built-in parents and rejects built-in leaves", () => {
+  const parents: MdastParentContent[] = [
+    { type: "paragraph", children: [] },
+    { type: "heading", depth: 2, children: [] },
+    { type: "blockquote", children: [] },
+    { type: "list", children: [] },
+    { type: "listItem", children: [] },
+    { type: "table", children: [] },
+    { type: "tableRow", children: [] },
+    { type: "tableCell", children: [] },
+    { type: "emphasis", children: [] },
+    { type: "strong", children: [] },
+    { type: "delete", children: [] },
+    { type: "link", url: "#", children: [] },
+    { type: "footnoteDefinition", identifier: "a", children: [] },
+    { type: "containerDirective", name: "note", children: [] },
+    { type: "descriptionList", children: [] },
+    { type: "superscript", children: [] },
+  ];
+  const leaves = [
+    "thematicBreak",
+    "html",
+    "code",
+    "definition",
+    "text",
+    "inlineCode",
+    "break",
+    "image",
+    "imageReference",
+    "footnoteReference",
+    "yaml",
+    "toml",
+    "math",
+    "inlineMath",
+  ];
+  visitAndRender("# Hello", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      for (const parent of parents) {
+        expect(() => ctx.wrapNode(node, parent), parent.type).not.toThrow();
+      }
+      for (const type of leaves) {
+        expect(
+          () => ctx.wrapNode(node, { type, value: "" } as unknown as MdastParentContent),
+          type,
+        ).toThrow(/cannot hold children/);
+      }
+    },
+  });
 });
 
 test("context.wrapNode() rejects a leaf-shaped custom wrapper", () => {

--- a/packages/satteri/test/visitor.test.ts
+++ b/packages/satteri/test/visitor.test.ts
@@ -303,6 +303,69 @@ test("context.wrapNode() wraps a node in a parent", () => {
   expect(html).toMatch(/<blockquote>.*<h1>/s);
 });
 
+// Regression (issue #182): an html leaf as the wrapper used to silently drop
+// or displace the wrapped node instead of wrapping it.
+test("context.wrapNode() rejects a leaf node as the wrapper", () => {
+  const html = visitAndRender("# Hello\n\nWorld", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      expect(() =>
+        // @ts-expect-error html is a leaf, not a wrapNode parent
+        ctx.wrapNode(node, { type: "html", value: "<div></div>" }),
+      ).toThrow(/cannot hold children/);
+      expect(() =>
+        // @ts-expect-error text is a leaf, not a wrapNode parent
+        ctx.wrapNode(node, { type: "text", value: "x" }),
+      ).toThrow(/cannot hold children/);
+    },
+  });
+  expect(html).toMatch(/<h1>Hello<\/h1>/);
+});
+
+// Regression (issue #182): a raw payload used to wrap in the parse root,
+// placing the parsed content after the node instead of around it.
+test("context.wrapNode() rejects raw content as the wrapper", () => {
+  const html = visitAndRender("# Hello\n\nWorld", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      expect(() =>
+        // @ts-expect-error raw content is not a wrapNode parent
+        ctx.wrapNode(node, { rawHtml: "<div></div>" }),
+      ).toThrow(/raw content cannot wrap/);
+      expect(() =>
+        // @ts-expect-error raw content is not a wrapNode parent
+        ctx.wrapNode(node, { raw: "> quoted" }),
+      ).toThrow(/raw content cannot wrap/);
+    },
+  });
+  expect(html).toMatch(/<h1>Hello<\/h1>/);
+});
+
+// A parent-shaped custom node is a valid wrapper: it renders as an element
+// through data.hName with the wrapped node inside.
+test("context.wrapNode() accepts a user-defined parent node", () => {
+  const html = visitAndRender("# Hello\n\nWorld", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      ctx.wrapNode(node, {
+        type: "callout",
+        data: { hName: "aside", hProperties: { className: ["callout"] } },
+        children: [],
+      });
+    },
+  });
+  expect(html).toContain('<aside class="callout"><h1>Hello</h1></aside>');
+});
+
+test("context.wrapNode() rejects a leaf-shaped custom wrapper", () => {
+  const html = visitAndRender("# Hello\n\nWorld", {
+    heading(node: MdastNode, ctx: MdastVisitorContext) {
+      expect(() =>
+        // @ts-expect-error a custom wrapper must declare a children array
+        ctx.wrapNode(node, { type: "marker", value: "x" }),
+      ).toThrow(/children array/);
+    },
+  });
+  expect(html).toMatch(/<h1>Hello<\/h1>/);
+});
+
 test("context.replaceNode() replaces a node via context method", () => {
   const html = visitAndRender("# Hello\n\nWorld", {
     heading(node: MdastNode, ctx: MdastVisitorContext) {

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -327,7 +327,7 @@ declare module "satteri" {
 
 `wrapNode` places the wrapped node as `parentNode`'s **first** child. If `parentNode` declares its own children, they are kept after it. Wrapping a heading in a `<div>` that holds an anchor link yields `<div><h2>…</h2><a>…</a></div>`. To put the node at an arbitrary position instead, return a replacement from the visitor.
 
-`parentNode` must be a node type that can hold children — a HAST element, an MDX JSX element, an MDAST container like `blockquote`, or a [custom node](#custom-nodes) declaring a `children` array. Leaf nodes (`html`, `text`, …) and leaf-shaped custom nodes have no slot for the wrapped node, so `wrapNode` rejects them.
+`parentNode` must be a node type that can hold children — a HAST element, an MDX JSX element, an MDAST container like `blockquote`, or a [custom node](#custom-nodes) declaring a `children` array. Leaf nodes (`html`, `text`, …) and leaf-shaped custom nodes have no slot for the wrapped node, so `wrapNode` rejects them. A void HAST element (`img`, `br`, …) is rejected for the same reason: it renders as a lone tag, so its children would never reach the output.
 
 In a HAST plugin, `wrapNode` also accepts a raw HTML string. It is parsed as an HTML fragment and must yield exactly one non-void element, which becomes the wrapper (its own children are kept after the wrapped node):
 
@@ -340,6 +340,8 @@ In an MDAST plugin there is no element node to parse into, so raw strings are re
 ```ts
 ctx.replaceNode(node, [{ type: "html", value: "<div>" }, node, { type: "html", value: "</div>" }]);
 ```
+
+`wrapNode` is deliberately the odd one out on both sides: it is the only MDAST mutation that refuses `{ raw }` / `{ rawHtml }` (a parsed string has no single slot to wrap with), and the only HAST mutation that accepts `{ rawHtml }` (the other HAST mutations take real nodes, and `raw` is a HAST node type of its own).
 
 `replaceNode`, `insertBefore`, `insertAfter`, `prependChild`, `appendChild`, and `insertChildAt` each accept either a single node or an array of nodes. An array is inserted in order at the target position, so `replaceNode(node, [a, b])` leaves `a` and `b` where `node` was. Passing `replaceNode` an empty array removes the node.
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -327,6 +327,20 @@ declare module "satteri" {
 
 `wrapNode` places the wrapped node as `parentNode`'s **first** child. If `parentNode` declares its own children, they are kept after it. Wrapping a heading in a `<div>` that holds an anchor link yields `<div><h2>…</h2><a>…</a></div>`. To put the node at an arbitrary position instead, return a replacement from the visitor.
 
+`parentNode` must be a node type that can hold children — a HAST element, an MDX JSX element, an MDAST container like `blockquote`, or a [custom node](#custom-nodes) declaring a `children` array. Leaf nodes (`html`, `text`, …) and leaf-shaped custom nodes have no slot for the wrapped node, so `wrapNode` rejects them.
+
+In a HAST plugin, `wrapNode` also accepts a raw HTML string. It is parsed as an HTML fragment and must yield exactly one non-void element, which becomes the wrapper (its own children are kept after the wrapped node):
+
+```ts
+ctx.wrapNode(node, { rawHtml: '<div class="callout"></div>' });
+```
+
+In an MDAST plugin there is no element node to parse into, so raw strings are rejected there. To surround an MDAST node with raw HTML tags, replace it with the tag halves around itself instead:
+
+```ts
+ctx.replaceNode(node, [{ type: "html", value: "<div>" }, node, { type: "html", value: "</div>" }]);
+```
+
 `replaceNode`, `insertBefore`, `insertAfter`, `prependChild`, `appendChild`, and `insertChildAt` each accept either a single node or an array of nodes. An array is inserted in order at the target position, so `replaceNode(node, [a, b])` leaves `a` and `b` where `node` was. Passing `replaceNode` an empty array removes the node.
 
 For MDAST, `key` must be a field of the node type and `value` must match that field's type. For HAST, `key` is a `string` and `value` is `unknown`.


### PR DESCRIPTION
Fixes #182