### PR TITLE
feat(plugin-api): plugin factories receive a pre-compile context

### DIFF
--- a/.sampo/changesets/plugin-factory-context.md
+++ b/.sampo/changesets/plugin-factory-context.md
@@ -11,3 +11,5 @@ const onlyChangelogs = (ctx) =>
 
 markdownToHtml(source, { mdastPlugins: [onlyChangelogs, myPlugin] });
 ```
+
+Anything else in a plugin list now fails with an error naming the option and what it expected.

--- a/.sampo/changesets/plugin-factory-context.md
+++ b/.sampo/changesets/plugin-factory-context.md
@@ -1,0 +1,13 @@
+---
+npm/satteri: minor
+npm/vite-plugin-satteri: minor
+---
+
+Added a way to run a plugin only on some documents: a plugin factory now receives the file's `fileURL`, `sourceFormat`, `source` and `data`, and can return `null`, `undefined` or `false` to be left out for that document. Those skip values are also accepted anywhere a plugin entry can appear.
+
+```js
+const onlyChangelogs = (ctx) =>
+  ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null;
+
+markdownToHtml(source, { mdastPlugins: [onlyChangelogs, myPlugin] });
+```

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -619,7 +619,10 @@ type ResolveInput<P, D extends readonly unknown[] = [0, 0, 0, 0, 0, 0, 0, 0]> = 
 ]
   ? P extends ReadonlyArray<infer Item>
     ? ResolveInput<Item, Rest>
-    : P extends () => infer Def
+    : // Must tolerate parameters: a factory taking a `PluginFactoryContext` is
+      // not assignable to `() => infer Def`, so matching on the nullary form
+      // silently drops it here and the compile narrows to a sync result.
+      P extends (...args: never[]) => infer Def
       ? ResolveInput<Def, Rest>
       : P
   : never;
@@ -648,8 +651,22 @@ export function markdownToHtml(
   options: CompileOptions = {},
 ): MarkdownToHtmlResult | Promise<MarkdownToHtmlResult> {
   const { features, fileURL, data = {} } = options;
-  const mdastPlugins = normalizePlugins(options.mdastPlugins ?? [], "mdastPlugins");
-  const hastPlugins = normalizePlugins(options.hastPlugins ?? [], "hastPlugins");
+  const mdastPlugins = normalizePlugins(
+    options.mdastPlugins ?? [],
+    "mdastPlugins",
+    source,
+    fileURL,
+    "markdown",
+    data,
+  );
+  const hastPlugins = normalizePlugins(
+    options.hastPlugins ?? [],
+    "hastPlugins",
+    source,
+    fileURL,
+    "markdown",
+    data,
+  );
   const hastMayHaveStubs = hastPlugins.length > 0;
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =
     featuresToNative(features);
@@ -827,8 +844,23 @@ function toJsImpl(
     data = {},
     ...mdxFields
   } = options;
-  const mdastPlugins = normalizePlugins(mdastInput, "mdastPlugins");
-  const hastPlugins = normalizePlugins(hastInput, "hastPlugins");
+  const sourceFormat: SourceFormat = mdx ? "mdx" : "markdown";
+  const mdastPlugins = normalizePlugins(
+    mdastInput,
+    "mdastPlugins",
+    source,
+    fileURL,
+    sourceFormat,
+    data,
+  );
+  const hastPlugins = normalizePlugins(
+    hastInput,
+    "hastPlugins",
+    source,
+    fileURL,
+    sourceFormat,
+    data,
+  );
   const hastMayHaveStubs = hastPlugins.length > 0;
   const mdxOptions = mdxOptionsToNative(mdxFields);
   const { features: nativeFeatures, convertOptions: nativeConvertOptions } =

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -619,9 +619,7 @@ type ResolveInput<P, D extends readonly unknown[] = [0, 0, 0, 0, 0, 0, 0, 0]> = 
 ]
   ? P extends ReadonlyArray<infer Item>
     ? ResolveInput<Item, Rest>
-    : // Must tolerate parameters: a factory taking a `PluginFactoryContext` is
-      // not assignable to `() => infer Def`, so matching on the nullary form
-      // silently drops it here and the compile narrows to a sync result.
+    : // A factory taking a ctx is not assignable to `() => infer Def`, which would drop it as sync.
       P extends (...args: never[]) => infer Def
       ? ResolveInput<Def, Rest>
       : P

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -36,6 +36,7 @@ export type {
   HastPluginEntry,
   MdastPluginList,
   HastPluginList,
+  PluginFactoryContext,
 } from "./plugin.js";
 
 // Visitor types (for plugin authors)

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -1,5 +1,24 @@
 import type { MdastPluginInstance } from "./mdast/mdast-visitor.js";
 import type { HastVisitorInstance } from "./hast/hast-visitor.js";
+import type { Data, SourceFormat } from "./types.js";
+
+/**
+ * What a plugin factory is told about the document, before it is parsed.
+ *
+ * Mirrors the fields a visitor's `ctx` exposes, minus everything that only
+ * exists once there is a tree. Return a skip value from the factory to leave
+ * the plugin out of the pipeline for this document.
+ */
+export interface PluginFactoryContext {
+  /** The `fileURL` compile option, or `undefined` when none was given. */
+  fileURL: URL | undefined;
+  /** Which kind of document is being compiled. */
+  sourceFormat: SourceFormat;
+  /** The unparsed source. Intended for cheap checks, not for parsing Markdown. */
+  source: string;
+  /** The document-level data bag, before any plugin has run. */
+  data: Data;
+}
 
 export type MdastPluginDefinition = MdastPluginInstance & { name: string };
 
@@ -19,7 +38,7 @@ export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition
 
 type PluginEntry<D> =
   | D
-  | (() => PluginEntry<D>)
+  | ((ctx: PluginFactoryContext) => PluginEntry<D>)
   | readonly PluginEntry<D>[]
   | null
   | undefined
@@ -45,8 +64,18 @@ const MAX_FACTORY_DEPTH = 10;
 /** The one place a plugin option becomes the definition array the pipeline
  *  runs. Factories resolve here and nowhere else, so each is called once per
  *  compile no matter how deeply it is nested. */
-export function normalizePlugins<D>(entries: readonly PluginEntry<D>[], option: string): D[] {
+// The context is taken apart rather than passed whole so it can be built on
+// the first factory encountered: a list with no factories allocates nothing.
+export function normalizePlugins<D>(
+  entries: readonly PluginEntry<D>[],
+  option: string,
+  source: string,
+  fileURL: URL | undefined,
+  sourceFormat: SourceFormat,
+  data: Data,
+): D[] {
   const out: D[] = [];
+  let ctx: PluginFactoryContext | undefined;
   const walk = (entry: PluginEntry<D>, factoryDepth: number): void => {
     // Only these three, not every falsy value, so a stray `0` or `""` still
     // reaches the push below and surfaces as a bad plugin rather than vanishing.
@@ -62,7 +91,8 @@ export function normalizePlugins<D>(entries: readonly PluginEntry<D>[], option: 
             `A factory may return a plugin or a list of plugins, but that list must not lead back to the same factory.`,
         );
       }
-      walk((entry as () => PluginEntry<D>)(), factoryDepth - 1);
+      ctx ??= { fileURL, sourceFormat, source, data };
+      walk((entry as (ctx: PluginFactoryContext) => PluginEntry<D>)(ctx), factoryDepth - 1);
       return;
     }
     out.push(entry as D);

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -11,13 +11,13 @@ import type { Data, SourceFormat } from "./types.js";
  */
 export interface PluginFactoryContext {
   /** The `fileURL` compile option, or `undefined` when none was given. */
-  fileURL: URL | undefined;
+  readonly fileURL: URL | undefined;
   /** Which kind of document is being compiled. */
-  sourceFormat: SourceFormat;
+  readonly sourceFormat: SourceFormat;
   /** The unparsed source. Intended for cheap checks, not for parsing Markdown. */
-  source: string;
+  readonly source: string;
   /** The document-level data bag, before any plugin has run. */
-  data: Data;
+  readonly data: Data;
 }
 
 export type MdastPluginDefinition = MdastPluginInstance & { name: string };
@@ -77,8 +77,8 @@ export function normalizePlugins<D>(
   const out: D[] = [];
   let ctx: PluginFactoryContext | undefined;
   const walk = (entry: PluginEntry<D>, factoryDepth: number): void => {
-    // Only these three, not every falsy value, so a stray `0` or `""` still
-    // reaches the push below and surfaces as a bad plugin rather than vanishing.
+    // Only these three, not every falsy value: a stray `0` or `""` is a
+    // mistake, so it reaches the push below and fails rather than vanishing.
     if (entry === null || entry === undefined || entry === false) return;
     if (Array.isArray(entry)) {
       for (const item of entry as readonly PluginEntry<D>[]) walk(item, factoryDepth);

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -5,9 +5,8 @@ import type { Data, SourceFormat } from "./types.js";
 /**
  * What a plugin factory is told about the document, before it is parsed.
  *
- * Mirrors the fields a visitor's `ctx` exposes, minus everything that only
- * exists once there is a tree. Return a skip value from the factory to leave
- * the plugin out of the pipeline for this document.
+ * Return `null`, `undefined` or `false` from the factory to leave the plugin
+ * out of the pipeline for this document.
  */
 export interface PluginFactoryContext {
   /** The `fileURL` compile option, or `undefined` when none was given. */
@@ -23,18 +22,6 @@ export interface PluginFactoryContext {
 export type MdastPluginDefinition = MdastPluginInstance & { name: string };
 
 export type HastPluginDefinition = HastVisitorInstance & { name: string };
-
-/**
- * A definition reused across documents, or a factory called once per compile
- * so closures reset per document.
- */
-export type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinition);
-
-/**
- * A definition reused across documents, or a factory called once per compile
- * so closures reset per document.
- */
-export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
 
 type PluginEntry<D> =
   | D
@@ -56,6 +43,12 @@ export type MdastPluginList = readonly MdastPluginEntry[];
 /** Value accepted by the `hastPlugins` option. */
 export type HastPluginList = readonly HastPluginEntry[];
 
+/** Older name for {@link MdastPluginEntry}. */
+export type MdastPluginInput = MdastPluginEntry;
+
+/** Older name for {@link HastPluginEntry}. */
+export type HastPluginInput = HastPluginEntry;
+
 /** Bounds factory-in-factory nesting. Real presets nest one level; anything
  *  deeper is a factory that leads back to itself, which would otherwise recurse
  *  until the stack overflows. */
@@ -64,8 +57,6 @@ const MAX_FACTORY_DEPTH = 10;
 /** The one place a plugin option becomes the definition array the pipeline
  *  runs. Factories resolve here and nowhere else, so each is called once per
  *  compile no matter how deeply it is nested. */
-// The context is taken apart rather than passed whole so it can be built on
-// the first factory encountered: a list with no factories allocates nothing.
 export function normalizePlugins<D>(
   entries: readonly PluginEntry<D>[],
   option: string,
@@ -75,10 +66,9 @@ export function normalizePlugins<D>(
   data: Data,
 ): D[] {
   const out: D[] = [];
+  // Built lazily so a list with no factories allocates no context.
   let ctx: PluginFactoryContext | undefined;
   const walk = (entry: PluginEntry<D>, factoryDepth: number): void => {
-    // Only these three, not every falsy value: a stray `0` or `""` is a
-    // mistake, so it reaches the push below and fails rather than vanishing.
     if (entry === null || entry === undefined || entry === false) return;
     if (Array.isArray(entry)) {
       for (const item of entry as readonly PluginEntry<D>[]) walk(item, factoryDepth);
@@ -87,13 +77,17 @@ export function normalizePlugins<D>(
     if (typeof entry === "function") {
       if (factoryDepth === 0) {
         throw new Error(
-          `${option}: plugin factory nesting is too deep — a factory most likely returns itself. ` +
+          `${option}: plugin factory nesting is too deep. A factory most likely returns itself. ` +
             `A factory may return a plugin or a list of plugins, but that list must not lead back to the same factory.`,
         );
       }
-      ctx ??= { fileURL, sourceFormat, source, data };
+      // `data` stays mutable on purpose: it is the live bag the visitors share.
+      ctx ??= Object.freeze({ fileURL, sourceFormat, source, data });
       walk((entry as (ctx: PluginFactoryContext) => PluginEntry<D>)(ctx), factoryDepth - 1);
       return;
+    }
+    if (typeof entry !== "object") {
+      throw new Error(`${option}: expected a plugin, a factory, a list, or null/undefined/false`);
     }
     out.push(entry as D);
   };

--- a/packages/satteri/src/plugin.ts
+++ b/packages/satteri/src/plugin.ts
@@ -17,7 +17,13 @@ export type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinit
  */
 export type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
 
-type PluginEntry<D> = D | (() => PluginEntry<D>) | readonly PluginEntry<D>[];
+type PluginEntry<D> =
+  | D
+  | (() => PluginEntry<D>)
+  | readonly PluginEntry<D>[]
+  | null
+  | undefined
+  | false;
 
 /** Entry accepted by `mdastPlugins`. */
 export type MdastPluginEntry = PluginEntry<MdastPluginDefinition>;
@@ -42,6 +48,9 @@ const MAX_FACTORY_DEPTH = 10;
 export function normalizePlugins<D>(entries: readonly PluginEntry<D>[], option: string): D[] {
   const out: D[] = [];
   const walk = (entry: PluginEntry<D>, factoryDepth: number): void => {
+    // Only these three, not every falsy value, so a stray `0` or `""` still
+    // reaches the push below and surfaces as a bad plugin rather than vanishing.
+    if (entry === null || entry === undefined || entry === false) return;
     if (Array.isArray(entry)) {
       for (const item of entry as readonly PluginEntry<D>[]) walk(item, factoryDepth);
       return;

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -6,7 +6,7 @@ import {
   defineMdastPlugin,
   defineHastPlugin,
 } from "../src/index.js";
-import type { MarkdownToHtmlResult } from "../src/index.js";
+import type { MarkdownToHtmlResult, MdastPluginEntry } from "../src/index.js";
 
 /** Records its name on each heading, making run order observable. */
 function recordMdast(order: string[], name: string) {
@@ -224,6 +224,31 @@ describe("nested plugin lists", () => {
     );
     expect(() => markdownToHtml("# T", { hastPlugins: [cyclic as never] })).toThrowError(
       /^hastPlugins: plugin factory nesting is too deep/,
+    );
+  });
+
+  test("factories nest ten deep, and the eleventh is rejected", () => {
+    const order: string[] = [];
+    const nest = (depth: number, plugin: MdastPluginEntry): MdastPluginEntry =>
+      depth === 0 ? plugin : () => nest(depth - 1, plugin);
+
+    markdownToHtml("# T", { mdastPlugins: [nest(10, recordMdast(order, "deep"))] });
+    expect(order).toEqual(["deep"]);
+
+    expect(() =>
+      markdownToHtml("# T", { mdastPlugins: [nest(11, recordMdast(order, "too-deep"))] }),
+    ).toThrowError(/^mdastPlugins: plugin factory nesting is too deep/);
+  });
+
+  test("an entry that is neither a plugin, factory, list nor skip value is rejected", () => {
+    expect(() => markdownToHtml("# T", { mdastPlugins: [0 as never] })).toThrowError(
+      /^mdastPlugins: expected a plugin, a factory, a list, or null\/undefined\/false/,
+    );
+    expect(() => markdownToHtml("# T", { hastPlugins: ["" as never] })).toThrowError(
+      /^hastPlugins: expected a plugin, a factory, a list, or null\/undefined\/false/,
+    );
+    expect(() => markdownToHtml("# T", { mdastPlugins: [true as never] })).toThrowError(
+      /^mdastPlugins: expected a plugin/,
     );
   });
 

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -90,6 +90,76 @@ describe("nested plugin lists", () => {
     expect(result.html).toContain("<h1>Title</h1>");
   });
 
+  test("null, undefined and false entries are skipped", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [null, recordMdast(order, "a"), undefined, false, recordMdast(order, "b")],
+    });
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("skip entries are skipped inside a nested bundle", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [[null, recordMdast(order, "a")], [[false, recordMdast(order, "b")]]],
+    });
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("an inline condition can drop a plugin from the list", () => {
+    const order: string[] = [];
+    const enabled = false;
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [enabled && recordMdast(order, "off"), recordMdast(order, "on")],
+    });
+
+    expect(order).toEqual(["on"]);
+  });
+
+  test("a factory may return a skip value instead of a plugin", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [() => null, recordMdast(order, "a"), () => undefined, () => false],
+    });
+
+    expect(order).toEqual(["a"]);
+  });
+
+  test("a factory returning a skip value drops the whole bundle it would have returned", () => {
+    const order: string[] = [];
+    const preset = (enabled: boolean) => () =>
+      enabled ? [recordMdast(order, "a"), recordMdast(order, "b")] : null;
+
+    markdownToHtml("# Title", { mdastPlugins: [preset(false), preset(true)] });
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("a list of only skip values compiles as if no plugins were passed", () => {
+    const result = markdownToHtml("# Title", {
+      mdastPlugins: [null, undefined, false, [null], () => null],
+      hastPlugins: [false, () => undefined],
+    });
+
+    expect(result.html).toContain("<h1>Title</h1>");
+  });
+
+  test("hast entries accept skip values too", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", {
+      hastPlugins: [null, recordHast(order, "a"), false, () => null],
+    });
+
+    expect(order).toEqual(["a"]);
+  });
+
   test("factories inside a bundle are invoked once per compile", () => {
     let calls = 0;
     const factory = () => {

--- a/packages/satteri/test/plugin-bundles.test.ts
+++ b/packages/satteri/test/plugin-bundles.test.ts
@@ -147,7 +147,7 @@ describe("nested plugin lists", () => {
       hastPlugins: [false, () => undefined],
     });
 
-    expect(result.html).toContain("<h1>Title</h1>");
+    expect(result.html).toBe(markdownToHtml("# Title").html);
   });
 
   test("hast entries accept skip values too", () => {

--- a/packages/satteri/test/plugin-factory-context.test-d.ts
+++ b/packages/satteri/test/plugin-factory-context.test-d.ts
@@ -1,0 +1,96 @@
+import { markdownToHtml, mdxToJs, defineMdastPlugin, defineHastPlugin } from "../src/index.js";
+import type { PluginFactoryContext } from "../src/index.js";
+
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+type IsPromise<T> = [T] extends [Promise<unknown>] ? true : false;
+
+const asyncMdast = defineMdastPlugin({
+  name: "async-mdast",
+  async code() {
+    await Promise.resolve();
+  },
+});
+
+const syncMdast = defineMdastPlugin({
+  name: "sync-mdast",
+  code() {},
+});
+
+const asyncHast = defineHastPlugin({
+  name: "async-hast",
+  async text() {
+    await Promise.resolve();
+  },
+});
+
+// `ResolveInput` matches factories structurally. A factory taking a ctx is not
+// assignable to `() => infer Def`, so if that pattern loses its parameters the
+// async plugin behind it goes unseen and these flip to `false`.
+const ctxFactoryAsync = markdownToHtml("x", {
+  mdastPlugins: [(ctx: PluginFactoryContext) => (ctx.sourceFormat === "mdx" ? asyncMdast : null)],
+});
+export type _CtxFactoryAsync = Expect<IsPromise<typeof ctxFactoryAsync>>;
+
+const ctxFactoryAsyncHast = markdownToHtml("x", {
+  hastPlugins: [(ctx: PluginFactoryContext) => (ctx.source ? asyncHast : undefined)],
+});
+export type _CtxFactoryAsyncHast = Expect<IsPromise<typeof ctxFactoryAsyncHast>>;
+
+const ctxFactoryBundleAsync = mdxToJs("x", {
+  mdastPlugins: [(ctx: PluginFactoryContext) => (ctx.fileURL ? [syncMdast, asyncMdast] : false)],
+});
+export type _CtxFactoryBundleAsync = Expect<IsPromise<typeof ctxFactoryBundleAsync>>;
+
+const nestedCtxFactoryAsync = markdownToHtml("x", {
+  mdastPlugins: [[syncMdast, [(ctx: PluginFactoryContext) => (ctx.data ? asyncMdast : null)]]],
+});
+export type _NestedCtxFactoryAsync = Expect<IsPromise<typeof nestedCtxFactoryAsync>>;
+
+// A zero-argument factory keeps working, and keeps narrowing.
+const legacyFactoryAsync = markdownToHtml("x", { mdastPlugins: [() => asyncMdast] });
+export type _LegacyFactoryAsync = Expect<IsPromise<typeof legacyFactoryAsync>>;
+
+// The other direction: nothing async in the list must stay synchronous, so the
+// fix above cannot pass by making everything a Promise.
+const ctxFactorySync = markdownToHtml("x", {
+  mdastPlugins: [(ctx: PluginFactoryContext) => (ctx.source ? syncMdast : null)],
+});
+export type _CtxFactorySync = ExpectFalse<IsPromise<typeof ctxFactorySync>>;
+
+const skipOnly = markdownToHtml("x", {
+  mdastPlugins: [null, undefined, false, () => null],
+  hastPlugins: [false],
+});
+export type _SkipOnlySync = ExpectFalse<IsPromise<typeof skipOnly>>;
+
+const plainSync = markdownToHtml("x", { mdastPlugins: [syncMdast] });
+export type _PlainSync = ExpectFalse<IsPromise<typeof plainSync>>;
+
+// Skip values must be accepted wherever an entry is, including from a factory.
+markdownToHtml("x", {
+  mdastPlugins: [null, undefined, false, syncMdast, [null, syncMdast], () => undefined],
+  hastPlugins: [false, () => null],
+});
+
+// The ctx is read-only enough to be useful without a cast.
+markdownToHtml("x", {
+  mdastPlugins: [
+    (ctx: PluginFactoryContext) => {
+      const url: URL | undefined = ctx.fileURL;
+      const format: "markdown" | "mdx" = ctx.sourceFormat;
+      const src: string = ctx.source;
+      const bag: Record<string, unknown> = ctx.data;
+      return url && format && src && bag ? syncMdast : null;
+    },
+  ],
+});
+
+// A factory may take no parameter at all.
+markdownToHtml("x", { mdastPlugins: [() => syncMdast] });
+
+// On its own, a factory's ctx is contextually typed and needs no annotation.
+markdownToHtml("x", {
+  mdastPlugins: [({ sourceFormat }) => (sourceFormat === "mdx" ? syncMdast : null)],
+});
+markdownToHtml("x", { mdastPlugins: [(ctx) => (ctx.source ? syncMdast : null)] });

--- a/packages/satteri/test/plugin-factory-context.test-d.ts
+++ b/packages/satteri/test/plugin-factory-context.test-d.ts
@@ -86,6 +86,23 @@ markdownToHtml("x", {
   ],
 });
 
+// Readonly from the start: relaxing it later is additive, adding it is not.
+markdownToHtml("x", {
+  mdastPlugins: [
+    (ctx: PluginFactoryContext) => {
+      // @ts-expect-error - fileURL is readonly
+      ctx.fileURL = undefined;
+      // @ts-expect-error - sourceFormat is readonly
+      ctx.sourceFormat = "mdx";
+      // @ts-expect-error - source is readonly
+      ctx.source = "";
+      // @ts-expect-error - data is readonly
+      ctx.data = {};
+      return syncMdast;
+    },
+  ],
+});
+
 // A factory may take no parameter at all.
 markdownToHtml("x", { mdastPlugins: [() => syncMdast] });
 

--- a/packages/satteri/test/plugin-factory-context.test.ts
+++ b/packages/satteri/test/plugin-factory-context.test.ts
@@ -207,7 +207,9 @@ describe("plugin factory context", () => {
     markdownToHtml("# Title", { mdastPlugins: [wantsPositions, observer] });
     expect(positions[0]).toBeDefined();
 
-    markdownToHtml("# Title", { mdastPlugins: [() => null, observer] });
+    markdownToHtml("# Title", {
+      mdastPlugins: [(ctx) => (ctx.sourceFormat === "mdx" ? wantsPositions : null), observer],
+    });
     expect(positions[1]).toBeUndefined();
   });
 

--- a/packages/satteri/test/plugin-factory-context.test.ts
+++ b/packages/satteri/test/plugin-factory-context.test.ts
@@ -1,0 +1,236 @@
+import { describe, test, expect } from "vitest";
+import { markdownToHtml, markdownToJs, mdxToJs, defineMdastPlugin } from "../src/index.js";
+import type { PluginFactoryContext } from "../src/index.js";
+
+/** Records its name on each heading, making run order observable. */
+function recordMdast(order: string[], name: string) {
+  return defineMdastPlugin({
+    name,
+    heading() {
+      order.push(name);
+    },
+  });
+}
+
+describe("plugin factory context", () => {
+  test("a factory receives the source, fileURL, sourceFormat and data", () => {
+    const seen: PluginFactoryContext[] = [];
+    const data = { seeded: true };
+    const fileURL = new URL("file:///docs/something.md");
+
+    markdownToHtml("# Title", {
+      fileURL,
+      data,
+      mdastPlugins: [
+        (ctx) => {
+          seen.push(ctx);
+          return null;
+        },
+      ],
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.source).toBe("# Title");
+    expect(seen[0]!.fileURL).toBe(fileURL);
+    expect(seen[0]!.sourceFormat).toBe("markdown");
+    expect(seen[0]!.data).toBe(data);
+  });
+
+  test("fileURL is undefined when the option was not given", () => {
+    let seen: URL | undefined | "unset" = "unset";
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [
+        (ctx) => {
+          seen = ctx.fileURL;
+          return null;
+        },
+      ],
+    });
+
+    expect(seen).toBeUndefined();
+  });
+
+  test("sourceFormat distinguishes mdx from markdown", () => {
+    const formats: string[] = [];
+    const probe = (ctx: PluginFactoryContext) => {
+      formats.push(ctx.sourceFormat);
+      return null;
+    };
+
+    markdownToHtml("# Title", { mdastPlugins: [probe] });
+    markdownToJs("# Title", { mdastPlugins: [probe] });
+    mdxToJs("# Title", { mdastPlugins: [probe] });
+
+    expect(formats).toEqual(["markdown", "markdown", "mdx"]);
+  });
+
+  test("hast factories receive the same context", () => {
+    const seen: PluginFactoryContext[] = [];
+    const fileURL = new URL("file:///docs/page.mdx");
+
+    mdxToJs("# Title", {
+      fileURL,
+      hastPlugins: [
+        (ctx) => {
+          seen.push(ctx);
+          return null;
+        },
+      ],
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.sourceFormat).toBe("mdx");
+    expect(seen[0]!.fileURL).toBe(fileURL);
+  });
+
+  test("a plugin runs only for the file it opts into", () => {
+    const order: string[] = [];
+    const onlySomething = (ctx: PluginFactoryContext) =>
+      ctx.fileURL?.pathname.endsWith("/something.md") ? recordMdast(order, "gated") : null;
+
+    markdownToHtml("# Title", {
+      fileURL: new URL("file:///docs/other.md"),
+      mdastPlugins: [onlySomething, recordMdast(order, "always")],
+    });
+    markdownToHtml("# Title", {
+      fileURL: new URL("file:///docs/something.md"),
+      mdastPlugins: [onlySomething, recordMdast(order, "always")],
+    });
+
+    expect(order).toEqual(["always", "gated", "always"]);
+  });
+
+  test("a preset factory gates its whole bundle per document", () => {
+    const order: string[] = [];
+    const preset = (ctx: PluginFactoryContext) =>
+      ctx.sourceFormat === "mdx" ? [recordMdast(order, "a"), recordMdast(order, "b")] : null;
+
+    markdownToHtml("# Title", { mdastPlugins: [preset] });
+    expect(order).toEqual([]);
+
+    mdxToJs("# Title", { mdastPlugins: [preset] });
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("factories nested inside bundles receive the context too", () => {
+    const seen: string[] = [];
+
+    mdxToJs("# Title", {
+      mdastPlugins: [
+        [
+          (ctx) => {
+            seen.push(ctx.sourceFormat);
+            return null;
+          },
+          [
+            (ctx) => {
+              seen.push(ctx.source);
+              return null;
+            },
+          ],
+        ],
+      ],
+    });
+
+    expect(seen).toEqual(["mdx", "# Title"]);
+  });
+
+  test("a factory returned by a factory also receives the context", () => {
+    const seen: string[] = [];
+
+    mdxToJs("# Title", {
+      mdastPlugins: [
+        () => (ctx: PluginFactoryContext) => {
+          seen.push(ctx.sourceFormat);
+          return null;
+        },
+      ],
+    });
+
+    expect(seen).toEqual(["mdx"]);
+  });
+
+  test("the data bag a factory sees is the one visitors mutate", () => {
+    const data: Record<string, unknown> = {};
+
+    const result = markdownToHtml("# Title", {
+      data,
+      mdastPlugins: [
+        (ctx) => {
+          ctx.data.fromFactory = true;
+          return defineMdastPlugin({
+            name: "reader",
+            heading(_node, visitorCtx) {
+              visitorCtx.data.sawFactoryValue = visitorCtx.data.fromFactory === true;
+            },
+          });
+        },
+      ],
+    });
+
+    expect(result.data.fromFactory).toBe(true);
+    expect(result.data.sawFactoryValue).toBe(true);
+  });
+
+  test("a zero-argument factory keeps working", () => {
+    const order: string[] = [];
+
+    markdownToHtml("# Title", { mdastPlugins: [() => recordMdast(order, "legacy")] });
+
+    expect(order).toEqual(["legacy"]);
+  });
+
+  test("gating every plugin off leaves the document untouched", () => {
+    const result = markdownToHtml("# Title\n\nText.", {
+      mdastPlugins: [() => null],
+      hastPlugins: [() => null],
+    });
+
+    expect(result.html).toBe(markdownToHtml("# Title\n\nText.").html);
+  });
+
+  test("a gated-off plugin does not force position tracking on the others", () => {
+    const positions: (object | undefined)[] = [];
+    const wantsPositions = defineMdastPlugin({
+      name: "wants-positions",
+      options: { position: true },
+      heading() {},
+    });
+    const observer = defineMdastPlugin({
+      name: "observer",
+      heading(node) {
+        positions.push(node.position);
+      },
+    });
+
+    markdownToHtml("# Title", { mdastPlugins: [wantsPositions, observer] });
+    expect(positions[0]).toBeDefined();
+
+    markdownToHtml("# Title", { mdastPlugins: [() => null, observer] });
+    expect(positions[1]).toBeUndefined();
+  });
+
+  test("a factory is called once per compile even when it skips", () => {
+    let calls = 0;
+    const factory = () => {
+      calls++;
+      return null;
+    };
+
+    markdownToHtml("# A", { mdastPlugins: [factory] });
+    markdownToHtml("# B", { mdastPlugins: [factory] });
+
+    expect(calls).toBe(2);
+  });
+
+  test("a factory that returns itself is still rejected", () => {
+    const recursive = (): unknown => recursive;
+
+    expect(() =>
+      markdownToHtml("# Title", {
+        mdastPlugins: [recursive as () => never],
+      }),
+    ).toThrow(/mdastPlugins: plugin factory nesting is too deep/);
+  });
+});

--- a/packages/satteri/test/plugin-factory-context.test.ts
+++ b/packages/satteri/test/plugin-factory-context.test.ts
@@ -65,6 +65,21 @@ describe("plugin factory context", () => {
     expect(formats).toEqual(["markdown", "markdown", "mdx"]);
   });
 
+  // markdownToJs runs the MDX pipeline with a different parser, so it could plausibly report "mdx".
+  test("hast factories see the entry point's sourceFormat", () => {
+    const formats: string[] = [];
+    const probe = (ctx: PluginFactoryContext) => {
+      formats.push(ctx.sourceFormat);
+      return null;
+    };
+
+    markdownToHtml("# Title", { hastPlugins: [probe] });
+    markdownToJs("# Title", { hastPlugins: [probe] });
+    mdxToJs("# Title", { hastPlugins: [probe] });
+
+    expect(formats).toEqual(["markdown", "markdown", "mdx"]);
+  });
+
   test("hast factories receive the same context", () => {
     const seen: PluginFactoryContext[] = [];
     const fileURL = new URL("file:///docs/page.mdx");
@@ -226,13 +241,43 @@ describe("plugin factory context", () => {
     expect(calls).toBe(2);
   });
 
-  test("a factory that returns itself is still rejected", () => {
-    const recursive = (): unknown => recursive;
+  test("data written by a factory survives when every plugin skips", () => {
+    const data: Record<string, unknown> = {};
 
-    expect(() =>
-      markdownToHtml("# Title", {
-        mdastPlugins: [recursive as () => never],
-      }),
-    ).toThrow(/mdastPlugins: plugin factory nesting is too deep/);
+    const result = markdownToHtml("# Title", {
+      data,
+      mdastPlugins: [
+        (ctx) => {
+          ctx.data.fromFactory = true;
+          return null;
+        },
+      ],
+      hastPlugins: [() => false],
+    });
+
+    expect(result.data).toBe(data);
+    expect(result.data.fromFactory).toBe(true);
+  });
+
+  test("a factory cannot mutate the context a later factory sees", () => {
+    const seen: string[] = [];
+    const vandal = (ctx: PluginFactoryContext) => {
+      expect(() => {
+        (ctx as { source: string }).source = "tampered";
+      }).toThrow(TypeError);
+      return null;
+    };
+
+    markdownToHtml("# Title", {
+      mdastPlugins: [
+        vandal,
+        (ctx) => {
+          seen.push(ctx.source);
+          return null;
+        },
+      ],
+    });
+
+    expect(seen).toEqual(["# Title"]);
   });
 });

--- a/website/content/docs/options.md
+++ b/website/content/docs/options.md
@@ -11,8 +11,8 @@ Options for Sätteri's [entry points](/docs/entry-points/). `CompileOptions` is 
 
 | Option         | Type              | Notes                                                                                         |
 | -------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| `mdastPlugins` | `MdastPluginList` | MDAST plugins, factories that return one, or arrays of either. See [Plugins](/docs/plugins/). |
-| `hastPlugins`  | `HastPluginList`  | HAST plugins, factories, or arrays of either.                                                 |
+| `mdastPlugins` | `MdastPluginList` | MDAST-stage plugins. See [What an entry can be](/docs/plugins/#what-an-entry-can-be).         |
+| `hastPlugins`  | `HastPluginList`  | HAST-stage plugins, same entry shapes as `mdastPlugins`.                                      |
 | `features`     | `Features`        | Parser extensions. See [Features](/docs/features/).                                           |
 | `fileURL`      | `URL`             | The document's URL, surfaced to plugins as `ctx.fileURL`.                                     |
 | `data`         | `Data`            | Initial [data bag](#data).                                                                    |

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -39,7 +39,13 @@ Factories are called once per invocation, so closures reset between documents.
 An entry may also be an array of entries, at any depth, so a package can export a bundle of plugins that is passed straight through:
 
 ```ts
