### PR TITLE
test(autolink): add the distilled GFM autolink conformance suite

### DIFF
--- a/packages/satteri/test/conformance/autolink-contexts.test.ts
+++ b/packages/satteri/test/conformance/autolink-contexts.test.ts
@@ -1,0 +1,541 @@
+// Distilled from a hand-crafted GFM autolink differential matrix (3,234 cases,
+// families A–L) run against `remark-parse` + `remark-gfm`. Every case kept here is
+// one the committed suite did not already exercise, and one whose behaviour no
+// other kept case repeats: where the matrix enumerated a rule over a vocabulary,
+// only the members that sit on a boundary of that rule survive.
+//
+// Each row carries the URLs satteri must produce, so a row that stops linking —
+// or starts linking something new — fails on its own terms and not only through
+// the tree comparison.
+//
+// This half covers autolinks in context: the constructs that contain them, the
+// constructs they collide with, line endings, and bracket state.
+
+import { describe, test, expect } from "vitest";
+import {
+  assertExtMdastConformance,
+  assertMdastConformance,
+  referenceMdast,
+  satteriMathMdast,
+  satteriMdast,
+} from "./helpers.js";
+
+interface AnyNode {
+  type: string;
+  url?: string;
+  children?: AnyNode[];
+}
+
+/** Every `link` URL in document order. */
+function collectUrls(tree: unknown): string[] {
+  const out: string[] = [];
+  const walk = (node: AnyNode): void => {
+    if (node.type === "link") out.push(String(node.url));
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(tree as AnyNode);
+  return out;
+}
+
+function linkUrls(md: string): string[] {
+  return collectUrls(satteriMdast(md));
+}
+
+/** The tree matches remark, and the autolinks are the ones named. */
+function conforms(md: string, urls: string[]): void {
+  assertMdastConformance(md);
+  expect(linkUrls(md), JSON.stringify(md)).toEqual(urls);
+}
+
+// Family D — containing constructs. One case per construct, with a second inner
+// only where the inner changes the answer.
+//
+// The two `_`-delimited rows wrap an email whose local part starts with `_`, so the
+// opening delimiter and the local part compete for the same character.
+describe("family D: containing constructs — emphasis", () => {
+  test.each([
+    ["*www.example.com*\n", ["http://www.example.com"]],
+    ["**www.example.com**\n", ["http://www.example.com"]],
+    ["~~www.example.com~~\n", ["http://www.example.com"]],
+    ["~www.example.com~\n", ["http://www.example.com"]],
+    ["__u@example.com_\n", ["mailto:u@example.com"]],
+    ["___u@example.com__\n", ["mailto:u@example.com"]],
+    ["*www.example.com\n", ["http://www.example.com"]],
+    ["**www.example.com*\n", ["http://www.example.com"]],
+    ["a *www.example.com* b\n", ["http://www.example.com"]],
+    ["~~a www.example.com~~ b\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — code spans", () => {
+  test.each([
+    ["`www.example.com`\n", []],
+    ["``www.example.com``\n", []],
+    ["`a` www.example.com\n", ["http://www.example.com"]],
+    ["`a www.example.com\n", ["http://www.example.com"]],
+    ["a` www.example.com `b\n", []],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — links and images", () => {
+  test.each([
+    ["[www.example.com](/dest)\n", ["/dest"]],
+    ["[a](www.example.com)\n", ["www.example.com"]],
+    ["[a](http://example.com/p)\n", ["http://example.com/p"]],
+    ['[a](/dest "www.example.com")\n', ["/dest"]],
+    ["[a](<www.example.com>)\n", ["www.example.com"]],
+    ["![www.example.com](/dest)\n", []],
+    ["![a](www.example.com)\n", []],
+    ["[www.example.com][ref]\n\n[ref]: /d\n", []],
+    ["[ref][www.example.com]\n\n[ref]: /d\n", ["http://www.example.com"]],
+    ["[www.example.com]\n\n[www.example.com]: /d\n", []],
+    ["[a]: www.example.com\n\n[a]\n", []],
+    ['[a]: /d "www.example.com"\n\n[a]\n', []],
+    ["[a][]\n\n[a]: www.example.com\n", []],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — the `](URL)x` overrun", () => {
+  test.each([
+    ["[a](www.example.com)x\n", ["www.example.com"]],
+    ["[a](/d)www.example.com\n", ["/d", "http://www.example.com"]],
+    ["[a](/d)xwww.example.com\n", ["/d"]],
+    ["[a](/d)xuser@example.com\n", ["/d", "mailto:xuser@example.com"]],
+    ["[a](www.example.com)www.example.com\n", ["www.example.com", "http://www.example.com"]],
+    ["[a]( www.example.com )x\n", ["www.example.com"]],
+    ['[a](www.example.com"t")x\n', ['www.example.com"t"']],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — headings", () => {
+  test.each([
+    ["# www.example.com\n", ["http://www.example.com"]],
+    ["### www.example.com ###\n", ["http://www.example.com"]],
+    ["www.example.com\n===\n", ["http://www.example.com"]],
+    ["www.example.com\n---\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — blockquotes", () => {
+  test.each([
+    ["> www.example.com\n", ["http://www.example.com"]],
+    [">www.example.com\n", ["http://www.example.com"]],
+    ["> a\nwww.example.com\n", ["http://www.example.com"]],
+    ["> > www.example.com\n", ["http://www.example.com"]],
+    ["> a\n> user@example.com\n", ["mailto:user@example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — lists", () => {
+  test.each([
+    ["- www.example.com\n", ["http://www.example.com"]],
+    ["1. www.example.com\n", ["http://www.example.com"]],
+    ["-   www.example.com\n", ["http://www.example.com"]],
+    ["- a\n\n  www.example.com\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — tables", () => {
+  test.each([
+    ["| a |\n| - |\n| www.example.com |\n", ["http://www.example.com"]],
+    ["| www.example.com | b |\n| - | - |\n| c | d |\n", ["http://www.example.com"]],
+    ["| a |\n| - |\n| www.example.com\\|z |\n", ["http://www.example.com\\|z"]],
+    ["| a |\n| - |\n| \\|www.example.com |\n", ["http://www.example.com"]],
+    [
+      "| a | b |\n| - | - |\n| www.example.com | www.example.com |\n",
+      ["http://www.example.com", "http://www.example.com"],
+    ],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — footnotes", () => {
+  test.each([
+    ["a[^1]\n\n[^1]: www.example.com\n", ["http://www.example.com"]],
+    ["a[^www.example.com]\n\n[^www.example.com]: x\n", []],
+    ["www.example.com[^1]\n\n[^1]: x\n", ["http://www.example.com[^1"]],
+    ["user@example.com[^1]\n\n[^1]: x\n", ["mailto:user@example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — HTML", () => {
+  test.each([
+    ["<b>www.example.com</b>\n", ["http://www.example.com"]],
+    ["a <b> www.example.com\n", ["http://www.example.com"]],
+    ["<div>\nwww.example.com\n</div>\n", []],
+    ["<!-- www.example.com -->\n", []],
+    ["a <!-- www.example.com --> b\n", []],
+    ["<?php www.example.com ?>\n", []],
+    ['<a href="www.example.com">x</a>\n', []],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — CommonMark autolinks", () => {
+  test.each([
+    ["<www.example.com>\n", ["http://www.example.com"]],
+    ["<user@example.com>\n", ["mailto:user@example.com"]],
+    ["<http://x.y> www.example.com\n", ["http://x.y", "http://www.example.com"]],
+    ["www.example.com <http://x.y>\n", ["http://www.example.com", "http://x.y"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — code blocks", () => {
+  test.each([
+    ["    www.example.com\n", []],
+    ["```\nwww.example.com\n```\n", []],
+    ["~~~js\nwww.example.com\n~~~\n", []],
+    ["```www.example.com\nx\n```\n", []],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — block boundaries", () => {
+  test.each([
+    ["www.example.com\n\n---\n", ["http://www.example.com"]],
+    ["---\nwww.example.com\n", ["http://www.example.com"]],
+    ["www.example.com", ["http://www.example.com"]],
+    ["\n\nwww.example.com\n\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family D: containing constructs — math", () => {
+  test.each([
+    ["$www.example.com$\n", []],
+    ["$$www.example.com$$\n", []],
+    ["$$\nwww.example.com\n$$\n", []],
+    ["a $x$ www.example.com\n", ["http://www.example.com"]],
+    ["$a www.example.com\n", ["http://www.example.com"]],
+  ])("%j", (md: string, urls: string[]) => {
+    assertExtMdastConformance(md, ["math"]);
+    expect(collectUrls(satteriMathMdast(md)), JSON.stringify(md)).toEqual(urls);
+  });
+});
+
+// Family E — shapes where an autolink meets another construct.
+describe("family E: adjacent autolinks", () => {
+  test.each([
+    ["www.a.com www.b.com", ["http://www.a.com", "http://www.b.com"]],
+    ["www.a.comwww.b.com", ["http://www.a.comwww.b.com"]],
+    ["www.a.com/www.b.com", ["http://www.a.com/www.b.com"]],
+    ["http://a.b http://c.d", ["http://a.b", "http://c.d"]],
+    ["http://a.bhttp://c.d", ["http://a.bhttp://c.d"]],
+    ["http://a.b/http://c.d", ["http://a.b/http://c.d"]],
+    ["a@b.com c@d.com", ["mailto:a@b.com", "mailto:c@d.com"]],
+    ["a@b.comc@d.com", ["mailto:a@b.comc"]],
+    ["www.a.com,www.b.com", ["http://www.a.com,www.b.com"]],
+    ["www.a.com;www.b.com", ["http://www.a.com;www.b.com"]],
+    ["a@b.com,c@d.com", ["mailto:a@b.com", "mailto:c@d.com"]],
+    ["http://a.b?x=http://c.d", ["http://a.b?x=http://c.d"]],
+    ["www.a.com#www.b.com", ["http://www.a.com#www.b.com"]],
+  ])("%j", conforms);
+});
+
+describe("family E: touching construct delimiters", () => {
+  test.each([
+    ["*www.a.com*www.b.com*", ["http://www.a.com*www.b.com"]],
+    ["www.a.com*www.b.com", ["http://www.a.com*www.b.com"]],
+    ["www.a.com_www.b.com", ["http://www.a.com_www.b.com"]],
+    ["www.a.com~www.b.com", ["http://www.a.com~www.b.com"]],
+    ["[www.a.com](www.b.com)", ["www.b.com"]],
+    ["www.a.com[www.b.com]", ["http://www.a.com[www.b.com"]],
+    ["`www.a.com`www.b.com", ["http://www.b.com"]],
+  ])("%j", conforms);
+});
+
+describe("family E: brackets around a trigger", () => {
+  test.each([
+    ["[www.example.com", ["http://www.example.com"]],
+    ["[[www.example.com", ["http://www.example.com"]],
+    ["[a][www.example.com", ["http://www.example.com"]],
+    ["[a](www.example.com", ["http://www.example.com"]],
+    ["]www.example.com", ["http://www.example.com"]],
+    ["[www.example.com]", ["http://www.example.com"]],
+    ["[www.example.com](", ["http://www.example.com]("]],
+    ["![www.example.com", ["http://www.example.com"]],
+    ["[a][b] www.example.com", ["http://www.example.com"]],
+    ["[](www.example.com)", ["www.example.com"]],
+    ["[ www.example.com ]", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family E: escapes", () => {
+  test.each([
+    ["\\www.example.com", ["http://www.example.com"]],
+    ["\\[www.example.com", ["http://www.example.com"]],
+    ["www\\.example.com", ["http://www.example.com"]],
+    ["www.example\\.com", ["http://www.example\\.com"]],
+    ["www.example.com\\", ["http://www.example.com\\"]],
+    ["www.example.com\\_x", ["http://www.example.com\\_x"]],
+    ["www.example.com\\*x*", ["http://www.example.com\\*x"]],
+    ["www.example.com/a\\_b", ["http://www.example.com/a\\_b"]],
+    ["a\\@b.com", ["mailto:a@b.com"]],
+    ["\\_a@b.com", ["mailto:_a@b.com"]],
+    ["_a\\@b.com", ["mailto:_a@b.com"]],
+    ["http\\://example.com", ["http://example.com"]],
+    ["http:\\//example.com", ["http://example.com"]],
+    ["\\\\www.example.com", ["http://www.example.com"]],
+    ["\\\\\\www.example.com", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family E: character references", () => {
+  test.each([
+    ["&#104;ttp://example.com", ["http://example.com"]],
+    ["&#119;ww.example.com", ["http://www.example.com"]],
+    ["&#95;a@b.com", ["mailto:a@b.com"]],
+    ["www.example.com&#47;path", ["http://www.example.com&#47;path"]],
+    ["www.example.com&#32;x", ["http://www.example.com&#32;x"]],
+    ["www.example&#46;com", ["http://www.example&#46;com"]],
+    ["&amp;www.example.com", ["http://www.example.com"]],
+    ["&#x77;&#x77;&#x77;.example.com", ["http://www.example.com"]],
+    ["&fjlig;www.example.com", []],
+    ["&NewLine;www.example.com", ["http://www.example.com"]],
+    ["&nbsp;www.example.com", ["http://www.example.com"]],
+    ["&copy;www.example.com", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+describe("family E: link destinations", () => {
+  test.each([
+    ["[a](http://x.y)b", ["http://x.y"]],
+    ["[a](www.x.y)b", ["www.x.y"]],
+    ["[a](u@v.com)b", ["u@v.com"]],
+    ["[a](/x)http://y.z", ["/x", "http://y.z"]],
+    ["[a](/x)www.y.z", ["/x", "http://www.y.z"]],
+    ["[a](/x)u@v.com", ["/x", "mailto:u@v.com"]],
+    ["[a](<http://x.y>)b", ["http://x.y"]],
+    ["[a](http://x.y 'title')b", ["http://x.y"]],
+    ["![a](http://x.y)b", []],
+    ["[a](http://x.y)[b](http://c.d)e", ["http://x.y", "http://c.d"]],
+    ["[a][b] (http://x.y)c\n\n[b]: /d", ["http://x.y)c"]],
+    ["[a[b]c](www.x.y)", ["www.x.y"]],
+    ["[a[b](www.x.y)c]", ["www.x.y"]],
+    ["[![a](www.x.y)](www.z.w)", ["www.z.w"]],
+    ["[a](/b (www.x.y))", ["/b"]],
+  ])("%j", conforms);
+});
+
+// The rest of the deferred-splice family is in link-edge-cases.test.ts; these
+// are the shapes it does not carry.
+describe("family E: the deferred splice", () => {
+  test.each([
+    ["[a] www.x.y\\`code`", ["http://www.x.y\\`code`"]],
+    ["<a> www.x.y\\<b>", ["http://www.x.y\\"]],
+    ["[a][b] www.x.y\\<c>", ["http://www.x.y\\"]],
+    ["$x$ www.a.b", ["http://www.a.b"]],
+  ])("%j", conforms);
+});
+
+// Family F — line endings. CRLF agrees everywhere; a lone CR does not, and the
+// pin below holds that.
+describe("family F: line endings", () => {
+  test.each([
+    ["www.example.com\r\n", ["http://www.example.com"]],
+    ["x\r\nwww.example.com\r\n", ["http://www.example.com"]],
+    ["> x\r\n> www.example.com\r\n", ["http://www.example.com"]],
+    ["> x\r\nwww.example.com\r\n", ["http://www.example.com"]],
+    [
+      "www.example.com\r\n\r\nwww.example.com\r\n",
+      ["http://www.example.com", "http://www.example.com"],
+    ],
+    ["user@example.com\r\n", ["mailto:user@example.com"]],
+    ["x\r\nuser@example.com\r\n", ["mailto:user@example.com"]],
+    ["[a] www.example.com\r\n", ["http://www.example.com"]],
+    ["x\r\n[a] www.example.com\r\n", ["http://www.example.com"]],
+    ["http://example.com/p.\r\n", ["http://example.com/p"]],
+    ["a www.example.com b\r\n", ["http://www.example.com"]],
+    ["> x\r\n> [a] www.example.com\r\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+
+  // Pre-existing and not autolink-specific: the block parser splits on a lone
+  // CR but the line map does not, so every line/column after one is short by a
+  // line. Offsets are right, which is why the autolink cases still slice back
+  // to their source.
+  test.fails("a lone CR is not a line break for line/column", () => {
+    assertMdastConformance("x\rwww.example.com\r");
+  });
+});
+
+// Family I — constructs that shift offsets before the link, including the ones
+// that push it onto the find-and-replace path.
+describe("family I: position stress", () => {
+  test.each([
+    ["你好 www.example.com", ["http://www.example.com"]],
+    ["你好[www.example.com", ["http://www.example.com"]],
+    ["&amp; [www.example.com", ["http://www.example.com"]],
+    ["\\* [www.example.com", ["http://www.example.com"]],
+    ["> 你好\n> www.example.com", ["http://www.example.com"]],
+    ["> [a\n> www.example.com", ["http://www.example.com"]],
+    ["- [a\n  www.example.com", ["http://www.example.com"]],
+    ["[a] &amp; www.x.y", ["http://www.x.y"]],
+    ["[a] \t www.x.y", ["http://www.x.y"]],
+    ["  [a] www.x.y", ["http://www.x.y"]],
+    ["\t[a] www.x.y", []],
+    ["[www.x.y&amp;b", ["http://www.x.y&b"]],
+    ["[&fjlig;www.a.com", []],
+    ["[www.a.com&fjlig;", ["http://www.a.comfj"]],
+    ["[a](/b)\nwww.x.y", ["/b", "http://www.x.y"]],
+    ["***[a www.x.y***", ["http://www.x.y"]],
+    ["[a `b` www.x.y", ["http://www.x.y"]],
+    ["[a <b> www.x.y", ["http://www.x.y"]],
+    ["> [a\r\n> www.x.y", ["http://www.x.y"]],
+    ["[你好 www.x.y", ["http://www.x.y"]],
+    ["[a](/b)你好www.x.y", ["/b"]],
+    ["[a www.x.y\n===", ["http://www.x.y"]],
+  ])("%j", conforms);
+});
+
+// Family K — bracket state and the deferred-autolink decision: a closed `[…]`
+// stops blocking a later trigger even when it resolved to nothing, so the URL
+// before it must not run on. The separator column is what decides whether the
+// second trigger is reachable at all, so it is swept per label class.
+describe("family K: bracket balance — a label that never blocked", () => {
+  test.each([
+    ["[a]www.b.com\n", ["http://www.b.com"]],
+    ["[a]_u@b.com\n", ["mailto:_u@b.com"]],
+    ["[a] www.b.com\n", ["http://www.b.com"]],
+    ["[a] _u@b.com\n", ["mailto:_u@b.com"]],
+    ["[a]xwww.b.com\n", []],
+    ["[a]x_u@b.com\n", ["mailto:x_u@b.com"]],
+    ["[a](/x)www.b.com\n", ["/x", "http://www.b.com"]],
+    ["[a](/x)_u@b.com\n", ["/x", "mailto:_u@b.com"]],
+    ["[a](/x) www.b.com\n", ["/x", "http://www.b.com"]],
+    ["[a](/x) _u@b.com\n", ["/x", "mailto:_u@b.com"]],
+    ["[a](/x)xwww.b.com\n", ["/x"]],
+    ["[a](/x)x_u@b.com\n", ["/x", "mailto:x_u@b.com"]],
+  ])("%j", conforms);
+});
+
+describe("family K: bracket balance — an unbalanced opener still blocks", () => {
+  test.each([
+    ["[awww.b.com\n", []],
+    ["[au@b.com\n", ["mailto:au@b.com"]],
+    ["[a_u@b.com\n", ["mailto:a_u@b.com"]],
+    ["[a www.b.com\n", ["http://www.b.com"]],
+    ["[a u@b.com\n", ["mailto:u@b.com"]],
+    ["[a _u@b.com\n", ["mailto:_u@b.com"]],
+    ["[axwww.b.com\n", []],
+    ["[axu@b.com\n", ["mailto:axu@b.com"]],
+    ["[ax_u@b.com\n", ["mailto:ax_u@b.com"]],
+    ["[a.www.b.com\n", ["http://www.b.com"]],
+    ["[a.u@b.com\n", ["mailto:a.u@b.com"]],
+    ["[a._u@b.com\n", ["mailto:a._u@b.com"]],
+    ["[a](/xwww.b.com\n", []],
+    ["[a](/xu@b.com\n", []],
+    ["[a](/x_u@b.com\n", ["mailto:u@b.com"]],
+    ["[a](/x www.b.com\n", ["http://www.b.com"]],
+    ["[a](/x u@b.com\n", ["mailto:u@b.com"]],
+    ["[a](/x _u@b.com\n", ["mailto:_u@b.com"]],
+    ["[a](/xxwww.b.com\n", []],
+    ["[a](/xxu@b.com\n", []],
+    ["[a](/xx_u@b.com\n", ["mailto:u@b.com"]],
+    ["[a](/x.www.b.com\n", ["http://www.b.com"]],
+    ["[a](/x.u@b.com\n", ["mailto:u@b.com"]],
+    ["[a](/x._u@b.com\n", ["mailto:_u@b.com"]],
+  ])("%j", conforms);
+});
+
+describe("family K: bracket balance — a label ending in a trigger", () => {
+  test.each([
+    ["[www.a.com] www.b.com\n", ["http://www.a.com", "http://www.b.com"]],
+    ["[www.a.com] u@b.com\n", ["http://www.a.com", "mailto:u@b.com"]],
+    ["[www.a.com] _u@b.com\n", ["http://www.a.com", "mailto:_u@b.com"]],
+    ["[www.a.com]xwww.b.com\n", ["http://www.a.com]xwww.b.com"]],
+    ["[www.a.com]xu@b.com\n", ["http://www.a.com", "mailto:xu@b.com"]],
+    ["[www.a.com]x_u@b.com\n", ["http://www.a.com", "mailto:x_u@b.com"]],
+    ["[www.a.com].www.b.com\n", ["http://www.a.com].www.b.com"]],
+    ["[www.a.com].u@b.com\n", ["http://www.a.com", "mailto:.u@b.com"]],
+    ["[www.a.com]._u@b.com\n", ["http://www.a.com", "mailto:._u@b.com"]],
+    ["[www.a.com]-www.b.com\n", ["http://www.a.com]-www.b.com"]],
+    ["[www.a.com]-u@b.com\n", ["http://www.a.com", "mailto:-u@b.com"]],
+    ["[www.a.com]-_u@b.com\n", ["http://www.a.com", "mailto:-_u@b.com"]],
+    ["[http://a.com]u@b.com\n", ["http://a.com", "mailto:u@b.com"]],
+    ["[http://a.com]_u@b.com\n", ["http://a.com", "mailto:_u@b.com"]],
+    ["[http://a.com] www.b.com\n", ["http://a.com", "http://www.b.com"]],
+    ["[http://a.com] u@b.com\n", ["http://a.com", "mailto:u@b.com"]],
+    ["[http://a.com] _u@b.com\n", ["http://a.com", "mailto:_u@b.com"]],
+    ["[http://a.com]xwww.b.com\n", ["http://a.com]xwww.b.com"]],
+    ["[http://a.com]xu@b.com\n", ["http://a.com", "mailto:xu@b.com"]],
+    ["[http://a.com]x_u@b.com\n", ["http://a.com", "mailto:x_u@b.com"]],
+    ["[http://a.com].www.b.com\n", ["http://a.com].www.b.com"]],
+    ["[http://a.com].u@b.com\n", ["http://a.com", "mailto:.u@b.com"]],
+    ["[http://a.com]._u@b.com\n", ["http://a.com", "mailto:._u@b.com"]],
+    ["[http://a.com]-www.b.com\n", ["http://a.com]-www.b.com"]],
+    ["[http://a.com]-u@b.com\n", ["http://a.com", "mailto:-u@b.com"]],
+    ["[http://a.com]-_u@b.com\n", ["http://a.com", "mailto:-_u@b.com"]],
+    ["[u@a.com]www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
+    ["[u@a.com]u@b.com\n", ["mailto:u@a.com", "mailto:u@b.com"]],
+    ["[u@a.com]_u@b.com\n", ["mailto:u@a.com", "mailto:_u@b.com"]],
+    ["[u@a.com] www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
+    ["[u@a.com] u@b.com\n", ["mailto:u@a.com", "mailto:u@b.com"]],
+    ["[u@a.com] _u@b.com\n", ["mailto:u@a.com", "mailto:_u@b.com"]],
+    ["[u@a.com]xwww.b.com\n", ["mailto:u@a.com"]],
+    ["[u@a.com]xu@b.com\n", ["mailto:u@a.com", "mailto:xu@b.com"]],
+    ["[u@a.com]x_u@b.com\n", ["mailto:u@a.com", "mailto:x_u@b.com"]],
+    ["[u@a.com].www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
+    ["[u@a.com].u@b.com\n", ["mailto:u@a.com", "mailto:.u@b.com"]],
+    ["[u@a.com]._u@b.com\n", ["mailto:u@a.com", "mailto:._u@b.com"]],
+    ["[u@a.com]-www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
+    ["[u@a.com]-u@b.com\n", ["mailto:u@a.com", "mailto:-u@b.com"]],
+    ["[u@a.com]-_u@b.com\n", ["mailto:u@a.com", "mailto:-_u@b.com"]],
+  ])("%j", conforms);
+});
+
+describe("family K: a closed label and a second trigger", () => {
+  test.each([
+    [
+      "[www.a.com]www.b.com www.c.com\n",
+      ["http://www.a.com", "http://www.b.com", "http://www.c.com"],
+    ],
+    ["[www.a.com]www.b.com]www.c.com\n", ["http://www.a.com", "http://www.b.com]www.c.com"]],
+    [
+      "[www.a.com]www.b.com\n\n[www.d.com]www.e.com\n",
+      ["http://www.a.com", "http://www.b.com", "http://www.d.com", "http://www.e.com"],
+    ],
+    ["*[www.a.com]www.b.com*\n", ["http://www.a.com", "http://www.b.com"]],
+    ["[www.a.com]www.b.com](/x)\n", ["http://www.a.com", "http://www.b.com"]],
+    ["[[www.a.com]www.b.com]www.c.com\n", ["http://www.a.com]www.b.com", "http://www.c.com"]],
+    ["[a][www.b.com]www.c.com\n", ["http://www.b.com", "http://www.c.com"]],
+    ["![www.a.com]www.b.com\n", ["http://www.a.com", "http://www.b.com"]],
+    ["[www.a.com\\]www.b.com\n", ["http://www.a.com]www.b.com"]],
+    ["[www.a.com]www.b.com`c`\n", ["http://www.a.com", "http://www.b.com`c`"]],
+    ["[www.a.com].u@b.com\n", ["http://www.a.com", "mailto:.u@b.com"]],
+  ])("%j", conforms);
+});
+
+// Family L — reference definitions and footnote definitions.
+describe("family L: definitions", () => {
+  test.each([
+    ["[a]: www.example.com\n\n[a]\n", []],
+    ["[a]: /x 'www.example.com'\n\n[a]\n", []],
+    ["[www.example.com]: /x\n\n[www.example.com]\n", []],
+    ["[a]: /x\nwww.example.com\n", ["http://www.example.com"]],
+    ["[a]: /x\n\nwww.example.com\n", ["http://www.example.com"]],
+    ["[^1]: www.example.com\n\na[^1]\n", ["http://www.example.com"]],
+    ["[^www.a.com]: x\n\na[^www.a.com]\n", []],
+    ["[a]: <www.example.com>\n\n[a]\n", []],
+    ["www.example.com\n[a]: /x\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+// Deliberate divergence (see website/content/docs/divergences.md):
+// mdast-util-gfm-task-list-item pulls a task item's paragraph start back over
+// the checkbox only when the paragraph's first child is a text node. An
+// autolink first child is the case the doc's examples do not name.
+describe("family D: paragraph start in a task list item (documented divergence)", () => {
+  test("an autolink first child keeps satteri's uniform start", () => {
+    const md = "- [ ] www.example.com\n";
+    const paragraphStart = (tree: unknown): number => {
+      const list = (tree as { children: AnyNode[] }).children[0]!;
+      const paragraph = list.children![0]!.children![0]! as {
+        position: { start: { offset: number } };
+      };
+      return paragraph.position.start.offset;
+    };
+    expect(paragraphStart(satteriMdast(md))).toBe(6);
+    expect(paragraphStart(referenceMdast(md))).toBe(2);
+    expect(linkUrls(md)).toEqual(["http://www.example.com"]);
+  });
+
+  test("a text first child agrees on both sides", () => {
+    assertMdastConformance("- [ ] plain text\n");
+  });
+});

--- a/packages/satteri/test/conformance/autolink-contexts.test.ts
+++ b/packages/satteri/test/conformance/autolink-contexts.test.ts
@@ -296,8 +296,7 @@ describe("family E: the deferred splice", () => {
   ])("%j", conforms);
 });
 
-// Family F — line endings. CRLF agrees everywhere; a lone CR does not, and the
-// pin below holds that.
+// Family F — line endings.
 describe("family F: line endings", () => {
   test.each([
     ["www.example.com\r\n", ["http://www.example.com"]],
@@ -308,14 +307,6 @@ describe("family F: line endings", () => {
     ["http://example.com/p.\r\n", ["http://example.com/p"]],
     ["> x\r\n> [a] www.example.com\r\n", ["http://www.example.com"]],
   ])("%j", conforms);
-
-  // Pre-existing and not autolink-specific: the block parser splits on a lone
-  // CR but the line map does not, so every line/column after one is short by a
-  // line. Offsets are right, which is why the autolink cases still slice back
-  // to their source.
-  test.fails("a lone CR is not a line break for line/column", () => {
-    assertMdastConformance("x\rwww.example.com\r");
-  });
 });
 
 // Family I — constructs that shift offsets before the link, including the ones

--- a/packages/satteri/test/conformance/autolink-contexts.test.ts
+++ b/packages/satteri/test/conformance/autolink-contexts.test.ts
@@ -15,37 +15,14 @@ import { describe, test, expect } from "vitest";
 import {
   assertExtMdastConformance,
   assertMdastConformance,
+  collectUrls,
+  conforms,
+  linkUrls,
   referenceMdast,
   satteriMathMdast,
   satteriMdast,
 } from "./helpers.js";
-
-interface AnyNode {
-  type: string;
-  url?: string;
-  children?: AnyNode[];
-}
-
-/** Every `link` URL in document order. */
-function collectUrls(tree: unknown): string[] {
-  const out: string[] = [];
-  const walk = (node: AnyNode): void => {
-    if (node.type === "link") out.push(String(node.url));
-    for (const child of node.children ?? []) walk(child);
-  };
-  walk(tree as AnyNode);
-  return out;
-}
-
-function linkUrls(md: string): string[] {
-  return collectUrls(satteriMdast(md));
-}
-
-/** The tree matches remark, and the autolinks are the ones named. */
-function conforms(md: string, urls: string[]): void {
-  assertMdastConformance(md);
-  expect(linkUrls(md), JSON.stringify(md)).toEqual(urls);
-}
+import type { UrlNode } from "./helpers.js";
 
 // Family D — containing constructs. One case per construct, with a second inner
 // only where the inner changes the answer.
@@ -221,10 +198,7 @@ describe("family E: adjacent autolinks", () => {
     ["a@b.com c@d.com", ["mailto:a@b.com", "mailto:c@d.com"]],
     ["a@b.comc@d.com", ["mailto:a@b.comc"]],
     ["www.a.com,www.b.com", ["http://www.a.com,www.b.com"]],
-    ["www.a.com;www.b.com", ["http://www.a.com;www.b.com"]],
     ["a@b.com,c@d.com", ["mailto:a@b.com", "mailto:c@d.com"]],
-    ["http://a.b?x=http://c.d", ["http://a.b?x=http://c.d"]],
-    ["www.a.com#www.b.com", ["http://www.a.com#www.b.com"]],
   ])("%j", conforms);
 });
 
@@ -299,10 +273,8 @@ describe("family E: link destinations", () => {
     ["[a](www.x.y)b", ["www.x.y"]],
     ["[a](u@v.com)b", ["u@v.com"]],
     ["[a](/x)http://y.z", ["/x", "http://y.z"]],
-    ["[a](/x)www.y.z", ["/x", "http://www.y.z"]],
     ["[a](/x)u@v.com", ["/x", "mailto:u@v.com"]],
     ["[a](<http://x.y>)b", ["http://x.y"]],
-    ["[a](http://x.y 'title')b", ["http://x.y"]],
     ["![a](http://x.y)b", []],
     ["[a](http://x.y)[b](http://c.d)e", ["http://x.y", "http://c.d"]],
     ["[a][b] (http://x.y)c\n\n[b]: /d", ["http://x.y)c"]],
@@ -331,17 +303,9 @@ describe("family F: line endings", () => {
     ["www.example.com\r\n", ["http://www.example.com"]],
     ["x\r\nwww.example.com\r\n", ["http://www.example.com"]],
     ["> x\r\n> www.example.com\r\n", ["http://www.example.com"]],
-    ["> x\r\nwww.example.com\r\n", ["http://www.example.com"]],
-    [
-      "www.example.com\r\n\r\nwww.example.com\r\n",
-      ["http://www.example.com", "http://www.example.com"],
-    ],
     ["user@example.com\r\n", ["mailto:user@example.com"]],
-    ["x\r\nuser@example.com\r\n", ["mailto:user@example.com"]],
     ["[a] www.example.com\r\n", ["http://www.example.com"]],
-    ["x\r\n[a] www.example.com\r\n", ["http://www.example.com"]],
     ["http://example.com/p.\r\n", ["http://example.com/p"]],
-    ["a www.example.com b\r\n", ["http://www.example.com"]],
     ["> x\r\n> [a] www.example.com\r\n", ["http://www.example.com"]],
   ])("%j", conforms);
 
@@ -363,11 +327,9 @@ describe("family I: position stress", () => {
     ["&amp; [www.example.com", ["http://www.example.com"]],
     ["\\* [www.example.com", ["http://www.example.com"]],
     ["> 你好\n> www.example.com", ["http://www.example.com"]],
-    ["> [a\n> www.example.com", ["http://www.example.com"]],
     ["- [a\n  www.example.com", ["http://www.example.com"]],
     ["[a] &amp; www.x.y", ["http://www.x.y"]],
     ["[a] \t www.x.y", ["http://www.x.y"]],
-    ["  [a] www.x.y", ["http://www.x.y"]],
     ["\t[a] www.x.y", []],
     ["[www.x.y&amp;b", ["http://www.x.y&b"]],
     ["[&fjlig;www.a.com", []],
@@ -385,8 +347,9 @@ describe("family I: position stress", () => {
 
 // Family K — bracket state and the deferred-autolink decision: a closed `[…]`
 // stops blocking a later trigger even when it resolved to nothing, so the URL
-// before it must not run on. The separator column is what decides whether the
-// second trigger is reachable at all, so it is swept per label class.
+// before it must not run on. The separator decides whether the second trigger is
+// reachable at all, so the rows below are the label/separator/trigger
+// combinations that answer differently, not the full cross-product.
 describe("family K: bracket balance — a label that never blocked", () => {
   test.each([
     ["[a]www.b.com\n", ["http://www.b.com"]],
@@ -436,44 +399,27 @@ describe("family K: bracket balance — an unbalanced opener still blocks", () =
 describe("family K: bracket balance — a label ending in a trigger", () => {
   test.each([
     ["[www.a.com] www.b.com\n", ["http://www.a.com", "http://www.b.com"]],
-    ["[www.a.com] u@b.com\n", ["http://www.a.com", "mailto:u@b.com"]],
     ["[www.a.com] _u@b.com\n", ["http://www.a.com", "mailto:_u@b.com"]],
     ["[www.a.com]xwww.b.com\n", ["http://www.a.com]xwww.b.com"]],
     ["[www.a.com]xu@b.com\n", ["http://www.a.com", "mailto:xu@b.com"]],
     ["[www.a.com]x_u@b.com\n", ["http://www.a.com", "mailto:x_u@b.com"]],
-    ["[www.a.com].www.b.com\n", ["http://www.a.com].www.b.com"]],
     ["[www.a.com].u@b.com\n", ["http://www.a.com", "mailto:.u@b.com"]],
     ["[www.a.com]._u@b.com\n", ["http://www.a.com", "mailto:._u@b.com"]],
-    ["[www.a.com]-www.b.com\n", ["http://www.a.com]-www.b.com"]],
     ["[www.a.com]-u@b.com\n", ["http://www.a.com", "mailto:-u@b.com"]],
     ["[www.a.com]-_u@b.com\n", ["http://www.a.com", "mailto:-_u@b.com"]],
     ["[http://a.com]u@b.com\n", ["http://a.com", "mailto:u@b.com"]],
     ["[http://a.com]_u@b.com\n", ["http://a.com", "mailto:_u@b.com"]],
-    ["[http://a.com] www.b.com\n", ["http://a.com", "http://www.b.com"]],
     ["[http://a.com] u@b.com\n", ["http://a.com", "mailto:u@b.com"]],
     ["[http://a.com] _u@b.com\n", ["http://a.com", "mailto:_u@b.com"]],
     ["[http://a.com]xwww.b.com\n", ["http://a.com]xwww.b.com"]],
-    ["[http://a.com]xu@b.com\n", ["http://a.com", "mailto:xu@b.com"]],
-    ["[http://a.com]x_u@b.com\n", ["http://a.com", "mailto:x_u@b.com"]],
-    ["[http://a.com].www.b.com\n", ["http://a.com].www.b.com"]],
     ["[http://a.com].u@b.com\n", ["http://a.com", "mailto:.u@b.com"]],
     ["[http://a.com]._u@b.com\n", ["http://a.com", "mailto:._u@b.com"]],
-    ["[http://a.com]-www.b.com\n", ["http://a.com]-www.b.com"]],
     ["[http://a.com]-u@b.com\n", ["http://a.com", "mailto:-u@b.com"]],
     ["[http://a.com]-_u@b.com\n", ["http://a.com", "mailto:-_u@b.com"]],
-    ["[u@a.com]www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
-    ["[u@a.com]u@b.com\n", ["mailto:u@a.com", "mailto:u@b.com"]],
     ["[u@a.com]_u@b.com\n", ["mailto:u@a.com", "mailto:_u@b.com"]],
-    ["[u@a.com] www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
-    ["[u@a.com] u@b.com\n", ["mailto:u@a.com", "mailto:u@b.com"]],
-    ["[u@a.com] _u@b.com\n", ["mailto:u@a.com", "mailto:_u@b.com"]],
     ["[u@a.com]xwww.b.com\n", ["mailto:u@a.com"]],
-    ["[u@a.com]xu@b.com\n", ["mailto:u@a.com", "mailto:xu@b.com"]],
-    ["[u@a.com]x_u@b.com\n", ["mailto:u@a.com", "mailto:x_u@b.com"]],
-    ["[u@a.com].www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
     ["[u@a.com].u@b.com\n", ["mailto:u@a.com", "mailto:.u@b.com"]],
     ["[u@a.com]._u@b.com\n", ["mailto:u@a.com", "mailto:._u@b.com"]],
-    ["[u@a.com]-www.b.com\n", ["mailto:u@a.com", "http://www.b.com"]],
     ["[u@a.com]-u@b.com\n", ["mailto:u@a.com", "mailto:-u@b.com"]],
     ["[u@a.com]-_u@b.com\n", ["mailto:u@a.com", "mailto:-_u@b.com"]],
   ])("%j", conforms);
@@ -497,14 +443,12 @@ describe("family K: a closed label and a second trigger", () => {
     ["![www.a.com]www.b.com\n", ["http://www.a.com", "http://www.b.com"]],
     ["[www.a.com\\]www.b.com\n", ["http://www.a.com]www.b.com"]],
     ["[www.a.com]www.b.com`c`\n", ["http://www.a.com", "http://www.b.com`c`"]],
-    ["[www.a.com].u@b.com\n", ["http://www.a.com", "mailto:.u@b.com"]],
   ])("%j", conforms);
 });
 
 // Family L — reference definitions and footnote definitions.
 describe("family L: definitions", () => {
   test.each([
-    ["[a]: www.example.com\n\n[a]\n", []],
     ["[a]: /x 'www.example.com'\n\n[a]\n", []],
     ["[www.example.com]: /x\n\n[www.example.com]\n", []],
     ["[a]: /x\nwww.example.com\n", ["http://www.example.com"]],
@@ -524,11 +468,8 @@ describe("family D: paragraph start in a task list item (documented divergence)"
   test("an autolink first child keeps satteri's uniform start", () => {
     const md = "- [ ] www.example.com\n";
     const paragraphStart = (tree: unknown): number => {
-      const list = (tree as { children: AnyNode[] }).children[0]!;
-      const paragraph = list.children![0]!.children![0]! as {
-        position: { start: { offset: number } };
-      };
-      return paragraph.position.start.offset;
+      const list = (tree as UrlNode).children![0]!;
+      return list.children![0]!.children![0]!.position!.start.offset;
     };
     expect(paragraphStart(satteriMdast(md))).toBe(6);
     expect(paragraphStart(referenceMdast(md))).toBe(2);

--- a/packages/satteri/test/conformance/autolink-literals.test.ts
+++ b/packages/satteri/test/conformance/autolink-literals.test.ts
@@ -12,34 +12,7 @@
 // URL ends, and the spec's own examples.
 
 import { describe, test, expect } from "vitest";
-import { assertMdastConformance, referenceMdast, satteriMdast } from "./helpers.js";
-
-interface AnyNode {
-  type: string;
-  url?: string;
-  children?: AnyNode[];
-}
-
-/** Every `link` URL in document order. */
-function collectUrls(tree: unknown): string[] {
-  const out: string[] = [];
-  const walk = (node: AnyNode): void => {
-    if (node.type === "link") out.push(String(node.url));
-    for (const child of node.children ?? []) walk(child);
-  };
-  walk(tree as AnyNode);
-  return out;
-}
-
-function linkUrls(md: string): string[] {
-  return collectUrls(satteriMdast(md));
-}
-
-/** The tree matches remark, and the autolinks are the ones named. */
-function conforms(md: string, urls: string[]): void {
-  assertMdastConformance(md);
-  expect(linkUrls(md), JSON.stringify(md)).toEqual(urls);
-}
+import { assertMdastConformance, conforms, linkUrls } from "./helpers.js";
 
 // Family A — the preceding-character classifier. It asks a character for its
 // Unicode General_Category, so there is one row per category it must accept or
@@ -153,47 +126,19 @@ describe("family A: the preceding-character classifier", () => {
   ])("%j", conforms);
 });
 
-// Deliberate divergence (see website/content/docs/divergences.md): remark reads
-// the preceding character as one UTF-16 code unit, so an astral one is a lone
-// surrogate and always blocks. Encoded the same way as in autolink-path.test.ts:
-// the reference side is asserted, then satteri's own span.
-describe("family A: astral characters before a GFM autolink (documented divergence)", () => {
-  const ASTRAL: Array<{ prefix: string; name: string }> = [
-    { prefix: "😀", name: "U+1F600 GRINNING FACE (So)" },
-    { prefix: "𐄁", name: "U+10101 AEGEAN WORD SEPARATOR DOT (Po)" },
-    { prefix: "𝛛", name: "U+1D6DB MATHEMATICAL BOLD PARTIAL DIFFERENTIAL (Sm)" },
-    { prefix: "👨\u{200d}💻", name: "a ZWJ sequence ending in U+1F4BB (So)" },
-  ];
+// Astral characters before a trigger are a documented divergence, pinned in
+// autolink-path.test.ts alongside remark's side of it.
 
-  test.each(ASTRAL)("$name", ({ prefix }) => {
-    const md = `${prefix}www.example.com`;
-    const remark = referenceMdast(md) as { children: AnyNode[] };
-    expect(linkUrls(md)).toEqual(["http://www.example.com"]);
-    expect((remark.children[0] as AnyNode).children?.map((c) => c.type)).toEqual(["text"]);
-
-    const link = (satteriMdast(md) as { children: AnyNode[] }).children[0]!.children!.find(
-      (c) => c.type === "link",
-    ) as {
-      position: { start: { offset: number }; end: { offset: number } };
-    };
-    expect(md.slice(link.position.start.offset, link.position.end.offset)).toBe("www.example.com");
-  });
-
-  // Only the `www` trigger diverges: the other two accept the character on both
-  // sides. Astral letters and digits block on both sides, for different reasons.
-  test.each([
-    ["😀user@example.com\n", ["mailto:user@example.com"]],
-    ["😀http://example.com\n", ["http://example.com"]],
-    ["😀_user@example.com\n", ["mailto:_user@example.com"]],
-    ["🯰www.example.com\n", []],
-    ["𝐀www.example.com\n", []],
-  ])("%j", conforms);
-});
-
-// Family B — the trailing-punctuation and trailing-entity rules. Both rules are
-// set-membership tests, so there is one row per member: a member quietly leaving
-// the trim set (or joining it) fails exactly one row here and nothing else.
-// Trailing runs that are not a member and only repeat "left alone" are dropped.
+// Family B — the trailing-punctuation and trailing-entity rules. For `www.` and
+// `http://` the trim is a set-membership test, so there is one row per member: a
+// member quietly leaving the trim set (or joining it) fails exactly one row here
+// and nothing else. Trailing runs that are not a member and only repeat "left
+// alone" are dropped.
+//
+// Emails get no trim at all — `fnr_find_email` reports the scan's end as the URL
+// end — so the third block is not a member sweep: the scan simply stops at the
+// first byte the domain rule rejects, and the rows are the few characters the
+// rule does read (`.`, `_`, `-`).
 describe("family B: trailing punctuation and entities", () => {
   test.each([
     ["www.example.com\n", ["http://www.example.com"]],
@@ -215,14 +160,8 @@ describe("family B: trailing punctuation and entities", () => {
     ["www.example.com(\n", ["http://www.example.com("]],
     ["www.example.com()\n", ["http://www.example.com()"]],
     ["www.example.com]\n", ["http://www.example.com"]],
-    ["www.example.com}\n", ["http://www.example.com}"]],
-    ["www.example.com>\n", ["http://www.example.com>"]],
     ["www.example.com<\n", ["http://www.example.com"]],
-    ["www.example.com-\n", ["http://www.example.com-"]],
-    ["www.example.com\\\n", ["http://www.example.com\\"]],
     ["www.example.com|\n", ["http://www.example.com|"]],
-    ["www.example.com`\n", ["http://www.example.com`"]],
-    ["www.example.com%\n", ["http://www.example.com%"]],
     ["www.example.com&amp;.\n", ["http://www.example.com"]],
     ["www.example.com&copy;\n", ["http://www.example.com"]],
     ["www.example.com&#35;\n", ["http://www.example.com&#35"]],
@@ -257,46 +196,8 @@ describe("family B: trailing punctuation and entities", () => {
     ["user@example.com\n", ["mailto:user@example.com"]],
     ["user@example.com.\n", ["mailto:user@example.com"]],
     ["user@example.com...\n", ["mailto:user@example.com"]],
-    ["user@example.com,\n", ["mailto:user@example.com"]],
-    ["user@example.com;\n", ["mailto:user@example.com"]],
-    ["user@example.com:\n", ["mailto:user@example.com"]],
-    ["user@example.com!\n", ["mailto:user@example.com"]],
-    ["user@example.com?!\n", ["mailto:user@example.com"]],
-    ["user@example.com'\n", ["mailto:user@example.com"]],
-    ['user@example.com"\n', ["mailto:user@example.com"]],
-    ["user@example.com*\n", ["mailto:user@example.com"]],
-    ["user@example.com**\n", ["mailto:user@example.com"]],
     ["user@example.com_\n", []],
-    ["user@example.com~~\n", ["mailto:user@example.com"]],
-    ["user@example.com)\n", ["mailto:user@example.com"]],
-    ["user@example.com))\n", ["mailto:user@example.com"]],
-    ["user@example.com(\n", ["mailto:user@example.com"]],
-    ["user@example.com()\n", ["mailto:user@example.com"]],
-    ["user@example.com]\n", ["mailto:user@example.com"]],
-    ["user@example.com}\n", ["mailto:user@example.com"]],
-    ["user@example.com>\n", ["mailto:user@example.com"]],
-    ["user@example.com<\n", ["mailto:user@example.com"]],
     ["user@example.com-\n", []],
-    ["user@example.com\\\n", ["mailto:user@example.com"]],
-    ["user@example.com|\n", ["mailto:user@example.com"]],
-    ["user@example.com`\n", ["mailto:user@example.com"]],
-    ["user@example.com%\n", ["mailto:user@example.com"]],
-    ["user@example.com&amp;\n", ["mailto:user@example.com"]],
-    ["user@example.com&amp;.\n", ["mailto:user@example.com"]],
-    ["user@example.com&amp;)\n", ["mailto:user@example.com"]],
-    ["user@example.com&copy;\n", ["mailto:user@example.com"]],
-    ["user@example.com&#35;\n", ["mailto:user@example.com"]],
-    ["user@example.com&#x23;\n", ["mailto:user@example.com"]],
-    ["user@example.com&notreal\n", ["mailto:user@example.com"]],
-    ["user@example.com&notreal;\n", ["mailto:user@example.com"]],
-    ["user@example.com&;\n", ["mailto:user@example.com"]],
-    ["user@example.com&amp\n", ["mailto:user@example.com"]],
-    ["user@example.com&amp;amp;\n", ["mailto:user@example.com"]],
-    ["user@example.com&nbsp;\n", ["mailto:user@example.com"]],
-    ["user@example.com&lt;\n", ["mailto:user@example.com"]],
-    ["user@example.com&#0;\n", ["mailto:user@example.com"]],
-    ["user@example.com&#xFFFF;\n", ["mailto:user@example.com"]],
-    ["user@example.com&#1114112;\n", ["mailto:user@example.com"]],
   ])("%j", conforms);
 
   // The same trims with text after them, where the trimmed tail has somewhere
@@ -321,17 +222,13 @@ describe("family C: the balanced-paren rule", () => {
     ["www.example.com/a(b)c)\n", ["http://www.example.com/a(b)c"]],
     ["www.example.com/a(b(c))\n", ["http://www.example.com/a(b(c))"]],
     ["www.example.com/a(b(c)\n", ["http://www.example.com/a(b(c)"]],
-    ["www.example.com/a((b))\n", ["http://www.example.com/a((b))"]],
-    ["www.example.com/a((b)\n", ["http://www.example.com/a((b)"]],
     ["www.example.com/(\n", ["http://www.example.com/("]],
     ["www.example.com/)\n", ["http://www.example.com/"]],
     ["www.example.com/()\n", ["http://www.example.com/()"]],
     ["www.example.com/)(\n", ["http://www.example.com/)("]],
     ["www.example.com/a(b).\n", ["http://www.example.com/a(b)"]],
-    ["www.example.com/a(b)&amp;\n", ["http://www.example.com/a(b)"]],
     ["http://example.com/a(b)c\n", ["http://example.com/a(b)c"]],
     ["http://example.com/foo).\n", ["http://example.com/foo"]],
-    ["http://example.com/foo)))\n", ["http://example.com/foo"]],
     ["http://example.com/(a)(b)\n", ["http://example.com/(a)(b)"]],
     ["http://example.com/(a)(b\n", ["http://example.com/(a)(b"]],
     [
@@ -349,8 +246,6 @@ describe("family C: the balanced-paren rule", () => {
     ["(www.example.com/a)\n", ["http://www.example.com/a"]],
     ["((www.example.com))\n", ["http://www.example.com"]],
     ["(www.example.com\n", ["http://www.example.com"]],
-    ["www.example.com)\n", ["http://www.example.com"]],
-    ["x www.example.com/a(b) y\n", ["http://www.example.com/a(b)"]],
     ["x (www.example.com) y\n", ["http://www.example.com"]],
   ])("%j", conforms);
 });
@@ -361,33 +256,20 @@ describe("family G: unicode in and around the URL", () => {
   test.each([
     ["www.exämple.com\n", ["http://www.exämple.com"]],
     ["www.example.com/ä\n", ["http://www.example.com/ä"]],
-    ["www.example.com/é/x\n", ["http://www.example.com/é/x"]],
     ["www.例え.com\n", ["http://www.例え.com"]],
-    ["www.example.com/中文\n", ["http://www.example.com/中文"]],
     ["www.example.com/😀\n", ["http://www.example.com/😀"]],
-    ["www.example.com/😀/x\n", ["http://www.example.com/😀/x"]],
-    ["www.example.com/a\u{200b}b\n", ["http://www.example.com/a\u{200b}b"]],
     ["https://例え.テスト\n", ["https://例え.テスト"]],
     ["https://example.com/päth?q=ü#frag\n", ["https://example.com/päth?q=ü#frag"]],
     ["ü@example.com\n", []],
     ["user@exämple.com\n", []],
-    ["user@例え.com\n", []],
     ["😀 www.example.com\n", ["http://www.example.com"]],
     ["www.example.com😀\n", ["http://www.example.com😀"]],
-    ["www.example.com 😀\n", ["http://www.example.com"]],
     ["中www.example.com\n", []],
-    ["中 www.example.com\n", ["http://www.example.com"]],
-    ["www.example.com中\n", ["http://www.example.com中"]],
     ["www.example.com/😀.\n", ["http://www.example.com/😀"]],
     ["www.example.com/a—b\n", ["http://www.example.com/a—b"]],
     ["www.example.com—\n", ["http://www.example.com—"]],
-    ["www.example.com…\n", ["http://www.example.com…"]],
     ["www.example.com\u{200b}\n", ["http://www.example.com\u{200b}"]],
     ["www.example.com\u{a0}x\n", ["http://www.example.com"]],
-    ["www.example.com）\n", ["http://www.example.com）"]],
-    ["www.example.com。\n", ["http://www.example.com。"]],
-    ["x www.exämple.com y\n", ["http://www.exämple.com"]],
-    ["x www.example.com/😀 y\n", ["http://www.example.com/😀"]],
   ])("%j", conforms);
 });
 
@@ -408,23 +290,20 @@ describe("family G: underscores in the last two domain labels", () => {
     ["http://a_b\n", []],
     ["www.a_b\n", []],
     ["user@exa_mple.com\n", ["mailto:user@exa_mple.com"]],
-    ["user@a.exa_mple.com\n", ["mailto:user@a.exa_mple.com"]],
     ["user@a_b.example.com\n", ["mailto:user@a_b.example.com"]],
     ["www.example.com/a_b\n", ["http://www.example.com/a_b"]],
     ["www.example.com?a_b\n", ["http://www.example.com?a_b"]],
-    ["www.example.com#a_b\n", ["http://www.example.com#a_b"]],
-    ["www.example.com_\n", ["http://www.example.com"]],
     ["www.example.com__\n", ["http://www.example.com"]],
     ["www.example.com_x\n", []],
-    ["x www.exa_mple.com y\n", []],
-    ["x http://foo_bar.com. y\n", ["http://foo_bar.com"]],
   ])("%j", conforms);
 });
 
 // Family H — one case per clause of GFM §6.9 (www / url / email autolink
-// extended). Kept whole apart from the email local-part enumeration, where 19
-// of the 33 characters only repeat "not in the accepted set, so the local part
-// starts after it".
+// extended). The spec's own examples already run as HTML in the generated
+// `gfm_autolink` suite on the Rust side; the tree and the URL are a different
+// assertion layer, which is why they are repeated here. The enumerations around
+// them are cut to boundary members: a character outside `is_email_local_char`
+// only repeats "the backward walk stops here", whichever character it is.
 describe("family H: GFM §6.9 spec clauses", () => {
   test.each([
     ["www.commonmark.org\n", ["http://www.commonmark.org"]],
@@ -491,47 +370,27 @@ describe("family H: GFM §6.9 spec clauses", () => {
     ["http://a-b.c-d.example.com\n", ["http://a-b.c-d.example.com"]],
     ["HTTPS://example.com\n", ["HTTPS://example.com"]],
     ["WWW.example.com\n", ["http://WWW.example.com"]],
-    ["wWw.example.com\n", ["http://wWw.example.com"]],
     ["5www.example.com\n", []],
     ["awww.example.com\n", []],
     ["a.www.example.com\n", ["http://www.example.com"]],
     ["xhttp://example.com\n", []],
     ["5http://example.com\n", ["http://example.com"]],
     [".http://example.com\n", ["http://example.com"]],
-    ["-http://example.com\n", ["http://example.com"]],
-    ["_http://example.com\n", ["http://example.com"]],
     ["a+b@c.com\n", ["mailto:a+b@c.com"]],
     ["a-b@c.com\n", ["mailto:a-b@c.com"]],
     ["a.b@c.com\n", ["mailto:a.b@c.com"]],
     ["a_b@c.com\n", ["mailto:a_b@c.com"]],
     ["a!b@c.com\n", ["mailto:b@c.com"]],
-    ["a%b@c.com\n", ["mailto:b@c.com"]],
-    ["a\\b@c.com\n", ["mailto:b@c.com"]],
-    ["a<b@c.com\n", ["mailto:b@c.com"]],
-    ["a|b@c.com\n", ["mailto:b@c.com"]],
-    ['a"b@c.com\n', ["mailto:b@c.com"]],
-    ["a`b@c.com\n", ["mailto:b@c.com"]],
     ["a@b@c.com\n", ["mailto:b@c.com"]],
     [".a@b.com\n", ["mailto:.a@b.com"]],
-    ["-a@b.com\n", ["mailto:-a@b.com"]],
-    ["_a@b.com\n", ["mailto:_a@b.com"]],
-    ["+a@b.com\n", ["mailto:+a@b.com"]],
-    ["www.example.com/a-\n", ["http://www.example.com/a-"]],
-    ["www.example.com/a_\n", ["http://www.example.com/a"]],
-    ["user@example.com-\n", []],
-    ["user@example.com_\n", []],
     ["user@example.co-m\n", ["mailto:user@example.co-m"]],
     ["user@example.co_m\n", ["mailto:user@example.co_m"]],
     ["http://example.com/a<b\n", ["http://example.com/a"]],
     ["user@example.com<x\n", ["mailto:user@example.com"]],
-    ["www.example.com<\n", ["http://www.example.com"]],
     ["www.example.com/?a=1&b=2;\n", ["http://www.example.com/?a=1&b=2"]],
     ["www.example.com&amp;;\n", ["http://www.example.com"]],
-    ["www.example.com;\n", ["http://www.example.com"]],
-    ["www.example.com&;\n", ["http://www.example.com&"]],
     ["www.example.com&x;\n", ["http://www.example.com"]],
     ["www.example.com&#;\n", ["http://www.example.com&#"]],
-    ["www.example.com&ampx;\n", ["http://www.example.com"]],
     ["www.example.com/a&amp;b\n", ["http://www.example.com/a&amp;b"]],
     ["http://example.com?a&copy;\n", ["http://example.com?a"]],
   ])("%j", conforms);
@@ -542,6 +401,9 @@ describe("family H: GFM §6.9 spec clauses", () => {
 // forms, the preceding-character (boundary) forms, and the find-and-replace
 // path. U+0085 is the boundary the `www` classifier had to be taught, and the two
 // `Cf` code points are the controls that must stay inside the URL.
+//
+// One code point per branch of `is_autolink_whitespace`: U+00A0 stands for every
+// code point that reaches it through `char::is_whitespace()`.
 describe("family J: unicode whitespace as terminator and boundary", () => {
   test.each([
     ["user@example.com\u{85}x\n", ["mailto:user@example.com"]],
@@ -562,24 +424,6 @@ describe("family J: unicode whitespace as terminator and boundary", () => {
     ["x\u{a0}_user@example.com\n", ["mailto:_user@example.com"]],
     ["[a www.example.com/p\u{a0}q\n", ["http://www.example.com/p\u{a0}q"]],
     ["[a x\u{a0}www.example.com\n", ["http://www.example.com"]],
-    ["user@example.com\u{2028}x\n", ["mailto:user@example.com"]],
-    ["user@exa\u{2028}mple.com\n", []],
-    ["https://example.com\u{2028}\n", ["https://example.com"]],
-    ["x\u{2028}www.example.com\n", ["http://www.example.com"]],
-    ["x\u{2028}http://example.com\n", ["http://example.com"]],
-    ["x\u{2028}user@example.com\n", ["mailto:user@example.com"]],
-    ["x\u{2028}_user@example.com\n", ["mailto:_user@example.com"]],
-    ["[a www.example.com/p\u{2028}q\n", ["http://www.example.com/p\u{2028}q"]],
-    ["[a x\u{2028}www.example.com\n", ["http://www.example.com"]],
-    ["user@example.com\u{3000}x\n", ["mailto:user@example.com"]],
-    ["user@exa\u{3000}mple.com\n", []],
-    ["https://example.com\u{3000}\n", ["https://example.com"]],
-    ["x\u{3000}www.example.com\n", ["http://www.example.com"]],
-    ["x\u{3000}http://example.com\n", ["http://example.com"]],
-    ["x\u{3000}user@example.com\n", ["mailto:user@example.com"]],
-    ["x\u{3000}_user@example.com\n", ["mailto:_user@example.com"]],
-    ["[a www.example.com/p\u{3000}q\n", ["http://www.example.com/p\u{3000}q"]],
-    ["[a x\u{3000}www.example.com\n", ["http://www.example.com"]],
     ["user@example.com\u{200b}x\n", ["mailto:user@example.com"]],
     ["user@exa\u{200b}mple.com\n", []],
     ["https://example.com\u{200b}\n", ["https://example.com\u{200b}"]],
@@ -589,6 +433,8 @@ describe("family J: unicode whitespace as terminator and boundary", () => {
     ["x\u{200b}_user@example.com\n", ["mailto:_user@example.com"]],
     ["[a www.example.com/p\u{200b}q\n", ["http://www.example.com/p\u{200b}q"]],
     ["[a x\u{200b}www.example.com\n", []],
+    // U+FEFF has no `https://example.com{WS}` or `user@example.com{WS}x` row:
+    // both trip the drop pinned as `test.fails` in link-edge-cases.test.ts.
     ["user@exa\u{feff}mple.com\n", []],
     ["x\u{feff}www.example.com\n", ["http://www.example.com"]],
     ["x\u{feff}http://example.com\n", ["http://example.com"]],

--- a/packages/satteri/test/conformance/autolink-literals.test.ts
+++ b/packages/satteri/test/conformance/autolink-literals.test.ts
@@ -1,0 +1,600 @@
+// Distilled from a hand-crafted GFM autolink differential matrix (3,234 cases,
+// families A–L) run against `remark-parse` + `remark-gfm`. Every case kept here is
+// one the committed suite did not already exercise, and one whose behaviour no
+// other kept case repeats: where the matrix enumerated a rule over a vocabulary,
+// only the members that sit on a boundary of that rule survive.
+//
+// Each row carries the URLs satteri must produce, so a row that stops linking —
+// or starts linking something new — fails on its own terms and not only through
+// the tree comparison.
+//
+// This half covers the scanner itself: what may precede a trigger, where the
+// URL ends, and the spec's own examples.
+
+import { describe, test, expect } from "vitest";
+import { assertMdastConformance, referenceMdast, satteriMdast } from "./helpers.js";
+
+interface AnyNode {
+  type: string;
+  url?: string;
+  children?: AnyNode[];
+}
+
+/** Every `link` URL in document order. */
+function collectUrls(tree: unknown): string[] {
+  const out: string[] = [];
+  const walk = (node: AnyNode): void => {
+    if (node.type === "link") out.push(String(node.url));
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(tree as AnyNode);
+  return out;
+}
+
+function linkUrls(md: string): string[] {
+  return collectUrls(satteriMdast(md));
+}
+
+/** The tree matches remark, and the autolinks are the ones named. */
+function conforms(md: string, urls: string[]): void {
+  assertMdastConformance(md);
+  expect(linkUrls(md), JSON.stringify(md)).toEqual(urls);
+}
+
+// Family A — the preceding-character classifier. It asks a character for its
+// Unicode General_Category, so there is one row per category it must accept or
+// reject, plus the ASCII characters that mean something else to a neighbouring
+// construct; not one row per character in the matrix. Which of the two autolink
+// paths each case takes is pinned in autolink-path.test.ts — what is pinned here
+// is the tree that comes out, for trigger kinds that file does not carry.
+const A_TRIGGERS = [
+  "www.example.com",
+  "http://example.com",
+  "user@example.com",
+  "_user@example.com",
+];
+
+// What each trigger links to when the preceding character lets it through, so a
+// row below reads as a pattern instead of four repeated URLs.
+const W = "http://www.example.com";
+const H = "http://example.com";
+const E = "mailto:user@example.com";
+const U = "mailto:_user@example.com";
+/** The trigger does not become a link at all. */
+const NO = "";
+
+const PRECEDING: Array<{ prefix: string; name: string; urls: string[] }> = [
+  { prefix: "", name: "start of document", urls: [W, H, E, U] },
+  { prefix: " ", name: "space", urls: [W, H, E, U] },
+  { prefix: "  ", name: "two spaces", urls: [W, H, E, U] },
+  { prefix: "(", name: "`(`", urls: [W, H, E, U] },
+  { prefix: "*", name: "`*`", urls: [W, H, E, U] },
+  { prefix: "_", name: "`_`", urls: [W, H, U, "mailto:__user@example.com"] },
+  { prefix: "~", name: "`~`", urls: [W, H, E, U] },
+  { prefix: "]", name: "`]`", urls: [W, H, E, U] },
+  { prefix: ">", name: "`>` (a blockquote marker here)", urls: [W, H, E, U] },
+  {
+    prefix: ".",
+    name: "`.`",
+    urls: [W, H, "mailto:.user@example.com", "mailto:._user@example.com"],
+  },
+  { prefix: ",", name: "`,`", urls: [W, H, E, U] },
+  { prefix: '"', name: '`"`', urls: [W, H, E, U] },
+  {
+    prefix: "-",
+    name: "`-`",
+    urls: [W, H, "mailto:-user@example.com", "mailto:-_user@example.com"],
+  },
+  { prefix: "|", name: "`|`", urls: [W, H, E, U] },
+  { prefix: "/", name: "`/`", urls: [W, H, NO, E] },
+  { prefix: "[", name: "`[`", urls: [W, H, E, U] },
+  { prefix: "\\", name: "`\\`", urls: [W, H, E, U] },
+  { prefix: "©", name: "So symbol", urls: [W, H, E, U] },
+  { prefix: "€", name: "Sc symbol", urls: [W, H, E, U] },
+  { prefix: "±", name: "Sm symbol", urls: [W, H, E, U] },
+  { prefix: "—", name: "Pd punctuation", urls: [W, H, E, U] },
+  { prefix: "•", name: "Po punctuation", urls: [W, H, E, U] },
+  { prefix: "。", name: "CJK Po punctuation", urls: [W, H, E, U] },
+  { prefix: "（", name: "Ps punctuation", urls: [W, H, E, U] },
+  { prefix: "\u{a0}", name: "Zs space", urls: [W, H, E, U] },
+  {
+    prefix: "5",
+    name: "Nd digit",
+    urls: [NO, H, "mailto:5user@example.com", "mailto:5_user@example.com"],
+  },
+  {
+    prefix: "a",
+    name: "ASCII letter",
+    urls: [NO, NO, "mailto:auser@example.com", "mailto:a_user@example.com"],
+  },
+  { prefix: "α", name: "Ll letter", urls: [NO, H, E, U] },
+  { prefix: "中", name: "Lo letter", urls: [NO, H, E, U] },
+  { prefix: "e\u{301}", name: "Mn combining mark", urls: [NO, H, E, U] },
+  { prefix: "\u{200b}", name: "Cf zero-width space", urls: [NO, H, E, U] },
+  { prefix: "\u{ad}", name: "Cf soft hyphen", urls: [NO, H, E, U] },
+  { prefix: "❤\u{fe0f}", name: "variation selector", urls: [NO, H, E, U] },
+  { prefix: "🯰", name: "astral Nd digit", urls: [NO, H, E, U] },
+  { prefix: "𝐀", name: "astral Lu letter", urls: [NO, H, E, U] },
+  { prefix: "𠀀", name: "astral Lo letter", urls: [NO, H, E, U] },
+];
+
+describe("family A: the preceding-character classifier", () => {
+  test.each(PRECEDING)("$name", ({ prefix, urls }) => {
+    for (const [ix, trigger] of A_TRIGGERS.entries()) {
+      const md = `${prefix}${trigger}\n`;
+      assertMdastConformance(md);
+      expect(linkUrls(md), JSON.stringify(md)).toEqual(urls[ix] === "" ? [] : [urls[ix]]);
+    }
+  });
+
+  // The trigger kinds the four-column table above does not carry.
+  test.each([
+    ["www.example.com/a/b\n", ["http://www.example.com/a/b"]],
+    ["https://example.com/a?b=c#d\n", ["https://example.com/a?b=c#d"]],
+    ["HtTp://Example.COM\n", ["HtTp://Example.COM"]],
+    ["u-s.e_r@sub.example.co.uk\n", ["mailto:u-s.e_r@sub.example.co.uk"]],
+    ["mailto:user@example.com\n", ["mailto:user@example.com"]],
+    ["xmpp:user@example.com\n", ["mailto:user@example.com"]],
+    ["(https://example.com/a?b=c#d\n", ["https://example.com/a?b=c#d"]],
+    ["(mailto:user@example.com\n", ["mailto:user@example.com"]],
+    [".mailto:user@example.com\n", ["mailto:user@example.com"]],
+    [".xmpp:user@example.com\n", ["mailto:user@example.com"]],
+  ])("%j", conforms);
+
+  // Mid-line, the same prefixes classify the same way — except these two, where
+  // the character means something else at the start of a line.
+  test.each([
+    ["x \twww.example.com\n", ["http://www.example.com"]],
+    ["x \tuser@example.com\n", ["mailto:user@example.com"]],
+    ["x \thttp://example.com\n", ["http://example.com"]],
+    ["x >www.example.com\n", ["http://www.example.com"]],
+    ["x >user@example.com\n", ["mailto:user@example.com"]],
+    ["x >http://example.com\n", ["http://example.com"]],
+  ])("%j", conforms);
+});
+
+// Deliberate divergence (see website/content/docs/divergences.md): remark reads
+// the preceding character as one UTF-16 code unit, so an astral one is a lone
+// surrogate and always blocks. Encoded the same way as in autolink-path.test.ts:
+// the reference side is asserted, then satteri's own span.
+describe("family A: astral characters before a GFM autolink (documented divergence)", () => {
+  const ASTRAL: Array<{ prefix: string; name: string }> = [
+    { prefix: "😀", name: "U+1F600 GRINNING FACE (So)" },
+    { prefix: "𐄁", name: "U+10101 AEGEAN WORD SEPARATOR DOT (Po)" },
+    { prefix: "𝛛", name: "U+1D6DB MATHEMATICAL BOLD PARTIAL DIFFERENTIAL (Sm)" },
+    { prefix: "👨\u{200d}💻", name: "a ZWJ sequence ending in U+1F4BB (So)" },
+  ];
+
+  test.each(ASTRAL)("$name", ({ prefix }) => {
+    const md = `${prefix}www.example.com`;
+    const remark = referenceMdast(md) as { children: AnyNode[] };
+    expect(linkUrls(md)).toEqual(["http://www.example.com"]);
+    expect((remark.children[0] as AnyNode).children?.map((c) => c.type)).toEqual(["text"]);
+
+    const link = (satteriMdast(md) as { children: AnyNode[] }).children[0]!.children!.find(
+      (c) => c.type === "link",
+    ) as {
+      position: { start: { offset: number }; end: { offset: number } };
+    };
+    expect(md.slice(link.position.start.offset, link.position.end.offset)).toBe("www.example.com");
+  });
+
+  // Only the `www` trigger diverges: the other two accept the character on both
+  // sides. Astral letters and digits block on both sides, for different reasons.
+  test.each([
+    ["😀user@example.com\n", ["mailto:user@example.com"]],
+    ["😀http://example.com\n", ["http://example.com"]],
+    ["😀_user@example.com\n", ["mailto:_user@example.com"]],
+    ["🯰www.example.com\n", []],
+    ["𝐀www.example.com\n", []],
+  ])("%j", conforms);
+});
+
+// Family B — the trailing-punctuation and trailing-entity rules. Both rules are
+// set-membership tests, so there is one row per member: a member quietly leaving
+// the trim set (or joining it) fails exactly one row here and nothing else.
+// Trailing runs that are not a member and only repeat "left alone" are dropped.
+describe("family B: trailing punctuation and entities", () => {
+  test.each([
+    ["www.example.com\n", ["http://www.example.com"]],
+    ["www.example.com.\n", ["http://www.example.com"]],
+    ["www.example.com...\n", ["http://www.example.com"]],
+    ["www.example.com,\n", ["http://www.example.com"]],
+    ["www.example.com;\n", ["http://www.example.com"]],
+    ["www.example.com:\n", ["http://www.example.com"]],
+    ["www.example.com!\n", ["http://www.example.com"]],
+    ["www.example.com?!\n", ["http://www.example.com"]],
+    ["www.example.com'\n", ["http://www.example.com"]],
+    ['www.example.com"\n', ["http://www.example.com"]],
+    ["www.example.com*\n", ["http://www.example.com"]],
+    ["www.example.com**\n", ["http://www.example.com"]],
+    ["www.example.com_\n", ["http://www.example.com"]],
+    ["www.example.com~~\n", ["http://www.example.com"]],
+    ["www.example.com)\n", ["http://www.example.com"]],
+    ["www.example.com))\n", ["http://www.example.com"]],
+    ["www.example.com(\n", ["http://www.example.com("]],
+    ["www.example.com()\n", ["http://www.example.com()"]],
+    ["www.example.com]\n", ["http://www.example.com"]],
+    ["www.example.com}\n", ["http://www.example.com}"]],
+    ["www.example.com>\n", ["http://www.example.com>"]],
+    ["www.example.com<\n", ["http://www.example.com"]],
+    ["www.example.com-\n", ["http://www.example.com-"]],
+    ["www.example.com\\\n", ["http://www.example.com\\"]],
+    ["www.example.com|\n", ["http://www.example.com|"]],
+    ["www.example.com`\n", ["http://www.example.com`"]],
+    ["www.example.com%\n", ["http://www.example.com%"]],
+    ["www.example.com&amp;.\n", ["http://www.example.com"]],
+    ["www.example.com&copy;\n", ["http://www.example.com"]],
+    ["www.example.com&#35;\n", ["http://www.example.com&#35"]],
+    ["www.example.com&#x23;\n", ["http://www.example.com&#x23"]],
+    ["www.example.com&notreal;\n", ["http://www.example.com"]],
+    ["www.example.com&;\n", ["http://www.example.com&"]],
+    ["www.example.com&amp\n", ["http://www.example.com&amp"]],
+    ["www.example.com&amp;amp;\n", ["http://www.example.com&amp;amp"]],
+    ["www.example.com&nbsp;\n", ["http://www.example.com"]],
+    ["www.example.com&lt;\n", ["http://www.example.com"]],
+    ["www.example.com&#0;\n", ["http://www.example.com&#0"]],
+    ["www.example.com&#xFFFF;\n", ["http://www.example.com&#xFFFF"]],
+    ["www.example.com&#1114112;\n", ["http://www.example.com&#1114112"]],
+  ])("%j", conforms);
+
+  test.each([
+    ["www.example.com/p\n", ["http://www.example.com/p"]],
+    ["www.example.com/p.\n", ["http://www.example.com/p"]],
+    ["www.example.com/p-\n", ["http://www.example.com/p-"]],
+    ["www.example.com/p_\n", ["http://www.example.com/p"]],
+    ["www.example.com/p\\\n", ["http://www.example.com/p\\"]],
+    ["www.example.com/p(\n", ["http://www.example.com/p("]],
+    ["www.example.com/p()\n", ["http://www.example.com/p()"]],
+    ["www.example.com/p)\n", ["http://www.example.com/p"]],
+    ["www.example.com/p))\n", ["http://www.example.com/p"]],
+    ["www.example.com/p&amp;\n", ["http://www.example.com/p"]],
+    ["www.example.com/p&amp;.\n", ["http://www.example.com/p"]],
+    ["www.example.com/p&amp;)\n", ["http://www.example.com/p"]],
+  ])("%j", conforms);
+
+  test.each([
+    ["user@example.com\n", ["mailto:user@example.com"]],
+    ["user@example.com.\n", ["mailto:user@example.com"]],
+    ["user@example.com...\n", ["mailto:user@example.com"]],
+    ["user@example.com,\n", ["mailto:user@example.com"]],
+    ["user@example.com;\n", ["mailto:user@example.com"]],
+    ["user@example.com:\n", ["mailto:user@example.com"]],
+    ["user@example.com!\n", ["mailto:user@example.com"]],
+    ["user@example.com?!\n", ["mailto:user@example.com"]],
+    ["user@example.com'\n", ["mailto:user@example.com"]],
+    ['user@example.com"\n', ["mailto:user@example.com"]],
+    ["user@example.com*\n", ["mailto:user@example.com"]],
+    ["user@example.com**\n", ["mailto:user@example.com"]],
+    ["user@example.com_\n", []],
+    ["user@example.com~~\n", ["mailto:user@example.com"]],
+    ["user@example.com)\n", ["mailto:user@example.com"]],
+    ["user@example.com))\n", ["mailto:user@example.com"]],
+    ["user@example.com(\n", ["mailto:user@example.com"]],
+    ["user@example.com()\n", ["mailto:user@example.com"]],
+    ["user@example.com]\n", ["mailto:user@example.com"]],
+    ["user@example.com}\n", ["mailto:user@example.com"]],
+    ["user@example.com>\n", ["mailto:user@example.com"]],
+    ["user@example.com<\n", ["mailto:user@example.com"]],
+    ["user@example.com-\n", []],
+    ["user@example.com\\\n", ["mailto:user@example.com"]],
+    ["user@example.com|\n", ["mailto:user@example.com"]],
+    ["user@example.com`\n", ["mailto:user@example.com"]],
+    ["user@example.com%\n", ["mailto:user@example.com"]],
+    ["user@example.com&amp;\n", ["mailto:user@example.com"]],
+    ["user@example.com&amp;.\n", ["mailto:user@example.com"]],
+    ["user@example.com&amp;)\n", ["mailto:user@example.com"]],
+    ["user@example.com&copy;\n", ["mailto:user@example.com"]],
+    ["user@example.com&#35;\n", ["mailto:user@example.com"]],
+    ["user@example.com&#x23;\n", ["mailto:user@example.com"]],
+    ["user@example.com&notreal\n", ["mailto:user@example.com"]],
+    ["user@example.com&notreal;\n", ["mailto:user@example.com"]],
+    ["user@example.com&;\n", ["mailto:user@example.com"]],
+    ["user@example.com&amp\n", ["mailto:user@example.com"]],
+    ["user@example.com&amp;amp;\n", ["mailto:user@example.com"]],
+    ["user@example.com&nbsp;\n", ["mailto:user@example.com"]],
+    ["user@example.com&lt;\n", ["mailto:user@example.com"]],
+    ["user@example.com&#0;\n", ["mailto:user@example.com"]],
+    ["user@example.com&#xFFFF;\n", ["mailto:user@example.com"]],
+    ["user@example.com&#1114112;\n", ["mailto:user@example.com"]],
+  ])("%j", conforms);
+
+  // The same trims with text after them, where the trimmed tail has somewhere
+  // to go.
+  test.each([
+    ["see www.example.com end\n", ["http://www.example.com"]],
+    ["see www.example.com. end\n", ["http://www.example.com"]],
+    ["see www.example.com&amp; end\n", ["http://www.example.com"]],
+    ["see www.example.com( end\n", ["http://www.example.com("]],
+    ["see www.example.com< end\n", ["http://www.example.com"]],
+    ["see www.example.com\\ end\n", ["http://www.example.com\\"]],
+    ["see www.example.com** end\n", ["http://www.example.com"]],
+    ["see www.example.com&#1114112; end\n", ["http://www.example.com&#1114112"]],
+  ])("%j", conforms);
+});
+
+// Family C — the GFM balanced-paren rule.
+describe("family C: the balanced-paren rule", () => {
+  test.each([
+    ["www.example.com/a(b\n", ["http://www.example.com/a(b"]],
+    ["www.example.com/a)b\n", ["http://www.example.com/a)b"]],
+    ["www.example.com/a(b)c)\n", ["http://www.example.com/a(b)c"]],
+    ["www.example.com/a(b(c))\n", ["http://www.example.com/a(b(c))"]],
+    ["www.example.com/a(b(c)\n", ["http://www.example.com/a(b(c)"]],
+    ["www.example.com/a((b))\n", ["http://www.example.com/a((b))"]],
+    ["www.example.com/a((b)\n", ["http://www.example.com/a((b)"]],
+    ["www.example.com/(\n", ["http://www.example.com/("]],
+    ["www.example.com/)\n", ["http://www.example.com/"]],
+    ["www.example.com/()\n", ["http://www.example.com/()"]],
+    ["www.example.com/)(\n", ["http://www.example.com/)("]],
+    ["www.example.com/a(b).\n", ["http://www.example.com/a(b)"]],
+    ["www.example.com/a(b)&amp;\n", ["http://www.example.com/a(b)"]],
+    ["http://example.com/a(b)c\n", ["http://example.com/a(b)c"]],
+    ["http://example.com/foo).\n", ["http://example.com/foo"]],
+    ["http://example.com/foo)))\n", ["http://example.com/foo"]],
+    ["http://example.com/(a)(b)\n", ["http://example.com/(a)(b)"]],
+    ["http://example.com/(a)(b\n", ["http://example.com/(a)(b"]],
+    [
+      "https://en.wikipedia.org/wiki/Ruby_(programming_language)\n",
+      ["https://en.wikipedia.org/wiki/Ruby_(programming_language)"],
+    ],
+    [
+      "https://en.wikipedia.org/wiki/Ruby_(programming_language))\n",
+      ["https://en.wikipedia.org/wiki/Ruby_(programming_language)"],
+    ],
+    [
+      "(https://en.wikipedia.org/wiki/Ruby_(programming_language))\n",
+      ["https://en.wikipedia.org/wiki/Ruby_(programming_language)"],
+    ],
+    ["(www.example.com/a)\n", ["http://www.example.com/a"]],
+    ["((www.example.com))\n", ["http://www.example.com"]],
+    ["(www.example.com\n", ["http://www.example.com"]],
+    ["www.example.com)\n", ["http://www.example.com"]],
+    ["x www.example.com/a(b) y\n", ["http://www.example.com/a(b)"]],
+    ["x (www.example.com) y\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});
+
+// Family G — unicode inside and around the URL, and the rule that an underscore
+// may not appear in either of the last two domain labels.
+describe("family G: unicode in and around the URL", () => {
+  test.each([
+    ["www.exämple.com\n", ["http://www.exämple.com"]],
+    ["www.example.com/ä\n", ["http://www.example.com/ä"]],
+    ["www.example.com/é/x\n", ["http://www.example.com/é/x"]],
+    ["www.例え.com\n", ["http://www.例え.com"]],
+    ["www.example.com/中文\n", ["http://www.example.com/中文"]],
+    ["www.example.com/😀\n", ["http://www.example.com/😀"]],
+    ["www.example.com/😀/x\n", ["http://www.example.com/😀/x"]],
+    ["www.example.com/a\u{200b}b\n", ["http://www.example.com/a\u{200b}b"]],
+    ["https://例え.テスト\n", ["https://例え.テスト"]],
+    ["https://example.com/päth?q=ü#frag\n", ["https://example.com/päth?q=ü#frag"]],
+    ["ü@example.com\n", []],
+    ["user@exämple.com\n", []],
+    ["user@例え.com\n", []],
+    ["😀 www.example.com\n", ["http://www.example.com"]],
+    ["www.example.com😀\n", ["http://www.example.com😀"]],
+    ["www.example.com 😀\n", ["http://www.example.com"]],
+    ["中www.example.com\n", []],
+    ["中 www.example.com\n", ["http://www.example.com"]],
+    ["www.example.com中\n", ["http://www.example.com中"]],
+    ["www.example.com/😀.\n", ["http://www.example.com/😀"]],
+    ["www.example.com/a—b\n", ["http://www.example.com/a—b"]],
+    ["www.example.com—\n", ["http://www.example.com—"]],
+    ["www.example.com…\n", ["http://www.example.com…"]],
+    ["www.example.com\u{200b}\n", ["http://www.example.com\u{200b}"]],
+    ["www.example.com\u{a0}x\n", ["http://www.example.com"]],
+    ["www.example.com）\n", ["http://www.example.com）"]],
+    ["www.example.com。\n", ["http://www.example.com。"]],
+    ["x www.exämple.com y\n", ["http://www.exämple.com"]],
+    ["x www.example.com/😀 y\n", ["http://www.example.com/😀"]],
+  ])("%j", conforms);
+});
+
+describe("family G: underscores in the last two domain labels", () => {
+  test.each([
+    ["www.exa_mple.com\n", []],
+    ["www.example_.com\n", []],
+    ["www.example.c_om\n", []],
+    ["www.a.exa_mple.com\n", []],
+    ["www.a_b.example.com\n", ["http://www.a_b.example.com"]],
+    ["www.a_b.c_d.example.com\n", ["http://www.a_b.c_d.example.com"]],
+    ["http://exa_mple.com\n", []],
+    ["http://a.exa_mple.com\n", []],
+    ["http://a_b.c.example.com\n", ["http://a_b.c.example.com"]],
+    ["http://foo_bar.com\n", []],
+    ["http://foo_bar.com.\n", ["http://foo_bar.com"]],
+    ["http://a.b_c\n", []],
+    ["http://a_b\n", []],
+    ["www.a_b\n", []],
+    ["user@exa_mple.com\n", ["mailto:user@exa_mple.com"]],
+    ["user@a.exa_mple.com\n", ["mailto:user@a.exa_mple.com"]],
+    ["user@a_b.example.com\n", ["mailto:user@a_b.example.com"]],
+    ["www.example.com/a_b\n", ["http://www.example.com/a_b"]],
+    ["www.example.com?a_b\n", ["http://www.example.com?a_b"]],
+    ["www.example.com#a_b\n", ["http://www.example.com#a_b"]],
+    ["www.example.com_\n", ["http://www.example.com"]],
+    ["www.example.com__\n", ["http://www.example.com"]],
+    ["www.example.com_x\n", []],
+    ["x www.exa_mple.com y\n", []],
+    ["x http://foo_bar.com. y\n", ["http://foo_bar.com"]],
+  ])("%j", conforms);
+});
+
+// Family H — one case per clause of GFM §6.9 (www / url / email autolink
+// extended). Kept whole apart from the email local-part enumeration, where 19
+// of the 33 characters only repeat "not in the accepted set, so the local part
+// starts after it".
+describe("family H: GFM §6.9 spec clauses", () => {
+  test.each([
+    ["www.commonmark.org\n", ["http://www.commonmark.org"]],
+    ["Visit www.commonmark.org/help for more information.\n", ["http://www.commonmark.org/help"]],
+    [
+      "Visit www.commonmark.org.\n\nVisit www.commonmark.org/a.b.\n",
+      ["http://www.commonmark.org", "http://www.commonmark.org/a.b"],
+    ],
+    [
+      "www.google.com/search?q=Markup+(business)\n",
+      ["http://www.google.com/search?q=Markup+(business)"],
+    ],
+    [
+      "www.google.com/search?q=Markup+(business))\n",
+      ["http://www.google.com/search?q=Markup+(business)"],
+    ],
+    [
+      "(www.google.com/search?q=Markup+(business))\n",
+      ["http://www.google.com/search?q=Markup+(business)"],
+    ],
+    [
+      "(www.google.com/search?q=Markup+(business)\n",
+      ["http://www.google.com/search?q=Markup+(business)"],
+    ],
+    ["www.google.com/search?q=(business))+ok\n", ["http://www.google.com/search?q=(business))+ok"]],
+    [
+      "www.google.com/search?q=commonmark&hl=en\n",
+      ["http://www.google.com/search?q=commonmark&hl=en"],
+    ],
+    ["www.google.com/search?q=commonmark&hl;\n", ["http://www.google.com/search?q=commonmark"]],
+    ["www.commonmark.org/he<lp\n", ["http://www.commonmark.org/he"]],
+    ["http://commonmark.org\n", ["http://commonmark.org"]],
+    [
+      "(Visit https://encrypted.google.com/search?q=Markup+(business))\n",
+      ["https://encrypted.google.com/search?q=Markup+(business)"],
+    ],
+    ["Anonymous FTP is available at ftp://foo.bar.baz.\n", []],
+    ["foo@bar.baz\n", ["mailto:foo@bar.baz"]],
+    [
+      "hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.\n",
+      ["mailto:hello+xyz@mail.example"],
+    ],
+    ["a.b-c_d@a.b\n", ["mailto:a.b-c_d@a.b"]],
+    ["a.b-c_d@a.b.\n", ["mailto:a.b-c_d@a.b"]],
+    ["a.b-c_d@a.b-\n", []],
+    ["a.b-c_d@a.b_\n", []],
+    ["user@localhost\n", []],
+    ["http://a\n", ["http://a"]],
+    ["http://.\n", []],
+    ["http://.com\n", ["http://.com"]],
+    ["www..com\n", ["http://www..com"]],
+    ["http:/example.com\n", []],
+    ["http:example.com\n", []],
+    ["://example.com\n", []],
+    ["@example.com\n", []],
+    ["user@\n", []],
+    ["user@.com\n", ["mailto:user@.com"]],
+    ["user@-.com\n", ["mailto:user@-.com"]],
+    ["user@a..b\n", []],
+    ["user@a.b..\n", ["mailto:user@a.b"]],
+    ["www.-example.com\n", ["http://www.-example.com"]],
+    ["www.example-.com\n", ["http://www.example-.com"]],
+    ["www.exam-ple.com\n", ["http://www.exam-ple.com"]],
+    ["http://a-b.c-d.example.com\n", ["http://a-b.c-d.example.com"]],
+    ["HTTPS://example.com\n", ["HTTPS://example.com"]],
+    ["WWW.example.com\n", ["http://WWW.example.com"]],
+    ["wWw.example.com\n", ["http://wWw.example.com"]],
+    ["5www.example.com\n", []],
+    ["awww.example.com\n", []],
+    ["a.www.example.com\n", ["http://www.example.com"]],
+    ["xhttp://example.com\n", []],
+    ["5http://example.com\n", ["http://example.com"]],
+    [".http://example.com\n", ["http://example.com"]],
+    ["-http://example.com\n", ["http://example.com"]],
+    ["_http://example.com\n", ["http://example.com"]],
+    ["a+b@c.com\n", ["mailto:a+b@c.com"]],
+    ["a-b@c.com\n", ["mailto:a-b@c.com"]],
+    ["a.b@c.com\n", ["mailto:a.b@c.com"]],
+    ["a_b@c.com\n", ["mailto:a_b@c.com"]],
+    ["a!b@c.com\n", ["mailto:b@c.com"]],
+    ["a%b@c.com\n", ["mailto:b@c.com"]],
+    ["a\\b@c.com\n", ["mailto:b@c.com"]],
+    ["a<b@c.com\n", ["mailto:b@c.com"]],
+    ["a|b@c.com\n", ["mailto:b@c.com"]],
+    ['a"b@c.com\n', ["mailto:b@c.com"]],
+    ["a`b@c.com\n", ["mailto:b@c.com"]],
+    ["a@b@c.com\n", ["mailto:b@c.com"]],
+    [".a@b.com\n", ["mailto:.a@b.com"]],
+    ["-a@b.com\n", ["mailto:-a@b.com"]],
+    ["_a@b.com\n", ["mailto:_a@b.com"]],
+    ["+a@b.com\n", ["mailto:+a@b.com"]],
+    ["www.example.com/a-\n", ["http://www.example.com/a-"]],
+    ["www.example.com/a_\n", ["http://www.example.com/a"]],
+    ["user@example.com-\n", []],
+    ["user@example.com_\n", []],
+    ["user@example.co-m\n", ["mailto:user@example.co-m"]],
+    ["user@example.co_m\n", ["mailto:user@example.co_m"]],
+    ["http://example.com/a<b\n", ["http://example.com/a"]],
+    ["user@example.com<x\n", ["mailto:user@example.com"]],
+    ["www.example.com<\n", ["http://www.example.com"]],
+    ["www.example.com/?a=1&b=2;\n", ["http://www.example.com/?a=1&b=2"]],
+    ["www.example.com&amp;;\n", ["http://www.example.com"]],
+    ["www.example.com;\n", ["http://www.example.com"]],
+    ["www.example.com&;\n", ["http://www.example.com&"]],
+    ["www.example.com&x;\n", ["http://www.example.com"]],
+    ["www.example.com&#;\n", ["http://www.example.com&#"]],
+    ["www.example.com&ampx;\n", ["http://www.example.com"]],
+    ["www.example.com/a&amp;b\n", ["http://www.example.com/a&amp;b"]],
+    ["http://example.com?a&copy;\n", ["http://example.com?a"]],
+  ])("%j", conforms);
+});
+
+// Family J — unicode whitespace. link-edge-cases.test.ts already covers it
+// inside a www/http URL body; these are the shapes it does not reach: the email
+// forms, the preceding-character (boundary) forms, and the find-and-replace
+// path. U+0085 is the boundary the `www` classifier had to be taught, and the two
+// `Cf` code points are the controls that must stay inside the URL.
+describe("family J: unicode whitespace as terminator and boundary", () => {
+  test.each([
+    ["user@example.com\u{85}x\n", ["mailto:user@example.com"]],
+    ["user@exa\u{85}mple.com\n", []],
+    ["https://example.com\u{85}\n", ["https://example.com\u{85}"]],
+    ["x\u{85}www.example.com\n", []],
+    ["x\u{85}http://example.com\n", ["http://example.com"]],
+    ["x\u{85}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{85}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{85}q\n", ["http://www.example.com/p\u{85}q"]],
+    ["[a x\u{85}www.example.com\n", []],
+    ["user@example.com\u{a0}x\n", ["mailto:user@example.com"]],
+    ["user@exa\u{a0}mple.com\n", []],
+    ["https://example.com\u{a0}\n", ["https://example.com"]],
+    ["x\u{a0}www.example.com\n", ["http://www.example.com"]],
+    ["x\u{a0}http://example.com\n", ["http://example.com"]],
+    ["x\u{a0}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{a0}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{a0}q\n", ["http://www.example.com/p\u{a0}q"]],
+    ["[a x\u{a0}www.example.com\n", ["http://www.example.com"]],
+    ["user@example.com\u{2028}x\n", ["mailto:user@example.com"]],
+    ["user@exa\u{2028}mple.com\n", []],
+    ["https://example.com\u{2028}\n", ["https://example.com"]],
+    ["x\u{2028}www.example.com\n", ["http://www.example.com"]],
+    ["x\u{2028}http://example.com\n", ["http://example.com"]],
+    ["x\u{2028}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{2028}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{2028}q\n", ["http://www.example.com/p\u{2028}q"]],
+    ["[a x\u{2028}www.example.com\n", ["http://www.example.com"]],
+    ["user@example.com\u{3000}x\n", ["mailto:user@example.com"]],
+    ["user@exa\u{3000}mple.com\n", []],
+    ["https://example.com\u{3000}\n", ["https://example.com"]],
+    ["x\u{3000}www.example.com\n", ["http://www.example.com"]],
+    ["x\u{3000}http://example.com\n", ["http://example.com"]],
+    ["x\u{3000}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{3000}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{3000}q\n", ["http://www.example.com/p\u{3000}q"]],
+    ["[a x\u{3000}www.example.com\n", ["http://www.example.com"]],
+    ["user@example.com\u{200b}x\n", ["mailto:user@example.com"]],
+    ["user@exa\u{200b}mple.com\n", []],
+    ["https://example.com\u{200b}\n", ["https://example.com\u{200b}"]],
+    ["x\u{200b}www.example.com\n", []],
+    ["x\u{200b}http://example.com\n", ["http://example.com"]],
+    ["x\u{200b}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{200b}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{200b}q\n", ["http://www.example.com/p\u{200b}q"]],
+    ["[a x\u{200b}www.example.com\n", []],
+    ["user@exa\u{feff}mple.com\n", []],
+    ["x\u{feff}www.example.com\n", ["http://www.example.com"]],
+    ["x\u{feff}http://example.com\n", ["http://example.com"]],
+    ["x\u{feff}user@example.com\n", ["mailto:user@example.com"]],
+    ["x\u{feff}_user@example.com\n", ["mailto:_user@example.com"]],
+    ["[a www.example.com/p\u{feff}q\n", ["http://www.example.com/p\u{feff}q"]],
+    ["[a x\u{feff}www.example.com\n", ["http://www.example.com"]],
+  ])("%j", conforms);
+});

--- a/packages/satteri/test/conformance/autolink-path.test.ts
+++ b/packages/satteri/test/conformance/autolink-path.test.ts
@@ -2,9 +2,12 @@ import { describe, test, expect } from "vitest";
 import {
   assertMdastConformance,
   assertSliceInvariantEverywhere,
+  conforms,
+  linkUrls,
   referenceMdast,
   satteriMdast,
 } from "./helpers.js";
+import type { UrlNode } from "./helpers.js";
 
 // Telling satteri's two autolink routes apart needs parser internals, so that
 // half of the probe is `autolink_path_probe` in `crates/satteri-pulldown-cmark`.
@@ -149,20 +152,42 @@ describe("GFM autolink preceding-character rules", () => {
 // code unit, so an astral one is a lone surrogate and always rejected; satteri
 // classifies the whole scalar. See website/content/docs/divergences.md.
 describe("divergence: astral characters before a GFM autolink", () => {
-  const ASTRAL = [
+  // The categories the classifier lets through, so satteri links and remark
+  // does not.
+  const ACCEPTED = [
     { prefix: "\u{10101}", name: "U+10101 AEGEAN WORD SEPARATOR DOT (Po)" },
     { prefix: "\u{1F600}", name: "U+1F600 GRINNING FACE (So)" },
     { prefix: "\u{1D6DB}", name: "U+1D6DB MATHEMATICAL BOLD PARTIAL DIFFERENTIAL (Sm)" },
-    // `Nd`, so both sides reject it — for different reasons, which is the point.
-    { prefix: "\u{1FBF0}", name: "U+1FBF0 SEGMENTED DIGIT ZERO (Nd)" },
+    { prefix: "\u{1F468}\u{200d}\u{1F4BB}", name: "a ZWJ sequence ending in U+1F4BB (So)" },
   ];
 
-  test.each(ASTRAL)("$name starts nothing in remark", ({ prefix }) => {
+  // `Nd`, so both sides reject it — for different reasons, which is the point.
+  const REJECTED = [{ prefix: "\u{1FBF0}", name: "U+1FBF0 SEGMENTED DIGIT ZERO (Nd)" }];
+
+  test.each([...ACCEPTED, ...REJECTED])("$name starts nothing in remark", ({ prefix }) => {
     expect(referencePaths(`${prefix}www.x.y`)).toEqual([]);
     for (const trigger of TRIGGERS) {
       expect(referencePaths(`[${prefix}${trigger}`)).toEqual([]);
     }
   });
+
+  // The span has to stop at the trigger, not swallow the character before it.
+  test.each(ACCEPTED)("$name: satteri links, starting at the trigger", ({ prefix }) => {
+    const md = `${prefix}www.example.com`;
+    expect(linkUrls(md)).toEqual(["http://www.example.com"]);
+
+    const link = collectLinks(satteriMdast(md))[0] as UrlNode;
+    const { start, end } = link.position!;
+    expect(md.slice(start.offset, end.offset)).toBe("www.example.com");
+  });
+
+  // Only the `www` trigger diverges: the other two accept the character on
+  // both sides.
+  test.each([
+    ["\u{1F600}user@example.com\n", ["mailto:user@example.com"]],
+    ["\u{1F600}http://example.com\n", ["http://example.com"]],
+    ["\u{1F600}_user@example.com\n", ["mailto:_user@example.com"]],
+  ])("%j", conforms);
 });
 
 describe("GFM autolink path selection", () => {

--- a/packages/satteri/test/conformance/helpers.ts
+++ b/packages/satteri/test/conformance/helpers.ts
@@ -549,6 +549,36 @@ export function assertMdastConformance(md: string): void {
   expect(actual).toEqual(expected);
 }
 
+/** The part of an mdast node the autolink suites walk. */
+export interface UrlNode {
+  type: string;
+  url?: string;
+  children?: UrlNode[];
+  position?: { start: { offset: number }; end: { offset: number } };
+}
+
+/** Every `link` URL in document order. */
+export function collectUrls(tree: unknown): string[] {
+  const out: string[] = [];
+  const walk = (node: UrlNode): void => {
+    if (node.type === "link") out.push(String(node.url));
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(tree as UrlNode);
+  return out;
+}
+
+/** Every `link` URL satteri produces for `md`, in document order. */
+export function linkUrls(md: string): string[] {
+  return collectUrls(satteriMdast(md));
+}
+
+/** The tree matches remark, and the autolinks are the ones named. */
+export function conforms(md: string, urls: string[]): void {
+  assertMdastConformance(md);
+  expect(linkUrls(md), JSON.stringify(md)).toEqual(urls);
+}
+
 /** Like `assertMdastConformance` but strips `position` fields before
  * comparing. Useful when the structural mdast matches but offsets diverge
  * in non-load-bearing ways (e.g. EOF accounting around trailing blanks). */


### PR DESCRIPTION
Distils a 3,234-case hand-crafted GFM autolink differential matrix into 534 permanent conformance tests, organised by the matrix's families.