### PR TITLE
feat(plugin-api): plugin options accept nested arrays of plugins

### DIFF
--- a/.sampo/changesets/mixed-plugin-list-narrowing.md
+++ b/.sampo/changesets/mixed-plugin-list-narrowing.md
@@ -2,4 +2,4 @@
 npm/satteri: patch
 ---
 
-Fixed `markdownToHtml` and `mdxToJs` being typed as synchronous when a plugin list mixed sync and async plugins. The result is now correctly typed as a `Promise`.
+Fixed `markdownToHtml`, `mdxToJs` and `markdownToJs` being typed as synchronous when a plugin list mixed sync and async plugins. The result is now correctly typed as a `Promise`.

--- a/.sampo/changesets/mixed-plugin-list-narrowing.md
+++ b/.sampo/changesets/mixed-plugin-list-narrowing.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Fixed `markdownToHtml` and `mdxToJs` being typed as synchronous when a plugin list mixed sync and async plugins. The result is now correctly typed as a `Promise`.

--- a/.sampo/changesets/plugin-bundles.md
+++ b/.sampo/changesets/plugin-bundles.md
@@ -3,7 +3,7 @@ npm/satteri: minor
 npm/vite-plugin-satteri: minor
 ---
 
-Added support for nested arrays in `mdastPlugins` and `hastPlugins`, so a package can export a bundle of plugins that you pass without spreading it. A bundle's plugins run in their own order, at the bundle's position.
+Added support for nested arrays in `mdastPlugins` and `hastPlugins`, so a package can export a bundle of plugins that you pass without spreading it. A bundle's plugins run in their own order, at the bundle's position. A factory can return a bundle as well as a single plugin, giving its plugins state they share with each other and reset per document.
 
 ```js
 import { typography } from "some-package"; // an array of plugins

--- a/.sampo/changesets/plugin-bundles.md
+++ b/.sampo/changesets/plugin-bundles.md
@@ -1,0 +1,12 @@
+---
+npm/satteri: minor
+npm/vite-plugin-satteri: minor
+---
+
+Added support for nested arrays in `mdastPlugins` and `hastPlugins`, so a package can export a bundle of plugins that you pass without spreading it. A bundle's plugins run in their own order, at the bundle's position.
+
+```js
+import { typography } from "some-package"; // an array of plugins
+
+markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
+```

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -620,7 +620,7 @@ type ResolveInput<P, D extends readonly unknown[] = [0, 0, 0, 0, 0, 0, 0, 0]> = 
   ? P extends ReadonlyArray<infer Item>
     ? ResolveInput<Item, Rest>
     : P extends () => infer Def
-      ? Def
+      ? ResolveInput<Def, Rest>
       : P
   : never;
 type AnyInputAsync<Ps> =
@@ -648,8 +648,8 @@ export function markdownToHtml(
   options: CompileOptions = {},
 ): MarkdownToHtmlResult | Promise<MarkdownToHtmlResult> {
   const { features, fileURL, data = {} } = options;
-  const mdastPlugins = normalizePlugins(options.mdastPlugins ?? []);
-  const hastPlugins = normalizePlugins(options.hastPlugins ?? []);
+  const mdastPlugins = normalizePlugins(options.mdastPlugins ?? [], "mdastPlugins");
+  const hastPlugins = normalizePlugins(options.hastPlugins ?? [], "hastPlugins");
   const hastMayHaveStubs = hastPlugins.length > 0;
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =
     featuresToNative(features);
@@ -827,8 +827,8 @@ function toJsImpl(
     data = {},
     ...mdxFields
   } = options;
-  const mdastPlugins = normalizePlugins(mdastInput);
-  const hastPlugins = normalizePlugins(hastInput);
+  const mdastPlugins = normalizePlugins(mdastInput, "mdastPlugins");
+  const hastPlugins = normalizePlugins(hastInput, "hastPlugins");
   const hastMayHaveStubs = hastPlugins.length > 0;
   const mdxOptions = mdxOptionsToNative(mdxFields);
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -604,10 +604,29 @@ type FieldIsAsync<V> = V extends AnyFn
 type AnyVisitorAsync<P> = {
   [K in keyof P]-?: FieldIsAsync<NonNullable<P[K]>>;
 }[keyof P];
-type IsPluginAsync<P> = true extends AnyVisitorAsync<P> ? true : false;
+// Distributes over P: `true extends AnyVisitorAsync<P>` alone would not, since
+// the checked type is `true` rather than P. Without distribution a list of
+// plugins with differing visitor keys collapses to `keyof` their intersection,
+// hiding the async visitor and typing a mixed list as sync.
+type IsPluginAsync<P> = P extends unknown
+  ? true extends AnyVisitorAsync<P>
+    ? true
+    : false
+  : never;
 // Nested entries are flattened first so a bundle's plugins are inspected too.
-type ResolveInput<P> =
-  P extends ReadonlyArray<infer Item> ? ResolveInput<Item> : P extends () => infer D ? D : P;
+// Depth-capped because `PluginEntry` is recursive: an uncapped walk never
+// terminates on a value typed as the alias itself (a forwarded plugin list),
+// which TS reports as "type instantiation is excessively deep".
+type ResolveInput<P, D extends readonly unknown[] = [0, 0, 0, 0, 0, 0, 0, 0]> = D extends readonly [
+  unknown,
+  ...infer Rest,
+]
+  ? P extends ReadonlyArray<infer Item>
+    ? ResolveInput<Item, Rest>
+    : P extends () => infer Def
+      ? Def
+      : P
+  : never;
 type AnyInputAsync<Ps> =
   Ps extends ReadonlyArray<infer P>
     ? true extends IsPluginAsync<ResolveInput<P>>

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -462,13 +462,10 @@ export interface Features {
 }
 
 export interface CompileOptions {
-  /**
-   * MDAST plugins, in run order. An entry may be a nested array, letting a
-   * package export a bundle that is passed through as-is; its plugins run in
-   * their own order at the bundle's position.
-   */
+  /** MDAST plugins, in run order. A nested array runs its own plugins, in
+   *  their own order, at the array's position. */
   mdastPlugins?: MdastPluginList;
-  /** HAST plugins, in run order. Nests the same way as `mdastPlugins`. */
+  /** HAST plugins, in run order. Nests like `mdastPlugins`. */
   hastPlugins?: HastPluginList;
   features?: Features;
   /**
@@ -604,19 +601,18 @@ type FieldIsAsync<V> = V extends AnyFn
 type AnyVisitorAsync<P> = {
   [K in keyof P]-?: FieldIsAsync<NonNullable<P[K]>>;
 }[keyof P];
-// Distributes over P: `true extends AnyVisitorAsync<P>` alone would not, since
-// the checked type is `true` rather than P. Without distribution a list of
-// plugins with differing visitor keys collapses to `keyof` their intersection,
-// hiding the async visitor and typing a mixed list as sync.
+// `P extends unknown` forces distribution; `true extends AnyVisitorAsync<P>`
+// alone would not, since the checked type is `true` rather than P. Undistributed,
+// a union of plugins with differing visitor keys collapses to their common keys
+// and the async visitor goes unseen.
 type IsPluginAsync<P> = P extends unknown
   ? true extends AnyVisitorAsync<P>
     ? true
     : false
   : never;
-// Nested entries are flattened first so a bundle's plugins are inspected too.
 // Depth-capped because `PluginEntry` is recursive: an uncapped walk never
-// terminates on a value typed as the alias itself (a forwarded plugin list),
-// which TS reports as "type instantiation is excessively deep".
+// terminates on a value typed as the alias itself, which TS rejects outright as
+// "type instantiation is excessively deep".
 type ResolveInput<P, D extends readonly unknown[] = [0, 0, 0, 0, 0, 0, 0, 0]> = D extends readonly [
   unknown,
   ...infer Rest,

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -10,11 +10,12 @@ import {
   type MdastHandle,
   type MdastPluginInstance,
 } from "./mdast/mdast-visitor.js";
+import { normalizePlugins } from "./plugin.js";
 import type {
   MdastPluginDefinition,
   HastPluginDefinition,
-  MdastPluginInput,
-  HastPluginInput,
+  MdastPluginList,
+  HastPluginList,
 } from "./plugin.js";
 import {
   applyCommandsAndCompileHandle,
@@ -153,7 +154,7 @@ function warnDroppedTransforms(
 
 function runMdastPluginsOnHandle(
   handle: MdastHandle,
-  plugins: MdastPluginInput[],
+  plugins: MdastPluginDefinition[],
   fileURL: URL | undefined,
   data: Data,
   sourceFormat: SourceFormat,
@@ -194,8 +195,7 @@ function runMdastPluginsOnHandle(
   let i = 0;
   const runNext = (): MdastPipelineResult | Promise<MdastPipelineResult> => {
     while (i < plugins.length) {
-      const raw = plugins[i++]!;
-      const plugin: MdastPluginDefinition = typeof raw === "function" ? raw() : raw;
+      const plugin = plugins[i++]!;
       const r = runPlugin(plugin as MdastPluginInstance, i === plugins.length);
       if (r instanceof Promise) return r.then(runNext);
     }
@@ -225,7 +225,7 @@ const NO_HAST_COMMANDS: CollectedHastCommands = {
  *  (`render` or `compile`), saving one NAPI roundtrip per compile. */
 function runHastPluginsCollectLast(
   handle: HastHandle,
-  plugins: HastPluginInput[],
+  plugins: HastPluginDefinition[],
   source: string,
   fileURL: URL | undefined,
   data: Data,
@@ -234,10 +234,9 @@ function runHastPluginsCollectLast(
   let i = 0;
   const runNext = (): CollectedHastCommands | Promise<CollectedHastCommands> => {
     while (i < plugins.length) {
-      const raw = plugins[i]!;
+      const plugin = plugins[i]!;
       const isLast = i === plugins.length - 1;
       i++;
-      const plugin: HastPluginDefinition = typeof raw === "function" ? raw() : raw;
       const subs = resolveSubscriptions(plugin);
 
       if (isLast) {
@@ -463,8 +462,14 @@ export interface Features {
 }
 
 export interface CompileOptions {
-  mdastPlugins?: MdastPluginInput[];
-  hastPlugins?: HastPluginInput[];
+  /**
+   * MDAST plugins, in run order. An entry may be a nested array, letting a
+   * package export a bundle that is passed through as-is; its plugins run in
+   * their own order at the bundle's position.
+   */
+  mdastPlugins?: MdastPluginList;
+  /** HAST plugins, in run order. Nests the same way as `mdastPlugins`. */
+  hastPlugins?: HastPluginList;
   features?: Features;
   /**
    * The document being processed, surfaced to plugins as `ctx.fileURL`. Must
@@ -600,7 +605,9 @@ type AnyVisitorAsync<P> = {
   [K in keyof P]-?: FieldIsAsync<NonNullable<P[K]>>;
 }[keyof P];
 type IsPluginAsync<P> = true extends AnyVisitorAsync<P> ? true : false;
-type ResolveInput<P> = P extends () => infer D ? D : P;
+// Nested entries are flattened first so a bundle's plugins are inspected too.
+type ResolveInput<P> =
+  P extends ReadonlyArray<infer Item> ? ResolveInput<Item> : P extends () => infer D ? D : P;
 type AnyInputAsync<Ps> =
   Ps extends ReadonlyArray<infer P>
     ? true extends IsPluginAsync<ResolveInput<P>>
@@ -626,8 +633,8 @@ export function markdownToHtml(
   options: CompileOptions = {},
 ): MarkdownToHtmlResult | Promise<MarkdownToHtmlResult> {
   const { features, fileURL, data = {} } = options;
-  let mdastPlugins: MdastPluginInput[] = options.mdastPlugins ?? [];
-  let hastPlugins: HastPluginInput[] = options.hastPlugins ?? [];
+  const mdastPlugins = normalizePlugins(options.mdastPlugins ?? []);
+  const hastPlugins = normalizePlugins(options.hastPlugins ?? []);
   const hastMayHaveStubs = hastPlugins.length > 0;
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =
     featuresToNative(features);
@@ -640,15 +647,10 @@ export function markdownToHtml(
     return { html, frontmatter: (frontmatter as Frontmatter | null | undefined) ?? null, data };
   }
 
-  // Resolve plugin factories once. An instance is itself a valid plugin input,
-  // so the run helpers below consume the resolved arrays unchanged. Track source
-  // positions only when some plugin opts in with `position: true`; otherwise the
-  // parse skips the LineIndex build and per-node line/column lookups.
-  mdastPlugins = mdastPlugins.map((p) => (typeof p === "function" ? p() : p));
-  hastPlugins = hastPlugins.map((p) => (typeof p === "function" ? p() : p));
+  // Track source positions only when some plugin opts in with `position: true`;
+  // otherwise the parse skips the LineIndex build and per-node line/column lookups.
   const trackPositions =
-    mdastPlugins.some((p) => (p as MdastPluginDefinition).options?.position) ||
-    hastPlugins.some((p) => (p as HastPluginDefinition).options?.position);
+    mdastPlugins.some((p) => p.options?.position) || hastPlugins.some((p) => p.options?.position);
 
   // Fused tail for MDAST-plugins-only (no HAST plugins): after the MDAST
   // plugin pass returns its pending commands, apply + convert + render all
@@ -810,8 +812,8 @@ function toJsImpl(
     data = {},
     ...mdxFields
   } = options;
-  let mdastPlugins: MdastPluginInput[] = mdastInput;
-  let hastPlugins: HastPluginInput[] = hastInput;
+  const mdastPlugins = normalizePlugins(mdastInput);
+  const hastPlugins = normalizePlugins(hastInput);
   const hastMayHaveStubs = hastPlugins.length > 0;
   const mdxOptions = mdxOptionsToNative(mdxFields);
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =
@@ -830,13 +832,9 @@ function toJsImpl(
     return { code, frontmatter: (frontmatter as Frontmatter | null | undefined) ?? null, data };
   }
 
-  // Resolve plugin factories once and track positions only when a plugin opts
-  // in (see `markdownToHtml` for the rationale).
-  mdastPlugins = mdastPlugins.map((p) => (typeof p === "function" ? p() : p));
-  hastPlugins = hastPlugins.map((p) => (typeof p === "function" ? p() : p));
+  // Track positions only when a plugin opts in (see `markdownToHtml`).
   const trackPositions =
-    mdastPlugins.some((p) => (p as MdastPluginDefinition).options?.position) ||
-    hastPlugins.some((p) => (p as HastPluginDefinition).options?.position);
+    mdastPlugins.some((p) => p.options?.position) || hastPlugins.some((p) => p.options?.position);
 
   // MDAST-plugins-only fused tail (no HAST plugins): apply + extract
   // frontmatter + convert + simplify + compile happen in one NAPI call.
@@ -1003,7 +1001,7 @@ function readFrontmatter(handle: MdastHandle): Frontmatter | null {
  *  the yaml/toml node are reflected in the returned value. */
 function createHastHandleFromMdast(
   source: string,
-  mdastPlugins: MdastPluginInput[],
+  mdastPlugins: MdastPluginDefinition[],
   mdx: boolean,
   fileURL: URL | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -32,6 +32,10 @@ export type {
   HastPluginDefinition,
   MdastPluginInput,
   HastPluginInput,
+  MdastPluginEntry,
+  HastPluginEntry,
+  MdastPluginList,
+  HastPluginList,
 } from "./plugin.js";
 
 // Visitor types (for plugin authors)

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -17,7 +17,7 @@ export type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinit
  */
 export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
 
-type PluginEntry<D> = D | (() => D) | readonly PluginEntry<D>[];
+type PluginEntry<D> = D | (() => PluginEntry<D>) | readonly PluginEntry<D>[];
 
 /** Entry accepted by `mdastPlugins`. */
 export type MdastPluginEntry = PluginEntry<MdastPluginDefinition>;
@@ -31,18 +31,34 @@ export type MdastPluginList = readonly MdastPluginEntry[];
 /** Value accepted by the `hastPlugins` option. */
 export type HastPluginList = readonly HastPluginEntry[];
 
+/** Bounds factory-in-factory nesting. Real presets nest one level; anything
+ *  deeper is a factory that leads back to itself, which would otherwise recurse
+ *  until the stack overflows. */
+const MAX_FACTORY_DEPTH = 10;
+
 /** The one place a plugin option becomes the definition array the pipeline
  *  runs. Factories resolve here and nowhere else, so each is called once per
  *  compile no matter how deeply it is nested. */
-export function normalizePlugins<D>(entries: readonly PluginEntry<D>[]): D[] {
+export function normalizePlugins<D>(entries: readonly PluginEntry<D>[], option: string): D[] {
   const out: D[] = [];
-  const walk = (list: readonly PluginEntry<D>[]): void => {
-    for (const entry of list) {
-      if (Array.isArray(entry)) walk(entry as readonly PluginEntry<D>[]);
-      else out.push(typeof entry === "function" ? (entry as () => D)() : (entry as D));
+  const walk = (entry: PluginEntry<D>, factoryDepth: number): void => {
+    if (Array.isArray(entry)) {
+      for (const item of entry as readonly PluginEntry<D>[]) walk(item, factoryDepth);
+      return;
     }
+    if (typeof entry === "function") {
+      if (factoryDepth === 0) {
+        throw new Error(
+          `${option}: plugin factory nesting is too deep — a factory most likely returns itself. ` +
+            `A factory may return a plugin or a list of plugins, but that list must not lead back to the same factory.`,
+        );
+      }
+      walk((entry as () => PluginEntry<D>)(), factoryDepth - 1);
+      return;
+    }
+    out.push(entry as D);
   };
-  walk(entries);
+  for (const entry of entries) walk(entry, MAX_FACTORY_DEPTH);
   return out;
 }
 

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -17,13 +17,12 @@ export type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinit
  */
 export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
 
-/** A plugin input, or a nested list of them, at any depth. */
 type PluginEntry<D> = D | (() => D) | readonly PluginEntry<D>[];
 
-/** Entry accepted by `mdastPlugins`: a plugin input, or a bundle of them. */
+/** Entry accepted by `mdastPlugins`. */
 export type MdastPluginEntry = PluginEntry<MdastPluginDefinition>;
 
-/** Entry accepted by `hastPlugins`: a plugin input, or a bundle of them. */
+/** Entry accepted by `hastPlugins`. */
 export type HastPluginEntry = PluginEntry<HastPluginDefinition>;
 
 /** Value accepted by the `mdastPlugins` option. */
@@ -32,9 +31,9 @@ export type MdastPluginList = readonly MdastPluginEntry[];
 /** Value accepted by the `hastPlugins` option. */
 export type HastPluginList = readonly HastPluginEntry[];
 
-/** Flatten nested plugin lists and resolve factories, in order, so a bundle's
- *  plugins run where the bundle sits. The one place a plugin option becomes
- *  the definition array the pipeline runs. */
+/** The one place a plugin option becomes the definition array the pipeline
+ *  runs. Factories resolve here and nowhere else, so each is called once per
+ *  compile no matter how deeply it is nested. */
 export function normalizePlugins<D>(entries: readonly PluginEntry<D>[]): D[] {
   const out: D[] = [];
   const walk = (list: readonly PluginEntry<D>[]): void => {

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -6,16 +6,46 @@ export type MdastPluginDefinition = MdastPluginInstance & { name: string };
 export type HastPluginDefinition = HastVisitorInstance & { name: string };
 
 /**
- * Entry accepted by `mdastPlugins`: a definition reused across documents,
- * or a factory called once per compile so closures reset per document.
+ * A definition reused across documents, or a factory called once per compile
+ * so closures reset per document.
  */
 export type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinition);
 
 /**
- * Entry accepted by `hastPlugins`: a definition reused across documents,
- * or a factory called once per compile so closures reset per document.
+ * A definition reused across documents, or a factory called once per compile
+ * so closures reset per document.
  */
 export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
+
+/** A plugin input, or a nested list of them, at any depth. */
+type PluginEntry<D> = D | (() => D) | readonly PluginEntry<D>[];
+
+/** Entry accepted by `mdastPlugins`: a plugin input, or a bundle of them. */
+export type MdastPluginEntry = PluginEntry<MdastPluginDefinition>;
+
+/** Entry accepted by `hastPlugins`: a plugin input, or a bundle of them. */
+export type HastPluginEntry = PluginEntry<HastPluginDefinition>;
+
+/** Value accepted by the `mdastPlugins` option. */
+export type MdastPluginList = readonly MdastPluginEntry[];
+
+/** Value accepted by the `hastPlugins` option. */
+export type HastPluginList = readonly HastPluginEntry[];
+
+/** Flatten nested plugin lists and resolve factories, in order, so a bundle's
+ *  plugins run where the bundle sits. The one place a plugin option becomes
+ *  the definition array the pipeline runs. */
+export function normalizePlugins<D>(entries: readonly PluginEntry<D>[]): D[] {
+  const out: D[] = [];
+  const walk = (list: readonly PluginEntry<D>[]): void => {
+    for (const entry of list) {
+      if (Array.isArray(entry)) walk(entry as readonly PluginEntry<D>[]);
+      else out.push(typeof entry === "function" ? (entry as () => D)() : (entry as D));
+    }
+  };
+  walk(entries);
+  return out;
+}
 
 // Generic so the inferred plugin type preserves each visitor's *actual* return
 // type. That lets the compile entry points distinguish sync plugins from async

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -97,6 +97,60 @@ describe("nested plugin lists", () => {
     expect(calls).toBe(2);
   });
 
+  test("a factory may return a bundle, flattened in place", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [
+        recordMdast(order, "a"),
+        () => [recordMdast(order, "b"), [recordMdast(order, "c")]],
+        recordMdast(order, "d"),
+      ],
+    });
+
+    expect(order).toEqual(["a", "b", "c", "d"]);
+  });
+
+  // The point of allowing it: plugins in one bundle can share state that resets
+  // per document, which an array of separate factories cannot express.
+  test("a factory returning a bundle gives its plugins shared per-compile state", () => {
+    const snapshots: string[][] = [];
+    const preset = () => {
+      const headings: string[] = [];
+      return [
+        defineMdastPlugin({
+          name: "collect",
+          heading(node) {
+            const child = node.children[0];
+            if (child?.type === "text") headings.push(child.value);
+          },
+        }),
+        defineMdastPlugin({
+          name: "report",
+          paragraph() {
+            snapshots.push([...headings]);
+          },
+        }),
+      ];
+    };
+
+    markdownToHtml("# One\n\npara", { mdastPlugins: [preset] });
+    markdownToHtml("# Two\n\npara", { mdastPlugins: [preset] });
+
+    expect(snapshots).toEqual([["One"], ["Two"]]);
+  });
+
+  test("a factory that returns itself is rejected, naming the option", () => {
+    const cyclic = (): unknown[] => [cyclic];
+
+    expect(() => markdownToHtml("# T", { mdastPlugins: [cyclic as never] })).toThrowError(
+      /^mdastPlugins: plugin factory nesting is too deep/,
+    );
+    expect(() => markdownToHtml("# T", { hastPlugins: [cyclic as never] })).toThrowError(
+      /^hastPlugins: plugin factory nesting is too deep/,
+    );
+  });
+
   test("mutations from a bundled plugin are applied", () => {
     const removeHeadings = defineMdastPlugin({
       name: "remove-headings",

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -25,6 +25,14 @@ function recordHast(order: string[], name: string) {
   });
 }
 
+const asyncBundled = defineMdastPlugin({
+  name: "async-bundled",
+  async code() {
+    await new Promise((r) => setTimeout(r, 1));
+    return { rawHtml: "<pre>done</pre>" };
+  },
+});
+
 describe("nested plugin lists", () => {
   test("a bundle runs in its own order at the bundle's position (mdast)", () => {
     const order: string[] = [];
@@ -141,18 +149,23 @@ describe("nested plugin lists", () => {
   });
 
   test("an async plugin inside a bundle still narrows the result to a Promise", async () => {
-    const asyncPlugin = defineMdastPlugin({
-      name: "async-bundled",
-      async code() {
-        await new Promise((r) => setTimeout(r, 1));
-        return { rawHtml: "<pre>done</pre>" };
-      },
-    });
-
     const result: Promise<MarkdownToHtmlResult> = markdownToHtml("```\nhi\n```", {
-      mdastPlugins: [[asyncPlugin]],
+      mdastPlugins: [[asyncBundled]],
     });
 
     expect((await result).html).toContain("done");
+  });
+
+  // The narrowing is asserted at compile time in `src/compile.ts` (tests are not
+  // typechecked); this covers the runtime half.
+  test("a bundle mixing sync and async plugins returns a Promise", async () => {
+    const order: string[] = [];
+    const result: Promise<MarkdownToHtmlResult> = markdownToHtml("# T\n\n```\nhi\n```", {
+      mdastPlugins: [[recordMdast(order, "sync"), asyncBundled]],
+    });
+
+    expect(result).toBeInstanceOf(Promise);
+    expect((await result).html).toContain("done");
+    expect(order).toEqual(["sync"]);
   });
 });

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "vitest";
-import { markdownToHtml, mdxToJs, defineMdastPlugin, defineHastPlugin } from "../src/index.js";
+import {
+  markdownToHtml,
+  markdownToJs,
+  mdxToJs,
+  defineMdastPlugin,
+  defineHastPlugin,
+} from "../src/index.js";
 import type { MarkdownToHtmlResult } from "../src/index.js";
 
 /** Records its name on each heading, making run order observable. */
@@ -195,6 +201,85 @@ describe("nested plugin lists", () => {
     expect(code).not.toContain("Gone");
     expect(code).toContain("Kept");
     expect(order).toEqual(["first", "remove", "hast"]);
+  });
+
+  test("bundles work in markdownToJs", () => {
+    const order: string[] = [];
+    const removeHeadings = defineMdastPlugin({
+      name: "remove-headings",
+      heading(node, ctx) {
+        order.push("remove");
+        ctx.removeNode(node);
+      },
+    });
+
+    const { code } = markdownToJs("# Gone\n\nKept", {
+      mdastPlugins: [[recordMdast(order, "first"), removeHeadings]],
+      hastPlugins: [[recordHast(order, "hast")]],
+    });
+
+    expect(code).not.toContain("Gone");
+    expect(code).toContain("Kept");
+    expect(order).toEqual(["first", "remove", "hast"]);
+  });
+
+  // markdownToJs shares its pipeline with mdxToJs but parses as Markdown, so
+  // the bundle has to survive the non-MDX branch too.
+  test("a bundled plugin sees Markdown, not MDX, in markdownToJs", () => {
+    const seen: string[] = [];
+    const collect = defineMdastPlugin({
+      name: "collect-text",
+      text(node) {
+        seen.push(node.value);
+      },
+    });
+
+    const { code } = markdownToJs("{not an expression}", { mdastPlugins: [[collect]] });
+
+    expect(seen).toEqual(["{not an expression}"]);
+    expect(code).toContain("not an expression");
+  });
+
+  // Ordering across a bundle boundary has to hold for custom nodes too: the
+  // second plugin only sees the node because the first one already ran.
+  test("a bundled plugin sees the custom node an earlier one in the bundle created", () => {
+    const seen: string[] = [];
+    const create = defineMdastPlugin({
+      name: "create-section",
+      paragraph(node, ctx) {
+        ctx.replaceNode(node, {
+          type: "section",
+          data: { hName: "section" },
+          children: node.children,
+        });
+      },
+    });
+    const observe = defineMdastPlugin({
+      name: "observe-section",
+      custom(node, ctx) {
+        seen.push(node.type);
+        ctx.setProperty(node, "data", { hName: "aside" });
+      },
+    });
+
+    const { html } = markdownToHtml("hi", { mdastPlugins: [[create, observe]] });
+
+    expect(seen).toEqual(["section"]);
+    expect(html).toContain("<aside>");
+  });
+
+  test("wrapNode from inside a bundle wraps with a parent node", () => {
+    const wrap = defineMdastPlugin({
+      name: "wrap-heading",
+      heading(node, ctx) {
+        ctx.wrapNode(node, { type: "blockquote", children: [] });
+      },
+    });
+
+    const { html } = markdownToHtml("# Title", { mdastPlugins: [[wrap]] });
+
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<h1>Title</h1>");
   });
 
   test("an async plugin inside a bundle still narrows the result to a Promise", async () => {

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import { markdownToHtml, mdxToJs, defineMdastPlugin, defineHastPlugin } from "../src/index.js";
 import type { MarkdownToHtmlResult } from "../src/index.js";
 
-/** Records its own name when it visits a heading, so plugin order is observable. */
+/** Records its name on each heading, making run order observable. */
 function recordMdast(order: string[], name: string) {
   return defineMdastPlugin({
     name,
@@ -88,12 +88,7 @@ describe("nested plugin lists", () => {
     let calls = 0;
     const factory = () => {
       calls++;
-      return defineMdastPlugin({
-        name: "counted",
-        heading() {
-          // observe only
-        },
-      });
+      return defineMdastPlugin({ name: "counted", heading() {} });
     };
 
     markdownToHtml("# A", { mdastPlugins: [[factory]] });
@@ -156,8 +151,6 @@ describe("nested plugin lists", () => {
     expect((await result).html).toContain("done");
   });
 
-  // The narrowing is asserted at compile time in `src/compile.ts` (tests are not
-  // typechecked); this covers the runtime half.
   test("a bundle mixing sync and async plugins returns a Promise", async () => {
     const order: string[] = [];
     const result: Promise<MarkdownToHtmlResult> = markdownToHtml("# T\n\n```\nhi\n```", {

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "vitest";
+import { markdownToHtml, mdxToJs, defineMdastPlugin, defineHastPlugin } from "../src/index.js";
+import type { MarkdownToHtmlResult } from "../src/index.js";
+
+/** Records its own name when it visits a heading, so plugin order is observable. */
+function recordMdast(order: string[], name: string) {
+  return defineMdastPlugin({
+    name,
+    heading() {
+      order.push(name);
+    },
+  });
+}
+
+/** HAST counterpart of `recordMdast`. */
+function recordHast(order: string[], name: string) {
+  return defineHastPlugin({
+    name,
+    element: {
+      filter: ["h1", "p"],
+      visit() {
+        order.push(name);
+      },
+    },
+  });
+}
+
+describe("nested plugin lists", () => {
+  test("a bundle runs in its own order at the bundle's position (mdast)", () => {
+    const order: string[] = [];
+    const bundle = [recordMdast(order, "b"), recordMdast(order, "c")];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [recordMdast(order, "a"), bundle, recordMdast(order, "d")],
+    });
+
+    expect(order).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("a bundle runs in its own order at the bundle's position (hast)", () => {
+    const order: string[] = [];
+    const bundle = [recordHast(order, "b"), recordHast(order, "c")];
+
+    markdownToHtml("# Title", {
+      hastPlugins: [recordHast(order, "a"), bundle, recordHast(order, "d")],
+    });
+
+    expect(order).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("bundles nest to arbitrary depth", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [
+        recordMdast(order, "a"),
+        [recordMdast(order, "b"), [recordMdast(order, "c"), [recordMdast(order, "d")]]],
+        recordMdast(order, "e"),
+      ],
+    });
+
+    expect(order).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("a readonly bundle is accepted", () => {
+    const order: string[] = [];
+    const bundle = [recordMdast(order, "a"), recordMdast(order, "b")] as const;
+
+    markdownToHtml("# Title", { mdastPlugins: [bundle] });
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("empty and empty-nested lists compile as if no plugins were passed", () => {
+    const result = markdownToHtml("# Title", { mdastPlugins: [[], [[]]], hastPlugins: [[]] });
+    expect(result.html).toContain("<h1>Title</h1>");
+  });
+
+  test("factories inside a bundle are invoked once per compile", () => {
+    let calls = 0;
+    const factory = () => {
+      calls++;
+      return defineMdastPlugin({
+        name: "counted",
+        heading() {
+          // observe only
+        },
+      });
+    };
+
+    markdownToHtml("# A", { mdastPlugins: [[factory]] });
+    markdownToHtml("# B", { mdastPlugins: [[factory]] });
+
+    expect(calls).toBe(2);
+  });
+
+  test("mutations from a bundled plugin are applied", () => {
+    const removeHeadings = defineMdastPlugin({
+      name: "remove-headings",
+      heading(node, ctx) {
+        ctx.removeNode(node);
+      },
+    });
+    const addId = defineHastPlugin({
+      name: "add-id",
+      element: {
+        filter: ["p"],
+        visit(node, ctx) {
+          ctx.setProperty(node, "id", "bundled");
+        },
+      },
+    });
+
+    const { html } = markdownToHtml("# Gone\n\nKept", {
+      mdastPlugins: [[removeHeadings]],
+      hastPlugins: [[addId]],
+    });
+
+    expect(html).not.toContain("Gone");
+    expect(html).toContain('id="bundled"');
+  });
+
+  test("bundles work in mdxToJs", () => {
+    const order: string[] = [];
+    const removeHeadings = defineMdastPlugin({
+      name: "remove-headings",
+      heading(node, ctx) {
+        order.push("remove");
+        ctx.removeNode(node);
+      },
+    });
+
+    const { code } = mdxToJs("# Gone\n\nKept", {
+      mdastPlugins: [[recordMdast(order, "first"), removeHeadings]],
+      hastPlugins: [[recordHast(order, "hast")]],
+    });
+
+    expect(code).not.toContain("Gone");
+    expect(code).toContain("Kept");
+    expect(order).toEqual(["first", "remove", "hast"]);
+  });
+
+  test("an async plugin inside a bundle still narrows the result to a Promise", async () => {
+    const asyncPlugin = defineMdastPlugin({
+      name: "async-bundled",
+      async code() {
+        await new Promise((r) => setTimeout(r, 1));
+        return { rawHtml: "<pre>done</pre>" };
+      },
+    });
+
+    const result: Promise<MarkdownToHtmlResult> = markdownToHtml("```\nhi\n```", {
+      mdastPlugins: [[asyncPlugin]],
+    });
+
+    expect((await result).html).toContain("done");
+  });
+});

--- a/packages/vite-plugin-satteri/package.json
+++ b/packages/vite-plugin-satteri/package.json
@@ -46,7 +46,7 @@
     "vitest": "^4"
   },
   "peerDependencies": {
-    "satteri": ">=0.4.0",
+    "satteri": ">=0.10.0",
     "vite": "^5 || ^6 || ^7 || ^8"
   }
 }

--- a/packages/vite-plugin-satteri/src/index.ts
+++ b/packages/vite-plugin-satteri/src/index.ts
@@ -5,8 +5,8 @@ import type {
   CompileOptions,
   Features,
   Frontmatter,
-  HastPluginInput,
-  MdastPluginInput,
+  HastPluginList,
+  MdastPluginList,
   MdxCompileOptions,
   MdxOnlyOptions,
 } from "satteri";
@@ -38,9 +38,9 @@ export interface VitePluginSatteriOptions {
   mdx?: boolean | MdxOptions;
 
   /** MDAST plugins applied before HAST conversion. Shared across .md and .mdx. */
-  mdastPlugins?: MdastPluginInput[];
+  mdastPlugins?: MdastPluginList;
   /** HAST plugins applied before rendering / MDX compile. Shared across .md and .mdx. */
-  hastPlugins?: HastPluginInput[];
+  hastPlugins?: HastPluginList;
   /** Parser feature toggles (gfm, frontmatter, math, …). Shared across .md and .mdx. */
   features?: Features;
 }

--- a/website/content/docs/options.md
+++ b/website/content/docs/options.md
@@ -9,13 +9,13 @@ Options for Sätteri's [entry points](/docs/entry-points/). `CompileOptions` is 
 
 ## CompileOptions
 
-| Option         | Type                 | Notes                                                                       |
-| -------------- | -------------------- | --------------------------------------------------------------------------- |
-| `mdastPlugins` | `MdastPluginInput[]` | MDAST plugins, or factories that return one. See [Plugins](/docs/plugins/). |
-| `hastPlugins`  | `HastPluginInput[]`  | HAST plugins, or factories.                                                 |
-| `features`     | `Features`           | Parser extensions. See [Features](/docs/features/).                         |
-| `fileURL`      | `URL`                | The document's URL, surfaced to plugins as `ctx.fileURL`.                   |
-| `data`         | `Data`               | Initial [data bag](#data).                                                  |
+| Option         | Type              | Notes                                                                                         |
+| -------------- | ----------------- | --------------------------------------------------------------------------------------------- |
+| `mdastPlugins` | `MdastPluginList` | MDAST plugins, factories that return one, or arrays of either. See [Plugins](/docs/plugins/). |
+| `hastPlugins`  | `HastPluginList`  | HAST plugins, factories, or arrays of either.                                                 |
+| `features`     | `Features`        | Parser extensions. See [Features](/docs/features/).                                           |
+| `fileURL`      | `URL`             | The document's URL, surfaced to plugins as `ctx.fileURL`.                                     |
+| `data`         | `Data`            | Initial [data bag](#data).                                                                    |
 
 ### fileURL
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -39,7 +39,7 @@ Factories are called once per invocation, so closures reset between documents.
 An entry may also be an array of entries, at any depth, so a package can export a bundle of plugins that is passed straight through:
 
 ```ts