-type MdastPluginEntry = MdastPluginDefinition | (() => MdastPluginEntry) | readonly MdastPluginEntry[];
+type MdastPluginEntry =
+  | MdastPluginDefinition
+  | ((ctx: PluginFactoryContext) => MdastPluginEntry)
+  | readonly MdastPluginEntry[]
+  | null
+  | undefined
+  | false;
 type MdastPluginList = readonly MdastPluginEntry[];
 ```
 
@@ -62,6 +68,37 @@ const headingAnchors = () => {
 markdownToHtml(source, { mdastPlugins: [headingAnchors] });
 ```
 
+### Running a plugin only on some documents
+
+A factory is handed a context describing the document about to be compiled, and may return `null`, `undefined` or `false` to leave the plugin out for that document:
+
+```ts
+interface PluginFactoryContext {
+  fileURL: URL | undefined;
+  sourceFormat: "markdown" | "mdx";
+  source: string;
+  data: Data;
+}
+```
+
+```js
+const onlyChangelogs = (ctx) =>
+  ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null;
+
+markdownToHtml(source, { mdastPlugins: [onlyChangelogs, myPlugin] });
+```
+
+Only what is known before parsing is available — there is no tree and no frontmatter yet. `source` is the unparsed document, meant for cheap checks such as "does this contain a code fence at all", not for parsing Markdown by hand.
+
+Deciding here rather than inside a visitor is what makes the skip worth doing: a plugin that is never added does not register visitors, and the pipeline picks its parsing and rendering strategy from the plugins that remain. A document that gates every plugin off is compiled by the same fast path as one that was passed no plugins, and position tracking is skipped unless a plugin that actually runs asks for it.
+
+The skip values work anywhere an entry does, so a list can be assembled inline:
+
+```js
+markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, myPlugin] });
+```
+
+A factory returning a skip value drops the whole bundle it would otherwise have returned, so a preset can enable or disable itself as a unit. Factories still run once per compile even when they skip, so keep them cheap.
 
 ### Source positions
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -57,13 +57,15 @@ import { typography } from "some-package"; // an array of plugins
 markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
 ```
 
-The bundle's plugins run in their own order, at the bundle's position — the list above is equivalent to spreading `typography` in place.
+The bundle's plugins run in their own order, at the bundle's position, so the list above is equivalent to spreading `typography` in place.
 
-**A skip value** — `null`, `undefined` or `false` — leaves that entry out, so a condition can go straight in the list:
+**A skip value** (`null`, `undefined` or `false`) leaves that entry out, so a condition can go straight in the list:
 
 ```js
 markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, myPlugin] });
 ```
+
+Only those three are skipped. Any other value that is not a plugin, a factory or a list is rejected with an error naming the option, so a condition that yields `0` or `""` is caught rather than silently dropped.
 
 A factory can return a skip value too, which is how one plugin runs on some documents and not others. Every factory is handed a context describing the document about to be compiled:
 
@@ -82,9 +84,9 @@ const onlyChangelogs = (ctx) => (ctx.fileURL?.pathname.endsWith("/CHANGELOG.md")
 markdownToHtml(source, { mdastPlugins: [onlyChangelogs, myPlugin] });
 ```
 
