### PR TITLE
chore(ci): typecheck the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
         run: pnpm run build:ts
         working-directory: packages/satteri
 
+      - name: Typecheck
+        run: pnpm run typecheck
+        working-directory: packages/satteri
+
       - name: Build NAPI binding
         run: pnpm run build:binary:native:debug
         working-directory: packages/satteri

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -43,6 +43,7 @@
     "build:binary:native:debug": "napi build --manifest-path ../../crates/satteri-napi-binding/Cargo.toml --output-dir . --platform --esm",
     "postbuild:binary:native:debug": "node patch-binding.js",
     "build:ts": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
     "build": "pnpm build:ts && pnpm build:binary:native",
     "build:wasm": "pnpm build:ts && pnpm build:binary:wasm",
     "artifacts": "napi create-npm-dirs && napi artifacts",

--- a/packages/satteri/test/conformance/definition-list.test.ts
+++ b/packages/satteri/test/conformance/definition-list.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { markdownToHtml, mdxToJs } from "../../src/index.js";
+import type { MdastNode } from "../../src/types.js";
 import {
   createMdastHandle,
   getHandleSource,

--- a/packages/satteri/test/raw-html-conformance.test.ts
+++ b/packages/satteri/test/raw-html-conformance.test.ts
@@ -146,7 +146,7 @@ describe("rawHtml conformance vs rehype-raw", () => {
   for (const { name, md } of cases) {
     test(`serialized HTML matches: ${name}`, () => {
       const ours = markdownToHast(md, { features: { rawHtml: true } });
-      expect(stringify(ours)).toBe(reference.stringify(referenceTree(md)));
+      expect(stringify(ours)).toBe(stringify(referenceTree(md)));
     });
 
     test(`hast tree matches: ${name}`, () => {


### PR DESCRIPTION
Runs `tsc --noEmit` over `test/` in CI so the suite's `@ts-expect-error`s and type assertions are actually enforced.