-type MdastPluginEntry = MdastPluginInput | readonly MdastPluginEntry[];
+type MdastPluginEntry = MdastPluginDefinition | (() => MdastPluginEntry) | readonly MdastPluginEntry[];
 type MdastPluginList = readonly MdastPluginEntry[];
 ```
 
@@ -50,6 +50,19 @@ markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
 ```
 
 The bundle's plugins run in their own order, at the bundle's position — the list above is equivalent to spreading `typography` in place. `HastPluginEntry` and `HastPluginList` are the HAST-side equivalents.
+
+A factory may return a bundle as well as a single plugin. That is how a preset gives its plugins state that is shared between them but still reset per document:
+
+```js
+const headingAnchors = () => {
+  const slugs = new Set(); // one set per compile, shared by both plugins below
+  return [collectSlugs(slugs), linkSlugs(slugs)];
+};
+
+markdownToHtml(source, { mdastPlugins: [headingAnchors] });
+```
+
+A factory that returns itself, directly or through a bundle, throws rather than recursing.
 
 ### Source positions
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -36,6 +36,21 @@ type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
 
 Factories are called once per invocation, so closures reset between documents.
 
+An entry may also be an array of entries, at any depth, so a package can export a bundle of plugins that is passed straight through:
+
+```ts
+type MdastPluginEntry = MdastPluginInput | readonly MdastPluginEntry[];
+type MdastPluginList = readonly MdastPluginEntry[];
+```
+
+```js
+import { typography } from "some-package"; // an array of plugins
+
+markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
+```
+
+The bundle's plugins run in their own order, at the bundle's position — the list above is equivalent to spreading `typography` in place. `HastPluginEntry` and `HastPluginList` are the HAST-side equivalents.
+
 ### Source positions
 
 Visitors read `node.position` (the `{ start, end }` source range) only when the plugin opts in with `options: { position: true }`. Tracking positions adds a measurable parsing cost (~15% of parse), so it is off by default. `node.position` is `undefined` unless some plugin in the pipeline requests it.

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -62,7 +62,6 @@ const headingAnchors = () => {
 markdownToHtml(source, { mdastPlugins: [headingAnchors] });
 ```
 
-A factory that returns itself, directly or through a bundle, throws rather than recursing.
 
 ### Source positions
 

--- a/website/content/docs/plugins.md
+++ b/website/content/docs/plugins.md
@@ -116,4 +116,6 @@ markdownToHtml(source, {
 
 The bundle's plugins keep their own order and run at the bundle's position, so the above is the same as `[...typography, unwrapImages]`.
 
+A factory can return a bundle too, which gives the plugins in it state that they share with each other but that still resets for every document.
+
 If you need to share state between visits (e.g. collecting a table of contents), close over a variable in the surrounding scope and read it back after `markdownToHtml` returns.

--- a/website/content/docs/plugins.md
+++ b/website/content/docs/plugins.md
@@ -104,4 +104,16 @@ markdownToHtml(source, {
 });
 ```
 
+An entry can also be an array of plugins, nested as deeply as you like. A package can therefore export a bundle of plugins that you pass without spreading:
+
+```js
+import { typography } from "some-package"; // an array of plugins
+
+markdownToHtml(source, {
+  mdastPlugins: [typography, unwrapImages],
+});
+```
+
+The bundle's plugins keep their own order and run at the bundle's position, so the above is the same as `[...typography, unwrapImages]`.
+
 If you need to share state between visits (e.g. collecting a table of contents), close over a variable in the surrounding scope and read it back after `markdownToHtml` returns.

--- a/website/content/docs/vite.md
+++ b/website/content/docs/vite.md
@@ -83,8 +83,8 @@ By default, the plugin compiles MDX with `development: true` in `serve` so React
 | -------------- | ----------------------- | ------- | -------------------------------------------------------------- |
 | `markdown`     | `boolean`               | `true`  | Process `.md` files.                                           |
 | `mdx`          | `boolean \| MdxOptions` | `true`  | Process `.mdx` files. Pass an object to configure the compile. |
-| `mdastPlugins` | `MdastPluginInput[]`    | —       | MDAST-stage plugins, shared across `.md` and `.mdx`.           |
-| `hastPlugins`  | `HastPluginInput[]`     | —       | HAST-stage plugins, shared across `.md` and `.mdx`.            |
+| `mdastPlugins` | `MdastPluginList`       | —       | MDAST-stage plugins, shared across `.md` and `.mdx`.           |
+| `hastPlugins`  | `HastPluginList`        | —       | HAST-stage plugins, shared across `.md` and `.mdx`.            |
 | `features`     | `Features`              | —       | Parser toggles. See [Features](/docs/features/).               |
 
 `MdxOptions` mirrors Sätteri's MDX options minus `outputFormat`. The plugin always emits an ES module so Vite can import it.


### PR DESCRIPTION
`mdastPlugins` and `hastPlugins` now accept nested arrays of plugins, so a bundle of plugins can be passed directly without spreading it.