-Only what is known before parsing is available — there is no tree and no frontmatter yet. `source` is the unparsed document, meant for cheap checks such as "does this contain a code fence at all", not for parsing Markdown by hand.
+Only what is known before parsing is available: there is no tree and no frontmatter yet. `source` is the unparsed document, meant for cheap checks such as "does this contain a code fence at all", not for parsing Markdown by hand. `data` is the same bag the visitors later read and write through `ctx.data`, so a factory can seed it for the plugins that run after it.
 
-Skipping here rather than returning early inside a visitor is what makes it worth doing: a plugin that is never added registers no visitors, and the pipeline picks its parsing and rendering strategy from the plugins that remain. A document that skips every plugin is compiled by the same fast path as one that was passed no plugins, and position tracking is skipped unless a plugin that actually runs asks for it. A factory returning a skip value drops the whole bundle it would otherwise have returned, so a preset can enable or disable itself as a unit — but factories run once per compile even when they skip, so keep them cheap.
+Skipping here rather than returning early inside a visitor is what makes it worth doing: a plugin that is never added registers no visitors, and the pipeline picks its parsing and rendering strategy from the plugins that remain. A document that skips every plugin is compiled by the same fast path as one that was passed no plugins, and position tracking is skipped unless a plugin that actually runs asks for it. A factory returning a skip value drops the whole bundle it would otherwise have returned, so a preset can enable or disable itself as a unit. Factories still run once per compile even when they skip, so keep them cheap.
 
 ### Source positions
 
@@ -435,7 +437,7 @@ The `mdxExpressions` option (default `true`) controls how MDX curly braces in th
 
 Any visitor may return a `Promise`. Sync and async visitors can be mixed freely. If any visitor in the pipeline is async, `markdownToHtml`, `mdxToJs`, and `markdownToJs` return a `Promise`; otherwise they return synchronously.
 
-The return type is decided from the plugins the types can see, so a factory that may return an async plugin types the compile as a `Promise` even on a document where it skips and the result comes back synchronously — `await` the result rather than calling `.then()` on it.
+The return type is decided from the plugins the types can see, so a factory that may return an async plugin types the compile as a `Promise` even on a document where it skips and the result comes back synchronously. Use `await` on the result rather than calling `.then()` on it.
 
 For performance, prefer sync visitors where you can: awaiting per match adds up, especially for a visitor that matches many nodes.
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -74,10 +74,10 @@ A factory is handed a context describing the document about to be compiled, and 
 
 ```ts
 interface PluginFactoryContext {
-  fileURL: URL | undefined;
-  sourceFormat: "markdown" | "mdx";
-  source: string;
-  data: Data;
+  readonly fileURL: URL | undefined;
+  readonly sourceFormat: "markdown" | "mdx";
+  readonly source: string;
+  readonly data: Data;
 }
 ```
 
@@ -448,6 +448,8 @@ The `mdxExpressions` option (default `true`) controls how MDX curly braces in th
 ## Async plugins
 
 Any visitor may return a `Promise`. Sync and async visitors can be mixed freely. If any visitor in the pipeline is async, `markdownToHtml`, `mdxToJs`, and `markdownToJs` return a `Promise`; otherwise they return synchronously.
+
+The return type is decided from the plugins the types can see, so a factory that may return an async plugin types the compile as a `Promise` even on a document where it skips and the result comes back synchronously — `await` the result rather than calling `.then()` on it.
 
 For performance, prefer sync visitors where you can: awaiting per match adds up, especially for a visitor that matches many nodes.
 

--- a/website/content/docs/plugin-api.md
+++ b/website/content/docs/plugin-api.md
@@ -27,37 +27,18 @@ const plugin = defineMdastPlugin({
 
 ### Passing plugins
 
-`mdastPlugins` and `hastPlugins` accept either a plugin definition or a factory that returns one. Use a factory when the plugin closes over per-document state.
+`mdastPlugins` and `hastPlugins` take a list of entries. An entry is a definition, a factory returning one, a bundle of entries, or a skip value:
 
 ```ts
-type MdastPluginInput = MdastPluginDefinition | (() => MdastPluginDefinition);
-type HastPluginInput = HastPluginDefinition | (() => HastPluginDefinition);
-```
-
-Factories are called once per invocation, so closures reset between documents.
-
-An entry may also be an array of entries, at any depth, so a package can export a bundle of plugins that is passed straight through:
-
-```ts
-type MdastPluginEntry =
-  | MdastPluginDefinition
-  | ((ctx: PluginFactoryContext) => MdastPluginEntry)
-  | readonly MdastPluginEntry[]
-  | null
-  | undefined
-  | false;
+type MdastPluginEntry = MdastPluginDefinition | ((ctx: PluginFactoryContext) => MdastPluginEntry) | readonly MdastPluginEntry[] | null | undefined | false;
 type MdastPluginList = readonly MdastPluginEntry[];
 ```
 
-```js
-import { typography } from "some-package"; // an array of plugins
+`HastPluginEntry` and `HastPluginList` are the HAST-side equivalents. The shapes compose: a factory may return a bundle, a bundle may contain factories, and a skip value is accepted wherever an entry is.
 
-markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
-```
+**A definition** is used as-is for every document. Reach for one whenever the plugin keeps no state between compiles.
 
-The bundle's plugins run in their own order, at the bundle's position — the list above is equivalent to spreading `typography` in place. `HastPluginEntry` and `HastPluginList` are the HAST-side equivalents.
-
-A factory may return a bundle as well as a single plugin. That is how a preset gives its plugins state that is shared between them but still reset per document:
+**A factory** is a function called once per compile, so anything it closes over resets for each document. It may return a bundle as well as a single plugin, which is how a preset gives its plugins state that they share with each other but that still resets per document:
 
 ```js
 const headingAnchors = () => {
@@ -68,9 +49,23 @@ const headingAnchors = () => {
 markdownToHtml(source, { mdastPlugins: [headingAnchors] });
 ```
 
-### Running a plugin only on some documents
+**A bundle** is an array of entries, nested as deeply as you like, so a package can export a group of plugins that is passed without spreading:
 
-A factory is handed a context describing the document about to be compiled, and may return `null`, `undefined` or `false` to leave the plugin out for that document:
+```js
+import { typography } from "some-package"; // an array of plugins
+
+markdownToHtml(source, { mdastPlugins: [typography, myPlugin] });
+```
+
+The bundle's plugins run in their own order, at the bundle's position — the list above is equivalent to spreading `typography` in place.
+
+**A skip value** — `null`, `undefined` or `false` — leaves that entry out, so a condition can go straight in the list:
+
+```js
+markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, myPlugin] });
+```
+
+A factory can return a skip value too, which is how one plugin runs on some documents and not others. Every factory is handed a context describing the document about to be compiled:
 
 ```ts
 interface PluginFactoryContext {
@@ -82,23 +77,14 @@ interface PluginFactoryContext {
 ```
 
 ```js
-const onlyChangelogs = (ctx) =>
-  ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null;
+const onlyChangelogs = (ctx) => (ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null);
 
 markdownToHtml(source, { mdastPlugins: [onlyChangelogs, myPlugin] });
 ```
 
 Only what is known before parsing is available — there is no tree and no frontmatter yet. `source` is the unparsed document, meant for cheap checks such as "does this contain a code fence at all", not for parsing Markdown by hand.
 
-Deciding here rather than inside a visitor is what makes the skip worth doing: a plugin that is never added does not register visitors, and the pipeline picks its parsing and rendering strategy from the plugins that remain. A document that gates every plugin off is compiled by the same fast path as one that was passed no plugins, and position tracking is skipped unless a plugin that actually runs asks for it.
-
-The skip values work anywhere an entry does, so a list can be assembled inline:
-
-```js
-markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, myPlugin] });
-```
-
-A factory returning a skip value drops the whole bundle it would otherwise have returned, so a preset can enable or disable itself as a unit. Factories still run once per compile even when they skip, so keep them cheap.
+Skipping here rather than returning early inside a visitor is what makes it worth doing: a plugin that is never added registers no visitors, and the pipeline picks its parsing and rendering strategy from the plugins that remain. A document that skips every plugin is compiled by the same fast path as one that was passed no plugins, and position tracking is skipped unless a plugin that actually runs asks for it. A factory returning a skip value drops the whole bundle it would otherwise have returned, so a preset can enable or disable itself as a unit — but factories run once per compile even when they skip, so keep them cheap.
 
 ### Source positions
 

--- a/website/content/docs/plugins.md
+++ b/website/content/docs/plugins.md
@@ -104,7 +104,11 @@ markdownToHtml(source, {
 });
 ```
 
-An entry can also be an array of plugins, nested as deeply as you like. A package can therefore export a bundle of plugins that you pass without spreading:
+## What an entry can be
+
+A list entry is usually a plugin definition, but three other shapes are accepted.
+
+An entry can be an **array** of entries, nested as deeply as you like, so a package can export a bundle of plugins that you pass without spreading:
 
 ```js
 import { typography } from "some-package"; // an array of plugins
@@ -116,27 +120,16 @@ markdownToHtml(source, {
 
 The bundle's plugins keep their own order and run at the bundle's position, so the above is the same as `[...typography, unwrapImages]`.
 
-A factory can return a bundle too, which gives the plugins in it state that they share with each other but that still resets for every document.
+An entry can be a **factory** — a function returning any of the other shapes. It runs once per compile, so state it closes over resets for every document, and it is handed what is known about that document before parsing: the file's URL, whether it is Markdown or MDX, the unparsed source, and the `data` bag.
 
-## Running a plugin only on some documents
-
-A factory receives a context describing the document about to be compiled, and can return `null` to sit this one out:
+An entry can also be **`null`, `undefined` or `false`**, which leaves it out. Combined with a factory, that is how one plugin runs on some documents and not others — cheaper than checking the same condition inside every visitor, which still pays for the plugin on documents it does not apply to:
 
 ```js
-const onlyChangelogs = (ctx) =>
-  ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null;
-
-markdownToHtml(source, { mdastPlugins: [onlyChangelogs, unwrapImages] });
+markdownToHtml(source, {
+  mdastPlugins: [isDev && debugPlugin, (ctx) => (ctx.sourceFormat === "mdx" ? mdxOnly : null)],
+});
 ```
 
-The context carries what is known before parsing: `fileURL`, `sourceFormat` (`"markdown"` or `"mdx"`), the unparsed `source`, and the `data` bag. This is the way to gate a plugin per file — checking the same condition inside every visitor still pays for the plugin on documents it does not apply to.
-
-`null`, `undefined` and `false` are skipped anywhere an entry can appear, so conditions can go straight in the list:
-
-```js
-markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, unwrapImages] });
-```
-
-See the [plugin API reference](/docs/plugin-api/#running-a-plugin-only-on-some-documents) for the full context type.
+See [Passing plugins](/docs/plugin-api/#passing-plugins) for the entry type and the full factory context.
 
 If you need to share state between visits (e.g. collecting a table of contents), close over a variable in the surrounding scope and read it back after `markdownToHtml` returns.

--- a/website/content/docs/plugins.md
+++ b/website/content/docs/plugins.md
@@ -118,4 +118,25 @@ The bundle's plugins keep their own order and run at the bundle's position, so t
 
 A factory can return a bundle too, which gives the plugins in it state that they share with each other but that still resets for every document.
 
+## Running a plugin only on some documents
+
+A factory receives a context describing the document about to be compiled, and can return `null` to sit this one out:
+
+```js
+const onlyChangelogs = (ctx) =>
+  ctx.fileURL?.pathname.endsWith("/CHANGELOG.md") ? rewriteVersions : null;
+
+markdownToHtml(source, { mdastPlugins: [onlyChangelogs, unwrapImages] });
+```
+
+The context carries what is known before parsing: `fileURL`, `sourceFormat` (`"markdown"` or `"mdx"`), the unparsed `source`, and the `data` bag. This is the way to gate a plugin per file — checking the same condition inside every visitor still pays for the plugin on documents it does not apply to.
+
+`null`, `undefined` and `false` are skipped anywhere an entry can appear, so conditions can go straight in the list:
+
+```js
+markdownToHtml(source, { mdastPlugins: [isDev && debugPlugin, unwrapImages] });
+```
+
+See the [plugin API reference](/docs/plugin-api/#running-a-plugin-only-on-some-documents) for the full context type.
+
 If you need to share state between visits (e.g. collecting a table of contents), close over a variable in the surrounding scope and read it back after `markdownToHtml` returns.

--- a/website/content/docs/plugins.md
+++ b/website/content/docs/plugins.md
@@ -120,9 +120,9 @@ markdownToHtml(source, {
 
 The bundle's plugins keep their own order and run at the bundle's position, so the above is the same as `[...typography, unwrapImages]`.
 
-An entry can be a **factory** — a function returning any of the other shapes. It runs once per compile, so state it closes over resets for every document, and it is handed what is known about that document before parsing: the file's URL, whether it is Markdown or MDX, the unparsed source, and the `data` bag.
+An entry can be a **factory**, a function returning any of the other shapes. It runs once per compile, so state it closes over resets for every document, and it is handed what is known about that document before parsing: the file's URL, whether it is Markdown or MDX, the unparsed source, and the `data` bag.
 
-An entry can also be **`null`, `undefined` or `false`**, which leaves it out. Combined with a factory, that is how one plugin runs on some documents and not others — cheaper than checking the same condition inside every visitor, which still pays for the plugin on documents it does not apply to:
+An entry can also be **`null`, `undefined` or `false`**, which leaves it out. Combined with a factory, that is how one plugin runs on some documents and not others, and it is cheaper than checking the same condition inside every visitor, which still pays for the plugin on documents it does not apply to:
 
 ```js
 markdownToHtml(source, {

--- a/website/content/docs/vite.md
+++ b/website/content/docs/vite.md
@@ -89,7 +89,7 @@ By default, the plugin compiles MDX with `development: true` in `serve` so React
 
 `MdxOptions` mirrors Sätteri's MDX options minus `outputFormat`. The plugin always emits an ES module so Vite can import it.
 
-Plugins given here apply to every Markdown and MDX file, unless an entry opts out of one — see [What an entry can be](/docs/plugins/#what-an-entry-can-be) for how a plugin limits itself to some files, and the [Plugins](/docs/plugins/) guide for how to write them.
+Plugins given here apply to every Markdown and MDX file, unless an entry opts out of one. See [What an entry can be](/docs/plugins/#what-an-entry-can-be) for how a plugin limits itself to some files, and the [Plugins](/docs/plugins/) guide for how to write them.
 
 ## TypeScript
 

--- a/website/content/docs/vite.md
+++ b/website/content/docs/vite.md
@@ -89,15 +89,7 @@ By default, the plugin compiles MDX with `development: true` in `serve` so React
 
 `MdxOptions` mirrors Sätteri's MDX options minus `outputFormat`. The plugin always emits an ES module so Vite can import it.
 
-Plugins given here apply to every Markdown and MDX file, unless a plugin opts out of one. Pass a factory instead of a definition and it is called for each file with that file's `fileURL`, `sourceFormat` and `source`; returning `null` leaves the plugin out for that file:
-
-```js
-satteri({
-  mdastPlugins: [(ctx) => (ctx.sourceFormat === "mdx" ? mdxOnlyPlugin : null)],
-});
-```
-
-See the [Plugins](/docs/plugins/) guide for how to write them.
+Plugins given here apply to every Markdown and MDX file, unless an entry opts out of one — see [What an entry can be](/docs/plugins/#what-an-entry-can-be) for how a plugin limits itself to some files, and the [Plugins](/docs/plugins/) guide for how to write them.
 
 ## TypeScript
 

--- a/website/content/docs/vite.md
+++ b/website/content/docs/vite.md
@@ -89,7 +89,15 @@ By default, the plugin compiles MDX with `development: true` in `serve` so React
 
 `MdxOptions` mirrors Sätteri's MDX options minus `outputFormat`. The plugin always emits an ES module so Vite can import it.
 
-Plugins given here apply to every Markdown and MDX file. See the [Plugins](/docs/plugins/) guide for how to write them.
+Plugins given here apply to every Markdown and MDX file, unless a plugin opts out of one. Pass a factory instead of a definition and it is called for each file with that file's `fileURL`, `sourceFormat` and `source`; returning `null` leaves the plugin out for that file:
+
+```js
+satteri({
+  mdastPlugins: [(ctx) => (ctx.sourceFormat === "mdx" ? mdxOnlyPlugin : null)],
+});
+```
+
+See the [Plugins](/docs/plugins/) guide for how to write them.
 
 ## TypeScript
 


### PR DESCRIPTION
Plugin factories now receive the file's `fileURL`, `sourceFormat`, `source` and `data`, and can return `null`, `undefined` or `false` to leave the plugin out for that document.