### PR TITLE
fix(autolink): the four residuals left after the GFM autolink migration

### DIFF
--- a/.sampo/changesets/autolink-email-before-www.md
+++ b/.sampo/changesets/autolink-email-before-www.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed an email address starting with `www.` linking as a URL instead of an email.

--- a/.sampo/changesets/autolink-escape-swallowed-constructs.md
+++ b/.sampo/changesets/autolink-escape-swallowed-constructs.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed emphasis and character references being lost after a GFM autolink whose URL ends in a backslash.

--- a/.sampo/changesets/autolink-smart-punctuation-positions.md
+++ b/.sampo/changesets/autolink-smart-punctuation-positions.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed GFM autolinks losing their positions when smart punctuation is enabled.

--- a/.sampo/changesets/bom-in-text-values.md
+++ b/.sampo/changesets/bom-in-text-values.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Fixed a zero-width no-break space being dropped when it starts a text value.

--- a/.sampo/changesets/mdx-lone-carriage-return.md
+++ b/.sampo/changesets/mdx-lone-carriage-return.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed MDX line comments and `import`/`export` blocks swallowing the lines after them in files that use lone carriage returns as line endings.

--- a/.sampo/changesets/mdx-reference-label-expression.md
+++ b/.sampo/changesets/mdx-reference-label-expression.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed text being dropped when an MDX expression contains the `]` that ends a reference label.

--- a/.sampo/changesets/mdx-string-line-continuation.md
+++ b/.sampo/changesets/mdx-string-line-continuation.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed MDX expressions failing to parse when a string inside them is continued over a CRLF line ending with a backslash.

--- a/crates/bench/benches/pipeline.rs
+++ b/crates/bench/benches/pipeline.rs
@@ -106,6 +106,16 @@ fn parse_autolinks_no_positions(bencher: divan::Bencher) {
     bencher.bench(|| satteri_pulldown_cmark::parse_no_positions(AUTOLINKS, opts));
 }
 
+/// One paragraph of autolink candidates whose decision is deferred by the
+/// unclosed `[`, interleaved with escapes: the per-candidate bookkeeping this
+/// shape exercises is the easiest place for the first pass to go quadratic.
+#[divan::bench]
+fn parse_deferred_autolinks(bencher: divan::Bencher) {
+    let opts = satteri_pulldown_cmark::DEFAULT_OPTIONS;
+    let source = "[a] ".to_owned() + &"www.a.b x\\* ".repeat(2000);
+    bencher.bench(|| satteri_pulldown_cmark::parse(divan::black_box(source.as_str()), opts));
+}
+
 /// Full pipeline: Markdown source → Arena → HTML string.
 #[divan::bench]
 fn full_pipeline_to_html(bencher: divan::Bencher) {

--- a/crates/satteri-pulldown-cmark/src/arena_build.rs
+++ b/crates/satteri-pulldown-cmark/src/arena_build.rs
@@ -1843,6 +1843,7 @@ fn parse_inner(
 
                     // Unresolved inline markers, should have been resolved by handle_inline.
                     ItemBody::MaybeEmphasis(..)
+                    | ItemBody::MaybeEmphasisEscaped(..)
                     | ItemBody::MaybeMath(..)
                     | ItemBody::MaybeSmartQuote(..)
                     | ItemBody::MaybeCode(..)

--- a/crates/satteri-pulldown-cmark/src/arena_build.rs
+++ b/crates/satteri-pulldown-cmark/src/arena_build.rs
@@ -2659,41 +2659,42 @@ mod autolink_path_probe {
         assert!(mismatches.is_empty(), "{}", mismatches.join("\n"));
     }
 
-    /// The three triggers have disagreeing preceding-character rules, and what
-    /// the construct path blocks falls through to find-and-replace, which wants
-    /// whitespace or punctuation.
+    /// The triggers have disagreeing preceding-character rules, and what the
+    /// construct path blocks falls through to find-and-replace, which wants
+    /// whitespace or punctuation. The fourth is a `www.` literal and an email
+    /// at the same offset, so it also pins which construct is tried first.
     #[test]
     fn a_preceding_character_selects_the_path_per_trigger() {
-        const TRIGGERS: [&str; 3] = ["www.x.y", "http://x.y", "a@b.cd"];
-        let rules: &[(&str, [Path; 3])] = &[
-            ("", [C, C, C]),
-            (" ", [C, C, C]),
-            ("(", [C, C, C]),
-            ("*", [C, C, C]),
-            ("_", [C, C, C]),
-            ("]", [C, C, C]),
-            ("~", [C, C, C]),
-            ("[", [F, F, F]),
-            (".", [F, C, C]),
-            ("/", [F, C, N]),
-            ("+", [F, C, C]),
-            (")", [F, C, C]),
-            ("!", [F, C, C]),
-            (":", [F, C, C]),
-            ("¥", [F, C, C]),
-            ("→", [F, C, C]),
-            ("a", [N, N, C]),
-            ("5", [N, C, C]),
-            ("é", [N, C, C]),
-            ("你", [N, C, C]),
-            ("你好", [N, C, C]),
-            ("\u{200b}", [N, C, C]),
+        const TRIGGERS: [&str; 4] = ["www.x.y", "http://x.y", "a@b.cd", "www.x@y.zz"];
+        let rules: &[(&str, [Path; 4])] = &[
+            ("", [C, C, C, C]),
+            (" ", [C, C, C, C]),
+            ("(", [C, C, C, C]),
+            ("*", [C, C, C, C]),
+            ("_", [C, C, C, C]),
+            ("]", [C, C, C, C]),
+            ("~", [C, C, C, C]),
+            ("[", [F, F, F, F]),
+            (".", [F, C, C, C]),
+            ("/", [F, C, N, F]),
+            ("+", [F, C, C, C]),
+            (")", [F, C, C, C]),
+            ("!", [F, C, C, C]),
+            (":", [F, C, C, C]),
+            ("¥", [F, C, C, C]),
+            ("→", [F, C, C, C]),
+            ("a", [N, N, C, C]),
+            ("5", [N, C, C, C]),
+            ("é", [N, C, C, C]),
+            ("你", [N, C, C, C]),
+            ("你好", [N, C, C, C]),
+            ("\u{200b}", [N, C, C, C]),
             // U+FEFF is not `White_Space`, yet find-and-replace takes it as a
             // boundary. Prefixed with a letter to keep leading-BOM handling out.
-            ("a\u{feff}", [F, C, C]),
+            ("a\u{feff}", [F, C, C, C]),
             // U+0085 is `White_Space`, but find-and-replace does not take it
             // as a boundary.
-            ("\u{85}", [N, C, C]),
+            ("\u{85}", [N, C, C, C]),
         ];
 
         for (prefix, expected) in rules {

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -1811,6 +1811,9 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         // Lowest start a further candidate may take: a committed candidate owns
         // its bytes, a deferred one only rules out a retry at the same start.
         let mut candidate_floor: usize = start;
+        // Ends of deferred candidates still in play. Overlapping candidates are
+        // possible, so this is a set; empty in every line without one.
+        let mut deferred_ends: Vec<usize> = Vec::new();
 
         let (final_ix, brk) = iterate_special_bytes(self.lookup_table, bytes, start, |ix, byte| {
             match byte {
@@ -1982,6 +1985,37 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         begin_text = ix + 1;
                         backslash_escaped = true;
                         LoopInstruction::ContinueAndSkip(0)
+                    } else if let Some((count, fired)) = (deferred_ends.contains(&(ix + 1)))
+                        .then(|| escaped_delim_run(self.text, start, ix, mode, self.options))
+                        .flatten()
+                    {
+                        // A deferred candidate's URL ends on this `\`, so the
+                        // run after it is the link's to unblock. Emitted in the
+                        // shape the link firing wants; `MaybeEmphasisEscaped`
+                        // holds it back until the splice says so.
+                        let blocked = delim_run_flags(
+                            self.text,
+                            start,
+                            ix + 2,
+                            count - 1,
+                            mode,
+                            self.options,
+                        );
+                        self.tree.append(Item {
+                            start: ix + 1,
+                            end: ix + 2,
+                            body: ItemBody::MaybeEmphasisEscaped(count, fired.0, fired.1),
+                        });
+                        for i in 1..count {
+                            self.tree.append(Item {
+                                start: ix + 1 + i,
+                                end: ix + 2 + i,
+                                body: ItemBody::MaybeEmphasis(count - i, blocked.0, blocked.1),
+                            });
+                        }
+                        begin_text = ix + 1 + count;
+                        backslash_escaped = false;
+                        LoopInstruction::ContinueAndSkip(count)
                     } else {
                         begin_text = ix + 1;
                         backslash_escaped = true;
@@ -2484,6 +2518,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         let (cand_start, cand_end) = (d.start, d.end);
                         if defer_autolink_decision(bytes, paragraph_floor, ix, self.options) {
                             candidate_floor = cand_start + 1;
+                            deferred_ends.push(cand_end);
                             // Leave `begin_text` at the candidate's start: its
                             // bytes stay ordinary text unless the marker fires.
                             self.append_autolink_marker(d, begin_text, backslash_escaped);
@@ -4817,6 +4852,58 @@ struct AutolinkDetection {
     end: usize,
     link_type: LinkType,
     url: String,
+}
+
+/// `(can_open, can_close)` for the run of `run_len` delimiters at `at`.
+fn delim_run_flags(
+    text: &str,
+    start: usize,
+    at: usize,
+    run_len: usize,
+    mode: TableParseMode,
+    options: Options,
+) -> (bool, bool) {
+    if run_len == 0 || at >= text.len() {
+        return (false, false);
+    }
+    let s = &text[start..];
+    let suffix = &text[at..];
+    (
+        delim_run_can_open(s, suffix, run_len, at - start, mode, options),
+        delim_run_can_close(s, suffix, run_len, at - start, mode, options),
+    )
+}
+
+/// A run of `~` only means anything at the lengths its extensions define.
+pub(crate) fn delim_run_is_valid(c: u8, count: usize, options: Options) -> bool {
+    c != b'~'
+        || count == 2
+        || (count == 1
+            && (options.contains(Options::ENABLE_STRIKETHROUGH)
+                || options.contains(Options::ENABLE_SUBSCRIPT)))
+}
+
+/// The delimiter run a `\` at `ix` would swallow, when the byte after it ends
+/// a deferred autolink candidate. `None` when nothing there could open or
+/// close, in which case the escape is left to stand as usual.
+fn escaped_delim_run(
+    text: &str,
+    start: usize,
+    ix: usize,
+    mode: TableParseMode,
+    options: Options,
+) -> Option<(usize, (bool, bool))> {
+    let bytes = text.as_bytes();
+    let c = *bytes.get(ix + 1)?;
+    if !matches!(c, b'*' | b'_' | b'~' | b'^') {
+        return None;
+    }
+    let count = 1 + scan_ch_repeat(&bytes[(ix + 2)..], c);
+    let fired = delim_run_flags(text, start, ix + 1, count, mode, options);
+    if (!fired.0 && !fired.1) || !delim_run_is_valid(c, count, options) {
+        return None;
+    }
+    Some((count, fired))
 }
 
 /// An email literal starting at the same offset as a `www.` literal, which

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -2505,6 +2505,10 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         let (cand_start, cand_end) = (d.start, d.end);
                         if defer_autolink_decision(bytes, paragraph_floor, ix, self.options) {
                             candidate_floor = cand_start + 1;
+                            // The scan only moves forward, so ends behind it can
+                            // never be probed again; dropping them here keeps the
+                            // probe in the escape arm off a growing list.
+                            deferred_ends.retain(|&e| e > ix);
                             deferred_ends.push(cand_end);
                             // Leave `begin_text` at the candidate's start: its
                             // bytes stay ordinary text unless the marker fires.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4898,8 +4898,9 @@ fn escaped_delim_run(
 }
 
 /// An email literal starting at the same offset as a `www.` literal, which
-/// GFM resolves in the email construct's favour. `www_end` bounds the search
-/// to bytes the www candidate already claims, keeping this amortised O(1).
+/// GFM resolves in the email construct's favour. `www_end` bounds the search to
+/// the www span, which the committed path skips outright and the deferred path
+/// was already rescanning.
 fn detect_email_inside_www(
     bytes: &[u8],
     ix: usize,
@@ -4915,28 +4916,34 @@ fn detect_email_inside_www(
     let at_ix = ix + memchr::memchr(b'@', &bytes[ix..www_end])?;
     let (email_start, email_end, full_url, retry_needed) =
         crate::post_passes::scan_email_autolink(bytes, at_ix, true)?;
-    // A local part reaching back past the trigger is the `_` hook's.
-    if retry_needed || email_start != ix {
+    // Opening past the trigger is the `@` hook's; opening before it needs an
+    // atext predecessor, and `_` is the only one a www literal takes.
+    if email_start != ix {
         return None;
     }
-    if email_start < begin_text || email_start < paragraph_start {
-        return None;
-    }
-    if email_start > 0
-        && bytes[email_start - 1] == b'\\'
-        && is_ascii_punctuation(bytes[email_start])
-    {
-        return None;
-    }
+    debug_assert!(
+        !retry_needed,
+        "a `/` predecessor would have failed the www literal first"
+    );
+    debug_assert!(
+        email_start >= begin_text && email_start >= paragraph_start,
+        "the trigger is inside the current text run"
+    );
     Some(AutolinkDetection {
         start: email_start,
         end: email_end,
         link_type: LinkType::Email,
-        url: full_url
-            .strip_prefix("mailto:")
-            .map(str::to_owned)
-            .unwrap_or(full_url),
+        url: email_addr(full_url),
     })
+}
+
+/// `scan_email_autolink` returns `mailto:<addr>`; arena_build's Email-link path
+/// prepends `mailto:` again, so strip it here.
+fn email_addr(full_url: String) -> String {
+    full_url
+        .strip_prefix("mailto:")
+        .map(str::to_owned)
+        .unwrap_or(full_url)
 }
 
 /// Detect a GFM autolink literal at a `h`/`H`/`w`/`W`/`@` trigger. Detection
@@ -4973,7 +4980,6 @@ fn detect_gfm_autolink(
             }
             // GFM registers the email construct ahead of www at the same
             // offset, so an `@` the www span would swallow wins instead.
-            // Bounded by that span, which the caller skips either way.
             if is_www {
                 if let Some(email) =
                     detect_email_inside_www(bytes, ix, end, paragraph_start, begin_text)
@@ -5012,17 +5018,11 @@ fn detect_gfm_autolink(
             {
                 return None;
             }
-            // `scan_email_autolink` returns `mailto:<addr>`; arena_build's
-            // Email-link path will prepend `mailto:` again, so strip here.
-            let email_addr = full_url
-                .strip_prefix("mailto:")
-                .map(str::to_owned)
-                .unwrap_or(full_url);
             Some(AutolinkDetection {
                 start: email_start,
                 end: email_end,
                 link_type: LinkType::Email,
-                url: email_addr,
+                url: email_addr(full_url),
             })
         }
         _ => None,

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4819,6 +4819,48 @@ struct AutolinkDetection {
     url: String,
 }
 
+/// An email literal starting at the same offset as a `www.` literal, which
+/// GFM resolves in the email construct's favour. `www_end` bounds the search
+/// to bytes the www candidate already claims, keeping this amortised O(1).
+fn detect_email_inside_www(
+    bytes: &[u8],
+    ix: usize,
+    www_end: usize,
+    paragraph_start: usize,
+    begin_text: usize,
+) -> Option<AutolinkDetection> {
+    // `_` is the one atext byte that can precede a www literal, and the
+    // attention arm's own email hook already owns that case.
+    if ix > 0 && bytes[ix - 1] == b'_' {
+        return None;
+    }
+    let at_ix = ix + memchr::memchr(b'@', &bytes[ix..www_end])?;
+    let (email_start, email_end, full_url, retry_needed) =
+        crate::post_passes::scan_email_autolink(bytes, at_ix, true)?;
+    // A local part reaching back past the trigger is the `_` hook's.
+    if retry_needed || email_start != ix {
+        return None;
+    }
+    if email_start < begin_text || email_start < paragraph_start {
+        return None;
+    }
+    if email_start > 0
+        && bytes[email_start - 1] == b'\\'
+        && is_ascii_punctuation(bytes[email_start])
+    {
+        return None;
+    }
+    Some(AutolinkDetection {
+        start: email_start,
+        end: email_end,
+        link_type: LinkType::Email,
+        url: full_url
+            .strip_prefix("mailto:")
+            .map(str::to_owned)
+            .unwrap_or(full_url),
+    })
+}
+
 /// Detect a GFM autolink literal at a `h`/`H`/`w`/`W`/`@` trigger. Detection
 /// only — committing or deferring is the caller's call, since it turns on
 /// state this function cannot see.
@@ -4830,18 +4872,17 @@ fn detect_gfm_autolink(
     begin_text: usize,
 ) -> Option<AutolinkDetection> {
     // Cheap reject first: most triggers in prose can't start an autolink.
-    match byte {
-        b'h' | b'H' | b'w' | b'W' => {
-            crate::post_passes::match_autolink_scheme(bytes, ix)?;
-        }
+    let is_www = match byte {
+        b'h' | b'H' | b'w' | b'W' => crate::post_passes::match_autolink_scheme(bytes, ix)?.1,
         b'@' => {
             // Email requires at least one atext char immediately before @.
             if ix == 0 || !is_email_local_char(bytes[ix - 1]) {
                 return None;
             }
+            false
         }
         _ => return None,
-    }
+    };
 
     match byte {
         b'h' | b'H' | b'w' | b'W' => {
@@ -4851,6 +4892,16 @@ fn detect_gfm_autolink(
                 scan_autolink_literal(bytes, ix, ix == paragraph_start)?;
             if fnr_only {
                 return None;
+            }
+            // GFM registers the email construct ahead of www at the same
+            // offset, so an `@` the www span would swallow wins instead.
+            // Bounded by that span, which the caller skips either way.
+            if is_www {
+                if let Some(email) =
+                    detect_email_inside_www(bytes, ix, end, paragraph_start, begin_text)
+                {
+                    return Some(email);
+                }
             }
             Some(AutolinkDetection {
                 start,

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -2441,20 +2441,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         } else if count == 3 {
                             ItemBody::SynthesizeChar('—')
                         } else {
-                            let (ems, ens) = match count % 6 {
-                                0 | 3 => (count / 3, 0),
-                                2 | 4 => (0, count / 2),
-                                1 => (count / 3 - 1, 2),
-                                _ => (count / 3, 1),
-                            };
-                            // – and — are 3 bytes each in utf8
-                            let mut buf = String::with_capacity(3 * (ems + ens));
-                            for _ in 0..ems {
-                                buf.push('—');
-                            }
-                            for _ in 0..ens {
-                                buf.push('–');
-                            }
+                            let buf = crate::post_passes::smart_dash_run(count);
                             ItemBody::SynthesizeText(self.allocs.allocate_cow(buf.into()))
                         };
 

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -332,10 +332,7 @@ pub(crate) fn try_parse_expression_body(
     let mut has_non_ws = false;
     while i < bytes.len() {
         if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
-            i += 2;
-            while i < bytes.len() && bytes[i] != b'\n' {
-                i += 1;
-            }
+            i = line_comment_end(bytes, i + 2);
         } else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
             let comment_start = i;
             i += 2;
@@ -592,6 +589,14 @@ fn skip_string(bytes: &[u8], start: usize) -> usize {
     ix
 }
 
+/// End of a `//` line comment whose body starts at `start`, i.e. the offset of
+/// the next line ending or of end-of-input. `\n`, `\r\n` and a lone `\r` all
+/// end the line; stopping *at* the ending rather than past it leaves the
+/// caller's own CRLF pairing to run.
+fn line_comment_end(bytes: &[u8], start: usize) -> usize {
+    memchr::memchr2(b'\n', b'\r', &bytes[start..]).map_or(bytes.len(), |i| start + i)
+}
+
 /// Is the byte at `ix` a line ending followed by a blank line (or EOF)?
 ///
 /// Used to cut the expression scan at block boundaries, so an unclosed `{`
@@ -833,10 +838,7 @@ fn scan_mdx_expression_end_inner(
             }
             b'/' if ix + 1 < bytes.len() && bytes[ix + 1] == b'/' => {
                 reject_if_lazy!();
-                ix += 2;
-                while ix < bytes.len() && bytes[ix] != b'\n' {
-                    ix += 1;
-                }
+                ix = line_comment_end(bytes, ix + 2);
             }
             b'/' if ix + 1 < bytes.len() && bytes[ix + 1] == b'*' => {
                 reject_if_lazy!();
@@ -1364,9 +1366,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 prev_was_value = true;
             }
             b'/' if ix + 1 < len && bytes[ix + 1] == b'/' => {
-                while ix < len && bytes[ix] != b'\n' {
-                    ix += 1;
-                }
+                ix = line_comment_end(bytes, ix + 2);
             }
             b'/' if ix + 1 < len && bytes[ix + 1] == b'*' => {
                 in_block_comment = true;
@@ -1380,7 +1380,10 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                 ix = scan_regex(bytes, ix);
                 prev_was_value = true;
             }
-            b'\n' => {
+            b'\n' | b'\r' => {
+                if bytes[ix] == b'\r' && ix + 1 < len && bytes[ix + 1] == b'\n' {
+                    ix += 1;
+                }
                 ix += 1;
                 if ix >= len {
                     break;
@@ -1397,7 +1400,7 @@ pub(crate) fn scan_mdx_esm(bytes: &[u8]) -> Option<usize> {
                     break;
                 }
             }
-            b' ' | b'\t' | b'\r' => ix += 1,
+            b' ' | b'\t' => ix += 1,
             b')' | b']' | b'}' => {
                 prev_was_value = true;
                 ix += 1;

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -580,6 +580,10 @@ fn skip_string(bytes: &[u8], start: usize) -> usize {
     while ix < len && bytes[ix] != quote && bytes[ix] != b'\n' && bytes[ix] != b'\r' {
         if bytes[ix] == b'\\' {
             ix += 1;
+            // A line continuation escapes the whole ending, CRLF included.
+            if bytes.get(ix) == Some(&b'\r') && bytes.get(ix + 1) == Some(&b'\n') {
+                ix += 1;
+            }
         }
         ix += 1;
     }

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -589,10 +589,8 @@ fn skip_string(bytes: &[u8], start: usize) -> usize {
     ix
 }
 
-/// End of a `//` line comment whose body starts at `start`, i.e. the offset of
-/// the next line ending or of end-of-input. `\n`, `\r\n` and a lone `\r` all
-/// end the line; stopping *at* the ending rather than past it leaves the
-/// caller's own CRLF pairing to run.
+/// End of a `//` line comment whose body starts at `start`. Stops *at* the line
+/// ending rather than past it, so the caller's own CRLF pairing still runs.
 fn line_comment_end(bytes: &[u8], start: usize) -> usize {
     memchr::memchr2(b'\n', b'\r', &bytes[start..]).map_or(bytes.len(), |i| start + i)
 }

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -1449,7 +1449,27 @@ impl<'input> ParserInner<'input> {
                                     };
                                     self.tree[reference_close_node].item.body =
                                         ItemBody::MaybeLinkClose(false);
-                                    let next_node = self.tree[reference_close_node].next;
+                                    // The label scan walks raw source, so it can
+                                    // stop inside a wider item (an MDX expression
+                                    // holding a `]`). The label owns up to
+                                    // `end_ix`; the rest is literal text, and
+                                    // without this it would belong to no node.
+                                    let close_end = self.tree[reference_close_node].item.end;
+                                    let next_node = if close_end > end_ix {
+                                        self.tree[reference_close_node].item.end = end_ix;
+                                        let tail = self.tree.create_node(Item {
+                                            start: end_ix,
+                                            end: close_end,
+                                            body: ItemBody::Text {
+                                                backslash_escaped: false,
+                                            },
+                                        });
+                                        self.tree[tail].next = self.tree[reference_close_node].next;
+                                        self.tree[reference_close_node].next = Some(tail);
+                                        Some(tail)
+                                    } else {
+                                        self.tree[reference_close_node].next
+                                    };
 
                                     (next_node, LinkType::Reference)
                                 }

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -175,6 +175,7 @@ impl ItemBody {
         matches!(
             *self,
             MaybeEmphasis(..)
+                | MaybeEmphasisEscaped(..)
                 | MaybeMath(..)
                 | MaybeSmartQuote(..)
                 | MaybeCode(..)
@@ -193,6 +194,7 @@ impl ItemBody {
         matches!(
             *self,
             MaybeEmphasis(..)
+                | MaybeEmphasisEscaped(..)
                 | MaybeMath(..)
                 | MaybeSmartQuote(..)
                 | MaybeCode(..)

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -1452,10 +1452,11 @@ impl<'input> ParserInner<'input> {
                                     self.tree[reference_close_node].item.body =
                                         ItemBody::MaybeLinkClose(false);
                                     // The label scan walks raw source, so it can
-                                    // stop inside a wider item (an MDX expression
-                                    // holding a `]`). The label owns up to
-                                    // `end_ix`; the rest is literal text, and
-                                    // without this it would belong to no node.
+                                    // stop inside a wider item, e.g. an MDX
+                                    // expression or directive holding a `]`. The
+                                    // label owns up to `end_ix`; the rest is
+                                    // literal text, and without this it would
+                                    // belong to no node.
                                     let close_end = self.tree[reference_close_node].item.end;
                                     let next_node = if close_end > end_ix {
                                         self.tree[reference_close_node].item.end = end_ix;
@@ -1614,11 +1615,11 @@ impl<'input> ParserInner<'input> {
 
                                     self.tree[tos.node].item.end = end;
                                     // No `max(orig_start, end)` clamp here,
-                                    // unlike the inline-link splice: `end - 1`
-                                    // is always the label's `]`, and the only
-                                    // zero-width items are autolink markers,
-                                    // which never sit on one. So the successor
-                                    // cannot start before `end`.
+                                    // unlike the inline-link splice: the item at
+                                    // `end - 1` either ends the label or was
+                                    // truncated to it, and the zero-width items
+                                    // that could sit at `end` all sit on a URL
+                                    // or email byte, never a `]`.
                                     debug_assert!(
                                         node_after_link.is_none_or(|node_after_ix| {
                                             self.tree[node_after_ix].item.start >= end

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -1591,6 +1591,18 @@ impl<'input> ParserInner<'input> {
                                     }
 
                                     self.tree[tos.node].item.end = end;
+                                    // No `max(orig_start, end)` clamp here,
+                                    // unlike the inline-link splice: `end - 1`
+                                    // is always the label's `]`, and the only
+                                    // zero-width items are autolink markers,
+                                    // which never sit on one. So the successor
+                                    // cannot start before `end`.
+                                    debug_assert!(
+                                        node_after_link.is_none_or(|node_after_ix| {
+                                            self.tree[node_after_ix].item.start >= end
+                                        }),
+                                        "reference splice must not overrun its successor",
+                                    );
 
                                     // set up cur so next node will be node_after_link
                                     cur = Some(tos.node);

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -62,6 +62,11 @@ pub(crate) enum ItemBody {
 
     // repeats, can_open, can_close
     MaybeEmphasis(usize, bool, bool),
+    /// Head of a run the first pass's escape handler would have swallowed,
+    /// sitting on the byte after a deferred autolink candidate's last. Carries
+    /// the flags for the run the link firing creates; blocked until it does.
+    // repeats, can_open, can_close
+    MaybeEmphasisEscaped(usize, bool, bool),
     // preceded_by_backslash, brace context
     MaybeMath(bool, u8),
     // quote byte, can_open, can_close
@@ -1241,6 +1246,25 @@ impl<'input> ParserInner<'input> {
                                 _ => {}
                             }
                         }
+                        self.repair_construct_after_url_end(cand.end, node_after_ix);
+                    }
+                }
+                ItemBody::MaybeEmphasisEscaped(count, ..) => {
+                    // Nothing unblocked it, so the escape stands: the delimiter
+                    // it hid is literal and the run after it is one shorter.
+                    self.tree[cur_ix].item.body = ItemBody::Text {
+                        backslash_escaped: true,
+                    };
+                    let c = self.text.as_bytes()[self.tree[cur_ix].item.start];
+                    if !crate::firstpass::delim_run_is_valid(c, count - 1, self.options) {
+                        let mut scan = self.tree[cur_ix].next;
+                        for _ in 1..count {
+                            let Some(next_ix) = scan else { break };
+                            self.tree[next_ix].item.body = ItemBody::Text {
+                                backslash_escaped: false,
+                            };
+                            scan = self.tree[next_ix].next;
+                        }
                     }
                 }
                 ItemBody::MaybeLinkOpen => {
@@ -1589,6 +1613,57 @@ impl<'input> ParserInner<'input> {
         self.wikilink_stack.clear();
         self.code_delims.clear();
         self.math_delims.clear();
+    }
+
+    /// The construct opening on the byte after a URL-ending `\`. The first
+    /// pass's escape handler consumed that byte, so the construct either never
+    /// got an item or got a blocked one; now that the link owns the `\`, give
+    /// it back.
+    fn repair_construct_after_url_end(&mut self, cand_end: usize, node_ix: TreeIndex) {
+        let item = self.tree[node_ix].item;
+        if item.start != cand_end {
+            return;
+        }
+        if let ItemBody::MaybeEmphasisEscaped(count, can_open, can_close) = item.body {
+            self.tree[node_ix].item.body = ItemBody::MaybeEmphasis(count, can_open, can_close);
+            // The rest of the run was emitted for the shorter run the escape
+            // would have left, so only its flanking needs restating.
+            let mut scan = self.tree[node_ix].next;
+            for _ in 1..count {
+                let Some(next_ix) = scan else { break };
+                if let ItemBody::MaybeEmphasis(_, open, close) = &mut self.tree[next_ix].item.body {
+                    *open = can_open;
+                    *close = can_close;
+                }
+                scan = self.tree[next_ix].next;
+            }
+            return;
+        }
+        if !matches!(item.body, ItemBody::Text { .. })
+            || self.text.as_bytes().get(cand_end) != Some(&b'&')
+        {
+            return;
+        }
+        let (n, Some(value)) = scan_entity(&self.text.as_bytes()[cand_end..]) else {
+            return;
+        };
+        if cand_end + n > item.end {
+            return;
+        }
+        let cow_ix = self.allocs.allocate_cow(value);
+        if cand_end + n < item.end {
+            let tail = self.tree.create_node(Item {
+                start: cand_end + n,
+                end: item.end,
+                body: ItemBody::Text {
+                    backslash_escaped: false,
+                },
+            });
+            self.tree[tail].next = self.tree[node_ix].next;
+            self.tree[node_ix].next = Some(tail);
+        }
+        self.tree[node_ix].item.end = cand_end + n;
+        self.tree[node_ix].item.body = ItemBody::SynthesizeText(cow_ix);
     }
 
     /// Handles a wikilink.

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -1089,32 +1089,35 @@ pub(crate) struct Smart {
     pub ellipses: bool,
 }
 
-/// The em/en dash mix smart punctuation renders a run of `count` hyphens as.
-pub(crate) fn smart_dash_run(count: usize) -> String {
-    if count == 2 {
-        return "\u{2013}".to_owned();
-    }
-    if count == 3 {
-        return "\u{2014}".to_owned();
-    }
-    let (ems, ens) = match count % 6 {
+/// How many em and en dashes smart punctuation renders a run of `count`
+/// hyphens as.
+fn smart_dash_counts(count: usize) -> (usize, usize) {
+    debug_assert!(count >= 2, "a lone hyphen is not a dash run");
+    match count % 6 {
         0 | 3 => (count / 3, 0),
         2 | 4 => (0, count / 2),
         1 => (count / 3 - 1, 2),
         _ => (count / 3, 1),
-    };
-    let mut buf = String::with_capacity(3 * (ems + ens));
+    }
+}
+
+/// The em/en dash mix smart punctuation renders a run of `count` hyphens as.
+pub(crate) fn smart_dash_run(count: usize) -> String {
+    let (ems, ens) = smart_dash_counts(count);
+    let mut buf = String::with_capacity(EM_DASH.len() * (ems + ens));
     for _ in 0..ems {
-        buf.push('\u{2014}');
+        buf.push_str(EM_DASH);
     }
     for _ in 0..ens {
-        buf.push('\u{2013}');
+        buf.push_str(EN_DASH);
     }
     buf
 }
 
+const EM_DASH: &str = "\u{2014}";
+const EN_DASH: &str = "\u{2013}";
+
 /// The raw and decoded lengths of the smart-punctuation rewrite at `raw[r]`.
-#[cold]
 fn smart_seg(raw: &[u8], r: usize, dec: &[u8], d: usize, smart: Smart) -> Option<(usize, usize)> {
     const ELLIPSIS: &str = "\u{2026}";
     match raw[r] {
@@ -1129,10 +1132,14 @@ fn smart_seg(raw: &[u8], r: usize, dec: &[u8], d: usize, smart: Smart) -> Option
             if count < 2 {
                 return None;
             }
-            let run = smart_dash_run(count);
-            dec[d..]
-                .starts_with(run.as_bytes())
-                .then_some((count, run.len()))
+            let (ems, ens) = smart_dash_counts(count);
+            let mut rest = &dec[d..];
+            for (n, dash) in [(ems, EM_DASH), (ens, EN_DASH)] {
+                for _ in 0..n {
+                    rest = rest.strip_prefix(dash.as_bytes())?;
+                }
+            }
+            Some((count, EM_DASH.len() * (ems + ens)))
         }
         c @ (b'"' | b'\'') if smart.quotes => {
             let curly: [&str; 2] = if c == b'"' {
@@ -1664,6 +1671,11 @@ mod tests {
         let m = smart_map("a-----b", "a\u{2014}\u{2013}b");
         assert_eq!(m.raw_start_of(1), Some(1));
         assert_eq!(m.raw_end_of(7), Some(6));
+
+        // Seven is the branch that subtracts: em + two en, 7 raw to 9 decoded.
+        let m = smart_map("a-------b", "a\u{2014}\u{2013}\u{2013}b");
+        assert_eq!(m.raw_start_of(1), Some(1));
+        assert_eq!(m.raw_end_of(10), Some(8));
     }
 
     #[test]

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -841,12 +841,13 @@ pub(crate) fn gfm_autolink_literal_pass(
             candidates.push(id);
         }
     }
-    // Smart punctuation rewrites text values in ways `build_raw_map` can't
-    // reverse, so a failed reconstruction is expected there.
-    let strict =
-        !(options.has_smart_quotes() || options.has_smart_dashes() || options.has_smart_ellipses());
+    let smart = Smart {
+        quotes: options.has_smart_quotes(),
+        dashes: options.has_smart_dashes(),
+        ellipses: options.has_smart_ellipses(),
+    };
     for node_id in candidates {
-        split_text_with_autolinks_fnr(arena, node_id, source_bytes, cursor.as_deref_mut(), strict);
+        split_text_with_autolinks_fnr(arena, node_id, source_bytes, cursor.as_deref_mut(), smart);
     }
 }
 
@@ -1088,7 +1089,81 @@ impl RawMap {
 ///
 /// Returns `None` when the value can't be reconstructed exactly; callers then
 /// report no position rather than a guessed one that mis-slices the source.
-fn build_raw_map(source: &[u8], r_start: usize, r_end: usize, decoded: &str) -> Option<RawMap> {
+/// Which smart-punctuation rewrites are on, so `build_raw_map` can undo them.
+#[derive(Clone, Copy)]
+pub(crate) struct Smart {
+    pub quotes: bool,
+    pub dashes: bool,
+    pub ellipses: bool,
+}
+
+/// The em/en dash mix smart punctuation renders a run of `count` hyphens as.
+pub(crate) fn smart_dash_run(count: usize) -> String {
+    if count == 2 {
+        return "\u{2013}".to_owned();
+    }
+    if count == 3 {
+        return "\u{2014}".to_owned();
+    }
+    let (ems, ens) = match count % 6 {
+        0 | 3 => (count / 3, 0),
+        2 | 4 => (0, count / 2),
+        1 => (count / 3 - 1, 2),
+        _ => (count / 3, 1),
+    };
+    let mut buf = String::with_capacity(3 * (ems + ens));
+    for _ in 0..ems {
+        buf.push('\u{2014}');
+    }
+    for _ in 0..ens {
+        buf.push('\u{2013}');
+    }
+    buf
+}
+
+/// The raw and decoded lengths of the smart-punctuation rewrite at `raw[r]`.
+#[cold]
+fn smart_seg(raw: &[u8], r: usize, dec: &[u8], d: usize, smart: Smart) -> Option<(usize, usize)> {
+    const ELLIPSIS: &str = "\u{2026}";
+    match raw[r] {
+        b'.' if smart.ellipses
+            && raw[r..].starts_with(b"...")
+            && dec[d..].starts_with(ELLIPSIS.as_bytes()) =>
+        {
+            Some((3, ELLIPSIS.len()))
+        }
+        b'-' if smart.dashes => {
+            let count = 1 + crate::scanners::scan_ch_repeat(&raw[(r + 1)..], b'-');
+            if count < 2 {
+                return None;
+            }
+            let run = smart_dash_run(count);
+            dec[d..]
+                .starts_with(run.as_bytes())
+                .then_some((count, run.len()))
+        }
+        c @ (b'"' | b'\'') if smart.quotes => {
+            let curly: [&str; 2] = if c == b'"' {
+                ["\u{201c}", "\u{201d}"]
+            } else {
+                ["\u{2018}", "\u{2019}"]
+            };
+            curly
+                .iter()
+                .find(|q| dec[d..].starts_with(q.as_bytes()))
+                .map(|q| (1, q.len()))
+        }
+        _ => None,
+    }
+}
+
+fn build_raw_map(
+    source: &[u8],
+    r_start: usize,
+    r_end: usize,
+    decoded: &str,
+    smart: Smart,
+) -> Option<RawMap> {
     if r_start > r_end || r_end > source.len() {
         return None;
     }
@@ -1128,6 +1203,9 @@ fn build_raw_map(source: &[u8], r_start: usize, r_end: usize, decoded: &str) -> 
         });
     };
 
+    // One predictable test keeps the smart arms off the hot path entirely for
+    // the documents that don't enable them.
+    let smart_any = smart.quotes || smart.dashes || smart.ellipses;
     let mut r = 0usize;
     let mut d = 0usize;
     while r < raw.len() {
@@ -1201,6 +1279,14 @@ fn build_raw_map(source: &[u8], r_start: usize, r_end: usize, decoded: &str) -> 
                 });
                 continue;
             }
+            b'.' | b'-' | b'"' | b'\'' if smart_any => {
+                if let Some((r_len, d_len)) = smart_seg(raw, r, dec, d, smart) {
+                    push_atomic(&mut segs, r, r_len, d, d_len);
+                    r += r_len;
+                    d += d_len;
+                    continue;
+                }
+            }
             0 => {
                 // CommonMark replaces NUL with the replacement character.
                 const REPLACEMENT: &str = "\u{FFFD}";
@@ -1254,7 +1340,7 @@ fn split_text_with_autolinks_fnr(
     text_id: u32,
     source_bytes: &[u8],
     cursor: Option<&mut satteri_arena::LineIndexCursor<'_, '_>>,
-    strict: bool,
+    smart: Smart,
 ) {
     let data = arena.get_type_data(text_id);
     if data.is_empty() {
@@ -1298,10 +1384,10 @@ fn split_text_with_autolinks_fnr(
     let (r_start, r_end) = (node.start_offset as usize, node.end_offset as usize);
     let map = cursor
         .as_ref()
-        .and_then(|_| build_raw_map(source_bytes, r_start, r_end, &text));
+        .and_then(|_| build_raw_map(source_bytes, r_start, r_end, &text, smart));
     if cursor.is_some() && map.is_none() {
         debug_assert!(
-            !strict,
+            false,
             "build_raw_map failed to reconstruct a text value from its source span"
         );
     }
@@ -1507,10 +1593,25 @@ pub(crate) fn mdx_mark_and_unravel(arena: &mut Arena<Mdast>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_raw_map, RawMap};
+    use super::{build_raw_map, RawMap, Smart};
+
+    const OFF: Smart = Smart {
+        quotes: false,
+        dashes: false,
+        ellipses: false,
+    };
+    const ON: Smart = Smart {
+        quotes: true,
+        dashes: true,
+        ellipses: true,
+    };
 
     fn map(source: &str, decoded: &str) -> RawMap {
-        build_raw_map(source.as_bytes(), 0, source.len(), decoded).expect("map should build")
+        build_raw_map(source.as_bytes(), 0, source.len(), decoded, OFF).expect("map should build")
+    }
+
+    fn smart_map(source: &str, decoded: &str) -> RawMap {
+        build_raw_map(source.as_bytes(), 0, source.len(), decoded, ON).expect("map should build")
     }
 
     #[test]
@@ -1543,6 +1644,52 @@ mod tests {
     }
 
     #[test]
+    fn raw_map_spans_a_smart_dash_run_whole() {
+        // `--` occupies raw 1..3 and decodes to one 3-byte en dash.
+        let m = smart_map("a--b", "a\u{2013}b");
+        assert_eq!(m.raw_start_of(1), Some(1));
+        assert_eq!(m.raw_end_of(4), Some(3));
+        // Interior of the atomic run names no raw offset.
+        assert_eq!(m.raw_start_of(2), None);
+        assert_eq!(m.raw_end_of(2), None);
+    }
+
+    #[test]
+    fn raw_map_spans_a_long_dash_run_by_the_shared_formula() {
+        // Five hyphens render as em + en, so the run is 5 raw to 6 decoded.
+        let m = smart_map("a-----b", "a\u{2014}\u{2013}b");
+        assert_eq!(m.raw_start_of(1), Some(1));
+        assert_eq!(m.raw_end_of(7), Some(6));
+    }
+
+    #[test]
+    fn raw_map_spans_an_ellipsis_and_a_quote_whole() {
+        let m = smart_map("a...b", "a\u{2026}b");
+        assert_eq!(m.raw_start_of(1), Some(1));
+        assert_eq!(m.raw_end_of(4), Some(4));
+
+        let q = smart_map("a\"b\"", "a\u{201c}b\u{201d}");
+        assert_eq!(q.raw_start_of(1), Some(1));
+        assert_eq!(q.raw_end_of(4), Some(2));
+    }
+
+    #[test]
+    fn raw_map_leaves_smart_bytes_alone_when_the_option_is_off() {
+        // The same raw text decodes to itself, so it stays the identity map.
+        assert!(matches!(map("a--b", "a--b"), RawMap::Identity { .. }));
+        // And a curled value cannot be reconstructed without the option.
+        assert!(build_raw_map("a--b".as_bytes(), 0, 4, "a\u{2013}b", OFF).is_none());
+    }
+
+    #[test]
+    fn raw_map_prefers_the_escape_over_a_smart_dash() {
+        // `\-` is an escape, so the run after it is only two hyphens.
+        let m = smart_map("\\---", "-\u{2013}");
+        assert_eq!(m.raw_end_of(1), Some(2));
+        assert_eq!(m.raw_end_of(4), Some(4));
+    }
+
+    #[test]
     fn raw_map_excludes_a_continuation_prefix() {
         // The `> ` produces nothing, so it belongs to neither side.
         let m = map("a\n> b", "a\nb");
@@ -1560,7 +1707,7 @@ mod tests {
 
     #[test]
     fn raw_map_refuses_to_guess() {
-        assert!(build_raw_map(b"a&amp;b", 0, 7, "a&z").is_none());
-        assert!(build_raw_map(b"abc", 0, 3, "abcd").is_none());
+        assert!(build_raw_map(b"a&amp;b", 0, 7, "a&z", OFF).is_none());
+        assert!(build_raw_map(b"abc", 0, 3, "abcd", OFF).is_none());
     }
 }

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -1081,14 +1081,6 @@ impl RawMap {
     }
 }
 
-/// Align a Text node's decoded value with the raw source it came from.
-///
-/// At each raw offset the walk asks which transform applies, never whether the
-/// bytes differ: raw `&amp;` starts with the byte it decodes to, so a
-/// mismatch-directed walk would consume it and then choke on `amp;`.
-///
-/// Returns `None` when the value can't be reconstructed exactly; callers then
-/// report no position rather than a guessed one that mis-slices the source.
 /// Which smart-punctuation rewrites are on, so `build_raw_map` can undo them.
 #[derive(Clone, Copy)]
 pub(crate) struct Smart {
@@ -1157,6 +1149,14 @@ fn smart_seg(raw: &[u8], r: usize, dec: &[u8], d: usize, smart: Smart) -> Option
     }
 }
 
+/// Align a Text node's decoded value with the raw source it came from.
+///
+/// At each raw offset the walk asks which transform applies, never whether the
+/// bytes differ: raw `&amp;` starts with the byte it decodes to, so a
+/// mismatch-directed walk would consume it and then choke on `amp;`.
+///
+/// Returns `None` when the value can't be reconstructed exactly; callers then
+/// report no position rather than a guessed one that mis-slices the source.
 fn build_raw_map(
     source: &[u8],
     r_start: usize,

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -1203,6 +1203,27 @@ fn build_raw_map(
         });
     };
 
+    // A continuation line's block prefix (`> `, indentation) produces no
+    // decoded bytes. Content can't start with one: leading whitespace is
+    // stripped and a leading `>` would have opened a blockquote.
+    let skip_block_prefix = |segs: &mut Vec<Seg>, r: &mut usize, d: usize| {
+        let prefix_start = *r;
+        while *r < raw.len()
+            && matches!(raw[*r], b' ' | b'\t' | b'>')
+            && dec.get(d) != Some(&raw[*r])
+        {
+            *r += 1;
+        }
+        if *r > prefix_start {
+            segs.push(Seg {
+                d_start: d as u32,
+                d_len: 0,
+                r_start: (r_start + prefix_start) as u32,
+                r_len: (*r - prefix_start) as u32,
+            });
+        }
+    };
+
     // One predictable test keeps the smart arms off the hot path entirely for
     // the documents that don't enable them.
     let smart_any = smart.quotes || smart.dashes || smart.ellipses;
@@ -1235,31 +1256,14 @@ fn build_raw_map(
                 push_atomic(&mut segs, r, 2, d, 1);
                 r += 2;
                 d += 1;
+                skip_block_prefix(&mut segs, &mut r, d);
                 continue;
             }
-            b'\n' if dec.get(d) == Some(&b'\n') => {
+            b'\n' | b'\r' if dec.get(d) == Some(&raw[r]) => {
                 extend_one_to_one(&mut segs, r, d);
                 r += 1;
                 d += 1;
-                // A continuation line's block prefix (`> `, indentation)
-                // produces no decoded bytes. Content can't start with one:
-                // leading whitespace is stripped and a leading `>` would have
-                // opened a blockquote.
-                let prefix_start = r;
-                while r < raw.len()
-                    && matches!(raw[r], b' ' | b'\t' | b'>')
-                    && dec.get(d) != Some(&raw[r])
-                {
-                    r += 1;
-                }
-                if r > prefix_start {
-                    segs.push(Seg {
-                        d_start: d as u32,
-                        d_len: 0,
-                        r_start: (r_start + prefix_start) as u32,
-                        r_len: (r - prefix_start) as u32,
-                    });
-                }
+                skip_block_prefix(&mut segs, &mut r, d);
                 continue;
             }
             b' ' | b'\t' if dec.get(d) != Some(&raw[r]) => {

--- a/crates/satteri-pulldown-cmark/tests/directive_inline.rs
+++ b/crates/satteri-pulldown-cmark/tests/directive_inline.rs
@@ -187,3 +187,24 @@ fn directive_fragment_inside_code_span_does_not_swallow_later_code() {
     assert_eq!(node_value(&arena, children[0]), ":foo[");
     assert_eq!(node_value(&arena, children[2]), "bar]");
 }
+
+// A container directive's `[label]` has no event mapping, so the pull parser
+// panics on every one of them. The arena path, which every consumer in this
+// workspace uses, builds the label correctly.
+#[test]
+#[should_panic(expected = "unexpected item body DirectiveLabel")]
+fn a_container_directive_label_has_no_event() {
+    satteri_pulldown_cmark::Parser::new_ext(":::a[b]\n:::\n", dir_options()).count();
+}
+
+#[test]
+fn the_arena_path_builds_that_label() {
+    let (arena, _) = parse(":::a[b]\n:::\n", dir_options());
+    let directive = arena.get_children(0)[0];
+    let label = arena.get_children(directive)[0];
+    assert_eq!(
+        arena.get_node(label).node_type,
+        MdastNodeType::Paragraph as u8
+    );
+    assert_eq!(node_value(&arena, arena.get_children(label)[0]), "b");
+}

--- a/packages/satteri/src/hast/hast-reader.ts
+++ b/packages/satteri/src/hast/hast-reader.ts
@@ -44,7 +44,7 @@ export class HastReader {
     } else {
       this.#view = new DataView(buffer);
     }
-    this.#textDecoder = new TextDecoder("utf-8");
+    this.#textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
     this.#header = this.#readHeader();
   }
 

--- a/packages/satteri/src/mdast/mdast-reader.ts
+++ b/packages/satteri/src/mdast/mdast-reader.ts
@@ -19,7 +19,7 @@ export class MdastReader {
     } else {
       this.#view = new DataView(buffer);
     }
-    this.#textDecoder = new TextDecoder("utf-8");
+    this.#textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
     this.#header = this.#readHeader();
   }
 

--- a/packages/satteri/src/wire-read.ts
+++ b/packages/satteri/src/wire-read.ts
@@ -6,7 +6,9 @@
 
 import type { Position } from "unist";
 
-const textDecoder = new TextDecoder("utf-8");
+// `ignoreBOM` keeps a value-initial U+FEFF: each string is decoded from its
+// own byte range, so the default BOM strip would eat it as content.
+const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 
 /** Read a u16 (LE) at `off`. */
 export function ru16(view: DataView, off: number): number {

--- a/packages/satteri/test/conformance/autolink-contexts.test.ts
+++ b/packages/satteri/test/conformance/autolink-contexts.test.ts
@@ -471,3 +471,20 @@ describe("family D: paragraph start in a task list item (documented divergence)"
     assertMdastConformance("- [ ] plain text\n");
   });
 });
+
+// The deferred path reaches the same construct-ordering decision through
+// `candidate_floor` rather than through the committed path's skip, and the
+// block containers each re-enter the scanner at a content start.
+describe("email and `www` triggering at the same offset, per container", () => {
+  test.each([
+    "[a] www.x.ya@b.cd",
+    "`c` www.x.ya@b.cd",
+    "<b> www.x.ya@b.cd",
+    "[a](b) www.x.ya@b.cd",
+    "# www.x.ya@b.cd",
+    "> www.x.ya@b.cd",
+    "- www.x.ya@b.cd",
+    "| a |\n| - |\n| www.x.ya@b.cd |",
+    "[^1]: www.x.ya@b.cd\n\n[^1]",
+  ])("%j", assertMdastConformance);
+});

--- a/packages/satteri/test/conformance/autolink-fnr-positions.test.ts
+++ b/packages/satteri/test/conformance/autolink-fnr-positions.test.ts
@@ -159,6 +159,16 @@ describe("find-and-replace autolink positions", () => {
     expect(link.position!.start).toEqual({ line: 2, column: 3, offset: 7 });
   });
 
+  test("7b. a lone carriage return ends the line the prefix follows", () => {
+    const md = "> [a\r> www.x.y";
+    expectReferenceTakesFnr(md);
+    expect(spans(md)).toEqual([
+      ["text", "[a\r", "[a\r"],
+      ["link", "http://www.x.y", "www.x.y"],
+      ["text", "www.x.y", "www.x.y"],
+    ]);
+  });
+
   test("8. a multi-character reference is included whole or not at all", () => {
     // `&fjlig;` decodes to two characters, so a boundary inside it has no raw
     // offset to name; here it falls within the match.
@@ -262,6 +272,14 @@ describe("smart punctuation does not cost the autolink its position", () => {
       "link",
       'http://www.a.com/a"b',
       'www.a.com/a\\"b',
+    ]);
+  });
+
+  test("a lone carriage return keeps the alignment on the rails", () => {
+    expect(smart('> "q"\r> [www.a.com/x').at(1)).toEqual([
+      "link",
+      "http://www.a.com/x",
+      "www.a.com/x",
     ]);
   });
 

--- a/packages/satteri/test/conformance/autolink-fnr-positions.test.ts
+++ b/packages/satteri/test/conformance/autolink-fnr-positions.test.ts
@@ -11,6 +11,7 @@ import {
   serializeHandle,
 } from "../../src/index.js";
 import { satteriMdast, referenceMdast } from "./helpers.js";
+import { markdownToMdast } from "../../src/index.js";
 
 interface Positioned {
   type: string;
@@ -35,7 +36,11 @@ function flatten(tree: unknown): Positioned[] {
 
 /** Every emitted node, paired with the source text its span covers. */
 function spans(md: string): Array<[string, string, string]> {
-  return flatten(satteriMdast(md))
+  return spansOf(md, satteriMdast(md));
+}
+
+function spansOf(md: string, tree: unknown): Array<[string, string, string]> {
+  return flatten(tree)
     .filter((n) => n.type === "link" || n.type === "text")
     .map((n) => [
       n.type,
@@ -197,5 +202,73 @@ describe("find-and-replace autolink positions", () => {
     } finally {
       dropHandle(handle);
     }
+  });
+});
+
+// Smart punctuation rewrites the text a find-and-replace autolink is found in,
+// so the decoded value no longer matches its source span byte for byte. The
+// alignment undoes the three rewrites, and these pin that it lands exactly —
+// an approximate span would be worse than the absent one it replaces.
+describe("smart punctuation does not cost the autolink its position", () => {
+  const smart = (md: string) =>
+    spansOf(
+      md,
+      markdownToMdast(md, {
+        features: { frontmatter: false, math: false, smartPunctuation: true },
+      }),
+    );
+
+  test.each([
+    // Inside the URL: the value curls, the span still covers the raw run.
+    ["[www.a.com/a--b", "http://www.a.com/a\u{2013}b", "www.a.com/a--b"],
+    ["[www.a.com/a...b", "http://www.a.com/a\u{2026}b", "www.a.com/a...b"],
+    ['[www.a.com/a"b', "http://www.a.com/a\u{201c}b", 'www.a.com/a"b'],
+    // The `%6` em/en formula, which the alignment shares with the first pass.
+    ["[www.a.com/a----b", "http://www.a.com/a\u{2013}\u{2013}b", "www.a.com/a----b"],
+    ["[www.a.com/a-----b", "http://www.a.com/a\u{2014}\u{2013}b", "www.a.com/a-----b"],
+  ])("%j", (md, url, slice) => {
+    const link = smart(md).find(([type]) => type === "link");
+    expect(link).toEqual(["link", url, slice]);
+  });
+
+  test("a rewrite before or after the match keeps every span exact", () => {
+    expect(smart('"q" [www.a.com/x')).toEqual([
+      ["text", "\u{201c}q\u{201d} [", '"q" ['],
+      ["link", "http://www.a.com/x", "www.a.com/x"],
+      ["text", "www.a.com/x", "www.a.com/x"],
+    ]);
+    expect(smart("[www.a.com/x -- y")).toEqual([
+      ["text", "[", "["],
+      ["link", "http://www.a.com/x", "www.a.com/x"],
+      ["text", "www.a.com/x", "www.a.com/x"],
+      ["text", " \u{2013} y", " -- y"],
+    ]);
+  });
+
+  test("it composes with the alignment's existing rules", () => {
+    // A continuation prefix, a character reference, and an escape that keeps
+    // its `-` out of the dash run.
+    expect(smart('> "q"\n> [www.a.com/x').at(1)).toEqual([
+      "link",
+      "http://www.a.com/x",
+      "www.a.com/x",
+    ]);
+    expect(smart("-- [www.a.com/&amp;b").at(1)).toEqual([
+      "link",
+      "http://www.a.com/&b",
+      "www.a.com/&amp;b",
+    ]);
+    expect(smart('[www.a.com/a\\"b').at(1)).toEqual([
+      "link",
+      'http://www.a.com/a"b',
+      'www.a.com/a\\"b',
+    ]);
+  });
+
+  test("the construct path is untouched: smart punctuation never enters a URL", () => {
+    expect(smart("www.a.com/a--b")).toEqual([
+      ["link", "http://www.a.com/a--b", "www.a.com/a--b"],
+      ["text", "www.a.com/a--b", "www.a.com/a--b"],
+    ]);
   });
 });

--- a/packages/satteri/test/conformance/autolink-literals.test.ts
+++ b/packages/satteri/test/conformance/autolink-literals.test.ts
@@ -25,6 +25,7 @@ const A_TRIGGERS = [
   "http://example.com",
   "user@example.com",
   "_user@example.com",
+  "www.user@example.com",
 ];
 
 // What each trigger links to when the preceding character lets it through, so a
@@ -33,62 +34,95 @@ const W = "http://www.example.com";
 const H = "http://example.com";
 const E = "mailto:user@example.com";
 const U = "mailto:_user@example.com";
+// The last trigger is a `www.` literal and an email at the same offset. The
+// email is registered first, so it wins wherever the preceding character lets
+// it through — and only there does the `www.` half get the match.
+const O = "mailto:www.user@example.com";
+const OW = "http://www.user@example.com";
 /** The trigger does not become a link at all. */
 const NO = "";
 
 const PRECEDING: Array<{ prefix: string; name: string; urls: string[] }> = [
-  { prefix: "", name: "start of document", urls: [W, H, E, U] },
-  { prefix: " ", name: "space", urls: [W, H, E, U] },
-  { prefix: "  ", name: "two spaces", urls: [W, H, E, U] },
-  { prefix: "(", name: "`(`", urls: [W, H, E, U] },
-  { prefix: "*", name: "`*`", urls: [W, H, E, U] },
-  { prefix: "_", name: "`_`", urls: [W, H, U, "mailto:__user@example.com"] },
-  { prefix: "~", name: "`~`", urls: [W, H, E, U] },
-  { prefix: "]", name: "`]`", urls: [W, H, E, U] },
-  { prefix: ">", name: "`>` (a blockquote marker here)", urls: [W, H, E, U] },
+  { prefix: "", name: "start of document", urls: [W, H, E, U, O] },
+  { prefix: " ", name: "space", urls: [W, H, E, U, O] },
+  { prefix: "  ", name: "two spaces", urls: [W, H, E, U, O] },
+  { prefix: "(", name: "`(`", urls: [W, H, E, U, O] },
+  { prefix: "*", name: "`*`", urls: [W, H, E, U, O] },
+  {
+    prefix: "_",
+    name: "`_`",
+    urls: [W, H, U, "mailto:__user@example.com", "mailto:_www.user@example.com"],
+  },
+  { prefix: "~", name: "`~`", urls: [W, H, E, U, O] },
+  { prefix: "]", name: "`]`", urls: [W, H, E, U, O] },
+  { prefix: ">", name: "`>` (a blockquote marker here)", urls: [W, H, E, U, O] },
   {
     prefix: ".",
     name: "`.`",
-    urls: [W, H, "mailto:.user@example.com", "mailto:._user@example.com"],
+    urls: [
+      W,
+      H,
+      "mailto:.user@example.com",
+      "mailto:._user@example.com",
+      "mailto:.www.user@example.com",
+    ],
   },
-  { prefix: ",", name: "`,`", urls: [W, H, E, U] },
-  { prefix: '"', name: '`"`', urls: [W, H, E, U] },
+  { prefix: ",", name: "`,`", urls: [W, H, E, U, O] },
+  { prefix: '"', name: '`"`', urls: [W, H, E, U, O] },
   {
     prefix: "-",
     name: "`-`",
-    urls: [W, H, "mailto:-user@example.com", "mailto:-_user@example.com"],
+    urls: [
+      W,
+      H,
+      "mailto:-user@example.com",
+      "mailto:-_user@example.com",
+      "mailto:-www.user@example.com",
+    ],
   },
-  { prefix: "|", name: "`|`", urls: [W, H, E, U] },
-  { prefix: "/", name: "`/`", urls: [W, H, NO, E] },
-  { prefix: "[", name: "`[`", urls: [W, H, E, U] },
-  { prefix: "\\", name: "`\\`", urls: [W, H, E, U] },
-  { prefix: "©", name: "So symbol", urls: [W, H, E, U] },
-  { prefix: "€", name: "Sc symbol", urls: [W, H, E, U] },
-  { prefix: "±", name: "Sm symbol", urls: [W, H, E, U] },
-  { prefix: "—", name: "Pd punctuation", urls: [W, H, E, U] },
-  { prefix: "•", name: "Po punctuation", urls: [W, H, E, U] },
-  { prefix: "。", name: "CJK Po punctuation", urls: [W, H, E, U] },
-  { prefix: "（", name: "Ps punctuation", urls: [W, H, E, U] },
-  { prefix: "\u{a0}", name: "Zs space", urls: [W, H, E, U] },
+  { prefix: "|", name: "`|`", urls: [W, H, E, U, O] },
+  { prefix: "/", name: "`/`", urls: [W, H, NO, E, OW] },
+  { prefix: "[", name: "`[`", urls: [W, H, E, U, OW] },
+  { prefix: "\\", name: "`\\`", urls: [W, H, E, U, O] },
+  { prefix: "©", name: "So symbol", urls: [W, H, E, U, O] },
+  { prefix: "€", name: "Sc symbol", urls: [W, H, E, U, O] },
+  { prefix: "±", name: "Sm symbol", urls: [W, H, E, U, O] },
+  { prefix: "—", name: "Pd punctuation", urls: [W, H, E, U, O] },
+  { prefix: "•", name: "Po punctuation", urls: [W, H, E, U, O] },
+  { prefix: "。", name: "CJK Po punctuation", urls: [W, H, E, U, O] },
+  { prefix: "（", name: "Ps punctuation", urls: [W, H, E, U, O] },
+  { prefix: "\u{a0}", name: "Zs space", urls: [W, H, E, U, O] },
   {
     prefix: "5",
     name: "Nd digit",
-    urls: [NO, H, "mailto:5user@example.com", "mailto:5_user@example.com"],
+    urls: [
+      NO,
+      H,
+      "mailto:5user@example.com",
+      "mailto:5_user@example.com",
+      "mailto:5www.user@example.com",
+    ],
   },
   {
     prefix: "a",
     name: "ASCII letter",
-    urls: [NO, NO, "mailto:auser@example.com", "mailto:a_user@example.com"],
+    urls: [
+      NO,
+      NO,
+      "mailto:auser@example.com",
+      "mailto:a_user@example.com",
+      "mailto:awww.user@example.com",
+    ],
   },
-  { prefix: "α", name: "Ll letter", urls: [NO, H, E, U] },
-  { prefix: "中", name: "Lo letter", urls: [NO, H, E, U] },
-  { prefix: "e\u{301}", name: "Mn combining mark", urls: [NO, H, E, U] },
-  { prefix: "\u{200b}", name: "Cf zero-width space", urls: [NO, H, E, U] },
-  { prefix: "\u{ad}", name: "Cf soft hyphen", urls: [NO, H, E, U] },
-  { prefix: "❤\u{fe0f}", name: "variation selector", urls: [NO, H, E, U] },
-  { prefix: "🯰", name: "astral Nd digit", urls: [NO, H, E, U] },
-  { prefix: "𝐀", name: "astral Lu letter", urls: [NO, H, E, U] },
-  { prefix: "𠀀", name: "astral Lo letter", urls: [NO, H, E, U] },
+  { prefix: "α", name: "Ll letter", urls: [NO, H, E, U, O] },
+  { prefix: "中", name: "Lo letter", urls: [NO, H, E, U, O] },
+  { prefix: "e\u{301}", name: "Mn combining mark", urls: [NO, H, E, U, O] },
+  { prefix: "\u{200b}", name: "Cf zero-width space", urls: [NO, H, E, U, O] },
+  { prefix: "\u{ad}", name: "Cf soft hyphen", urls: [NO, H, E, U, O] },
+  { prefix: "❤\u{fe0f}", name: "variation selector", urls: [NO, H, E, U, O] },
+  { prefix: "🯰", name: "astral Nd digit", urls: [NO, H, E, U, O] },
+  { prefix: "𝐀", name: "astral Lu letter", urls: [NO, H, E, U, O] },
+  { prefix: "𠀀", name: "astral Lo letter", urls: [NO, H, E, U, O] },
 ];
 
 describe("family A: the preceding-character classifier", () => {
@@ -100,7 +134,7 @@ describe("family A: the preceding-character classifier", () => {
     }
   });
 
-  // The trigger kinds the four-column table above does not carry.
+  // The trigger kinds the table above does not carry.
   test.each([
     ["www.example.com/a/b\n", ["http://www.example.com/a/b"]],
     ["https://example.com/a?b=c#d\n", ["https://example.com/a?b=c#d"]],

--- a/packages/satteri/test/conformance/autolink-literals.test.ts
+++ b/packages/satteri/test/conformance/autolink-literals.test.ts
@@ -444,3 +444,44 @@ describe("family J: unicode whitespace as terminator and boundary", () => {
     ["[a x\u{feff}www.example.com\n", ["http://www.example.com"]],
   ])("%j", conforms);
 });
+
+// GFM registers the email construct ahead of `www` at the same offset, so an
+// email whose local part opens with `www.` beats the www literal that could
+// start there. The rows below are the whole family: every failing shape the
+// differential sweep found was one of these local parts under one of the
+// preceding characters `www` itself accepts.
+describe("family M: email and `www` triggering at the same offset", () => {
+  test.each([
+    ["www.x.ya@b.cd\n", ["mailto:www.x.ya@b.cd"]],
+    // The extent shrinks too, not just the scheme: `/p` stays text.
+    ["www.x.ya@b.cd/p\n", ["mailto:www.x.ya@b.cd"]],
+    ["WWW.x@b.cd\n", ["mailto:WWW.x@b.cd"]],
+    ["wWw.x@b.cd\n", ["mailto:wWw.x@b.cd"]],
+    ["www.@b.cd\n", ["mailto:www.@b.cd"]],
+    ["www.-@b.cd\n", ["mailto:www.-@b.cd"]],
+    ["www.1@b.cd\n", ["mailto:www.1@b.cd"]],
+    ["www.a.b.c@d.ef\n", ["mailto:www.a.b.c@d.ef"]],
+    // The email construct fails on its own terms here, so `www` still wins.
+    ["www.x.ya@b\n", ["http://www.x.ya@b"]],
+    // `_` is trailing punctuation, so the www URL trims it — and the email
+    // domain it would have ended on is rejected for not ending alphabetic.
+    ["www.x.ya@b.cd_\n", ["http://www.x.ya@b.cd"]],
+    // The domain scan rejects outright, so no span is skipped and the `@`
+    // hook picks it up unaided.
+    ["www.a_b@c.de\n", ["mailto:www.a_b@c.de"]],
+    ["_www.x.ya@b.cd\n", ["mailto:_www.x.ya@b.cd"]],
+    // An atext run from `h` stops at `:`, so a protocol literal and an email
+    // can never open at the same offset.
+    ["http://x.ya@b.cd\n", ["http://x.ya@b.cd"]],
+    ["https://x.ya@b.cd\n", ["https://x.ya@b.cd"]],
+    // The characters `www` accepts as a predecessor.
+    ["(www.x.ya@b.cd)\n", ["mailto:www.x.ya@b.cd"]],
+    ["*www.x.ya@b.cd*\n", ["mailto:www.x.ya@b.cd"]],
+    ["~www.x.ya@b.cd~\n", ["mailto:www.x.ya@b.cd"]],
+    ["]www.x.ya@b.cd\n", ["mailto:www.x.ya@b.cd"]],
+    ["x www.x.ya@b.cd\n", ["mailto:www.x.ya@b.cd"]],
+    // Not predecessors `www` accepts, so only the `@` hook can fire.
+    ["a.www.x.ya@b.cd\n", ["mailto:a.www.x.ya@b.cd"]],
+    ["1www.x.ya@b.cd\n", ["mailto:1www.x.ya@b.cd"]],
+  ])("%j", conforms);
+});

--- a/packages/satteri/test/conformance/autolink-literals.test.ts
+++ b/packages/satteri/test/conformance/autolink-literals.test.ts
@@ -517,5 +517,13 @@ describe("family M: email and `www` triggering at the same offset", () => {
     // Not predecessors `www` accepts, so only the `@` hook can fire.
     ["a.www.x.ya@b.cd\n", ["mailto:a.www.x.ya@b.cd"]],
     ["1www.x.ya@b.cd\n", ["mailto:1www.x.ya@b.cd"]],
+    // The email ends before the www literal would have, and the bytes between
+    // the two ends go back through inline scanning as ordinary content.
+    ["www.x.ya@b.cd*em*\n", ["mailto:www.x.ya@b.cd"]],
+    ["www.x.ya@b.cd\\*\n", ["mailto:www.x.ya@b.cd"]],
+    ["www.x.ya@b.cd&amp;\n", ["mailto:www.x.ya@b.cd"]],
+    ["www.x.ya@b.cd)\n", ["mailto:www.x.ya@b.cd"]],
+    ["www.x.ya@b.cd<b>\n", ["mailto:www.x.ya@b.cd"]],
+    ["www.x.ya@b.cd`c`\n", ["mailto:www.x.ya@b.cd"]],
   ])("%j", conforms);
 });

--- a/packages/satteri/test/conformance/autolink-path.test.ts
+++ b/packages/satteri/test/conformance/autolink-path.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   assertMdastConformance,
   assertSliceInvariantEverywhere,
+  collectUrls,
   conforms,
   linkUrls,
   referenceMdast,
@@ -102,42 +103,55 @@ const PROBE_INPUTS: Array<[string, PathKind[]]> = [
   ["x\u{85}www.x.y", []],
 ];
 
-// The three triggers have disagreeing preceding-character rules, and what the
+// The triggers have disagreeing preceding-character rules, and what the
 // construct path blocks falls through to find-and-replace, which wants
-// whitespace or punctuation.
-const TRIGGERS = ["www.x.y", "http://x.y", "a@b.cd"] as const;
+// whitespace or punctuation. The fourth is a `www.` literal and an email at
+// the same offset, so it also pins which construct is tried first.
+const TRIGGERS = ["www.x.y", "http://x.y", "a@b.cd", "www.x@y.zz"] as const;
 const PRECEDING_RULES: Array<{
   prefix: string;
   name: string;
-  paths: [PathKind, PathKind, PathKind];
+  paths: [PathKind, PathKind, PathKind, PathKind];
 }> = [
-  { prefix: "", name: "start of document", paths: ["construct", "construct", "construct"] },
-  { prefix: " ", name: "space", paths: ["construct", "construct", "construct"] },
-  { prefix: "(", name: "`(`", paths: ["construct", "construct", "construct"] },
-  { prefix: "*", name: "`*`", paths: ["construct", "construct", "construct"] },
-  { prefix: "_", name: "`_`", paths: ["construct", "construct", "construct"] },
-  { prefix: "]", name: "`]`", paths: ["construct", "construct", "construct"] },
-  { prefix: "~", name: "`~`", paths: ["construct", "construct", "construct"] },
-  { prefix: "[", name: "`[`", paths: ["fnr", "fnr", "fnr"] },
-  { prefix: ".", name: "`.`", paths: ["fnr", "construct", "construct"] },
-  { prefix: "/", name: "`/`", paths: ["fnr", "construct", "none"] },
-  { prefix: "+", name: "`+`", paths: ["fnr", "construct", "construct"] },
-  { prefix: ")", name: "`)`", paths: ["fnr", "construct", "construct"] },
-  { prefix: "!", name: "`!`", paths: ["fnr", "construct", "construct"] },
-  { prefix: ":", name: "`:`", paths: ["fnr", "construct", "construct"] },
-  { prefix: "¥", name: "BMP symbol", paths: ["fnr", "construct", "construct"] },
-  { prefix: "→", name: "BMP math symbol", paths: ["fnr", "construct", "construct"] },
-  { prefix: "a", name: "ASCII letter", paths: ["none", "none", "construct"] },
-  { prefix: "5", name: "ASCII digit", paths: ["none", "construct", "construct"] },
-  { prefix: "é", name: "BMP letter", paths: ["none", "construct", "construct"] },
-  { prefix: "你", name: "CJK letter", paths: ["none", "construct", "construct"] },
-  { prefix: "你好", name: "two CJK letters", paths: ["none", "construct", "construct"] },
-  { prefix: "​", name: "zero-width space (Cf)", paths: ["none", "construct", "construct"] },
+  {
+    prefix: "",
+    name: "start of document",
+    paths: ["construct", "construct", "construct", "construct"],
+  },
+  { prefix: " ", name: "space", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "(", name: "`(`", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "*", name: "`*`", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "_", name: "`_`", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "]", name: "`]`", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "~", name: "`~`", paths: ["construct", "construct", "construct", "construct"] },
+  { prefix: "[", name: "`[`", paths: ["fnr", "fnr", "fnr", "fnr"] },
+  { prefix: ".", name: "`.`", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: "/", name: "`/`", paths: ["fnr", "construct", "none", "fnr"] },
+  { prefix: "+", name: "`+`", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: ")", name: "`)`", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: "!", name: "`!`", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: ":", name: "`:`", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: "¥", name: "BMP symbol", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: "→", name: "BMP math symbol", paths: ["fnr", "construct", "construct", "construct"] },
+  { prefix: "a", name: "ASCII letter", paths: ["none", "none", "construct", "construct"] },
+  { prefix: "5", name: "ASCII digit", paths: ["none", "construct", "construct", "construct"] },
+  { prefix: "é", name: "BMP letter", paths: ["none", "construct", "construct", "construct"] },
+  { prefix: "你", name: "CJK letter", paths: ["none", "construct", "construct", "construct"] },
+  {
+    prefix: "你好",
+    name: "two CJK letters",
+    paths: ["none", "construct", "construct", "construct"],
+  },
+  {
+    prefix: "​",
+    name: "zero-width space (Cf)",
+    paths: ["none", "construct", "construct", "construct"],
+  },
   // U+FEFF is not `White_Space`, yet find-and-replace takes it as a boundary.
   // Prefixed with a letter to keep leading-BOM handling out of it.
-  { prefix: "a﻿", name: "byte order mark", paths: ["fnr", "construct", "construct"] },
+  { prefix: "a﻿", name: "byte order mark", paths: ["fnr", "construct", "construct", "construct"] },
   // U+0085 is `White_Space`, but find-and-replace does not take it as a boundary.
-  { prefix: "\u{85}", name: "next line", paths: ["none", "construct", "construct"] },
+  { prefix: "\u{85}", name: "next line", paths: ["none", "construct", "construct", "construct"] },
 ];
 
 describe("GFM autolink preceding-character rules", () => {
@@ -164,11 +178,27 @@ describe("divergence: astral characters before a GFM autolink", () => {
   // `Nd`, so both sides reject it — for different reasons, which is the point.
   const REJECTED = [{ prefix: "\u{1FBF0}", name: "U+1FBF0 SEGMENTED DIGIT ZERO (Nd)" }];
 
+  // The overlapping trigger is left out: remark's find-and-replace finds the
+  // email inside it whatever precedes the `www.`, so it is pinned below.
+  const BLOCKED = TRIGGERS.filter((trigger) => trigger !== "www.x@y.zz");
+
   test.each([...ACCEPTED, ...REJECTED])("$name starts nothing in remark", ({ prefix }) => {
     expect(referencePaths(`${prefix}www.x.y`)).toEqual([]);
-    for (const trigger of TRIGGERS) {
+    for (const trigger of BLOCKED) {
       expect(referencePaths(`[${prefix}${trigger}`)).toEqual([]);
     }
+  });
+
+  test.each(ACCEPTED)("$name: the www half of an overlap still wins", ({ prefix }) => {
+    const md = `[${prefix}www.x@y.zz`;
+    expect(linkUrls(md)).toEqual(["http://www.x@y.zz"]);
+    expect(collectUrls(referenceMdast(md))).toEqual(["mailto:x@y.zz"]);
+  });
+
+  test.each(REJECTED)("$name: the email inside the overlap wins on both sides", ({ prefix }) => {
+    const md = `[${prefix}www.x@y.zz`;
+    expect(linkUrls(md)).toEqual(["mailto:x@y.zz"]);
+    expect(collectUrls(referenceMdast(md))).toEqual(["mailto:x@y.zz"]);
   });
 
   // The span has to stop at the trigger, not swallow the character before it.

--- a/packages/satteri/test/conformance/directive.test.ts
+++ b/packages/satteri/test/conformance/directive.test.ts
@@ -201,6 +201,12 @@ describe("Directive MDAST conformance", () => {
       );
     });
 
+    test("a reference label ending inside a directive's attributes", () => {
+      // The label scan walks raw source, so it can stop on a `]` the directive
+      // holds; the bytes past that `]` are literal text.
+      assertExtMdastConformance('[a][:x{k="]"}]\n\n[:x{k="]: /u\n', DIR);
+    });
+
     test("directive attached to preceding word with no space", () => {
       // Regression: prose like `is:inline` (an Astro attribute name written
       // bare, not in backticks) parses as text + textDirective `:inline`.

--- a/packages/satteri/test/conformance/link-edge-cases.test.ts
+++ b/packages/satteri/test/conformance/link-edge-cases.test.ts
@@ -530,8 +530,9 @@ describe("MDAST conformance: unicode whitespace ends a GFM autolink literal", ()
     }
   });
 
-  test.fails("a U+FEFF ending the URL is dropped from the text after it", () => {
-    // The link's extent is right; the drop is general, not autolink-specific.
+  test("a U+FEFF ending the URL stays in the text after it", () => {
     assertMdastConformance("www.example.com/a\u{feff}b\n");
+    assertMdastConformance("https://example.com\u{feff}\n");
+    assertMdastConformance("user@example.com\u{feff}x\n");
   });
 });

--- a/packages/satteri/test/conformance/link-edge-cases.test.ts
+++ b/packages/satteri/test/conformance/link-edge-cases.test.ts
@@ -435,17 +435,37 @@ describe("MDAST conformance: deferred GFM autolink splice", () => {
     assertMdastConformance("[a http://x.y\\&amp;");
   });
 
-  // Only `<` is repaired: the other constructs leave nothing for the splice to
-  // re-open, so fixing them means deferring the escape itself.
-  test.fails("emphasis after a URL-ending backslash is swallowed", () => {
-    // Wanted: text(`<`) + emphasis(link + `_`) + text(`~\t>`); the closing `_`
-    // never becomes a delimiter.
+  test("emphasis closes after a URL-ending backslash", () => {
+    // text(`<`) + emphasis(link) + text(`~\t>`): the `_` the escape hid closes
+    // the run opened before the URL, so the link is the emphasis's only child.
     assertMdastConformance("<_HTTPS://a.b:-&;\\_~\t>");
+    assertMdastConformance("[a] *www.a.b\\* x");
+    assertMdastConformance("[a] _www.a.b\\_ x");
+    assertMdastConformance("[a] **www.a.b\\** x");
+    assertMdastConformance("[a] ~~www.a.b\\~~ x");
+    assertMdastConformance("[a] ~www.a.b\\~ x");
+    assertMdastConformance("`x` *www.a.b\\* x");
+    assertMdastConformance("<b> *www.a.b\\* x");
+    // Blocked instead of fired: the escape stands, so the delimiter it hid is
+    // literal and the run after it is one shorter.
+    assertMdastConformance("[a *www.a.b\\* x");
+    assertMdastConformance("[a ~~www.a.b\\~~ x");
   });
 
-  test.fails("a character reference after a URL-ending backslash is swallowed", () => {
-    // Wanted: link(`www.a.b\`) + text(`&`); the `&amp;` stays literal.
+  test("a character reference after a URL-ending backslash still decodes", () => {
+    // The link owns the `\`, so the reference the escape swallowed is split
+    // back out and decodes: link(`www.a.b\`) + text(`&`).
     assertMdastConformance("[a] www.a.b\\&amp;");
+    assertMdastConformance("[a] www.a.b\\&nbsp;");
+    assertMdastConformance("[a] http://x.y\\&amp;");
+    assertMdastConformance("`x` www.a.b\\&amp;");
+    // Only the reference the escape swallowed is at stake; a second one
+    // after it was never in doubt.
+    assertMdastConformance("[a] www.a.b\\&amp;&amp;");
+    // Not a reference, so the escape stands and the `&` stays literal.
+    assertMdastConformance("[a] www.a.b\\&notanentity;");
+    // Blocked instead of fired: the escape stands and nothing is split out.
+    assertMdastConformance("[a http://x.y\\&amp;");
   });
 
   test("an escaped `<` outside any autolink is unaffected", () => {

--- a/packages/satteri/test/conformance/mdast.test.ts
+++ b/packages/satteri/test/conformance/mdast.test.ts
@@ -841,9 +841,14 @@ describe("MDAST conformance: control and format characters at a text-node edge",
     assertMdastConformance("    code\u{b}\n");
   });
 
-  test.fails("a BOM opening a text node is kept", () => {
+  test("a BOM opening a text node is kept", () => {
     assertMdastConformance("*a*\u{feff}x\n");
     assertMdastConformance("user@example.com\u{feff}\n");
+    // The drop was general to any value starting on one, not inline-only.
+    assertMdastConformance("x\n\n\u{feff}y\n");
+    assertMdastConformance("# \u{feff}h\n");
+    assertMdastConformance("[a](b)\u{feff}y\n");
+    assertMdastConformance("`\u{feff}x`\n");
   });
 
   test("a line of only VT or FF is a paragraph, not a blank line", () => {

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -431,18 +431,77 @@ describe("MDX expression holding the `]` that ends a reference label", () => {
   });
 });
 
-// Found by `fuzz/mdx.test.ts` at seed 3; pre-existing, unrelated to the
-// reference-label case above. A `//` line comment inside an expression is
-// terminated by a lone CR in micromark, so the `}` after it still closes the
-// expression. Sätteri's scanner runs the comment on to end of input and
-// rejects the document. `\n` and `\r\n` are both fine.
-describe("MDX expression comment ended by a lone CR", () => {
-  test.fails("the `}` after the comment still closes the expression", () => {
-    assertMdastConformance("a{//\r}");
+// Found by `fuzz/mdx.test.ts` at seed 3. A `//` line comment ends at any line
+// ending, so every case below has to behave the same for `\n`, `\r\n` and a
+// lone `\r`.
+describe.each([
+  ["LF", "\n"],
+  ["CRLF", "\r\n"],
+  ["CR", "\r"],
+])("MDX expression comment ended by %s", (_name, eol) => {
+  test("the `}` after the comment still closes the expression", () => {
+    assertMdastConformance(`a{//${eol}}`);
+    assertMdastConformance(`a{//${eol}} b`);
   });
 
-  test("control: the same shape with LF", () => {
-    assertMdastConformance("a{//\n}");
-    assertMdastConformance("a{//\r\n}");
+  test("comment mid-expression", () => {
+    assertMdastConformance(`a{1 + // c${eol}2}`);
+    assertMdastConformance(`a{[1, //${eol}2]}`);
+    assertMdastConformance(`a{{x:1} //${eol}}`);
+  });
+
+  test("the comment body is not re-lexed", () => {
+    assertMdastConformance(`a{// }${eol}1}`);
+    assertMdastConformance(`a{// don't${eol}1}`);
+    assertMdastConformance(`a{// \`x${eol}1}`);
+    assertMdastConformance(`a{// /*${eol}1}`);
+    assertMdastConformance(`a{// /x/${eol}1}`);
+  });
+
+  test("comment-only body", () => {
+    assertMdastConformance(`{//${eol}}${eol}`);
+    assertMdastConformance(`{//a${eol}//b${eol}}`);
+  });
+
+  test("in JSX attributes and children", () => {
+    assertMdastConformance(`<Foo bar={//${eol}1}/>${eol}`);
+    assertMdastConformance(`<Box>{//${eol}1}</Box>${eol}`);
+  });
+
+  test("after a value that could swallow the line", () => {
+    assertMdastConformance(`a{\`t\` //${eol}}`);
+  });
+
+  // Block comments legitimately span line endings, so the same shapes must
+  // still run past one rather than stopping with the line.
+  test("block comments still span the line ending", () => {
+    assertMdastConformance(`a{/*${eol}*/}`);
+    assertMdastConformance(`a{/* x${eol}y${eol} */ 1}`);
+    assertMdastConformance(`<Foo bar={/* x${eol}*/ 1}/>${eol}`);
+  });
+
+  test("a comment in an ESM block ends with the line", () => {
+    assertMdastConformance(`import a from "b" //${eol}${eol}x${eol}`);
+    assertMdastConformance(`export const a = 1 // c${eol}${eol}x${eol}`);
+    assertMdastConformance(`import a from "b" //x${eol}import c from "d"${eol}${eol}y${eol}`);
+    assertMdastConformance(`export const a = 1 /* c${eol}*/${eol}${eol}x${eol}`);
+  });
+});
+
+// Pre-existing and unrelated to line endings — both reproduce identically for
+// `\n`, `\r\n` and `\r`. `export` followed by a line ending opens an ESM block
+// in Sätteri but not in micromark, and a block comment spanning the blank line
+// that should end the block is accepted rather than cut short.
+describe.each([
+  ["LF", "\n"],
+  ["CRLF", "\r\n"],
+  ["CR", "\r"],
+])("MDX ESM block opener divergences (%s)", (_name, eol) => {
+  test.fails("`export` followed by a line ending is not an ESM block", () => {
+    assertMdastConformance(`export${eol}const a = 1${eol}${eol}x${eol}`);
+  });
+
+  test.fails("a block comment does not span the blank line ending the block", () => {
+    assertMdastConformance(`export const a = 1 /*${eol}${eol}*/${eol}z${eol}`);
   });
 });

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -392,3 +392,41 @@ describe("MDX nested deep-indent lists", () => {
     assertMdastConformance("7. outer\n\n          - a\n          - b\n          - c\n");
   });
 });
+
+// A reference label is scanned over raw source, so it can stop on a `]` that
+// sits inside an expression — the expression loses to the label, and the bytes
+// past the label's `]` are literal text. remark resolves them the same way;
+// they used to belong to no node at all here and vanished from the output.
+describe("MDX expression holding the `]` that ends a reference label", () => {
+  test("full reference", () => {
+    assertMdastConformance('[a][{"]"}]\n\n[{"]: /u\n');
+  });
+
+  test("image reference", () => {
+    assertMdastConformance('![a][{"]"}]\n\n[{"]: /u\n');
+  });
+
+  test("the expression's own quoting does not matter", () => {
+    assertMdastConformance("[a][{`]`}]\n\n[{`]: /u\n");
+    assertMdastConformance('[a][{"]" + "]"}]\n\n[{"]: /u\n');
+  });
+
+  test("with content around it", () => {
+    assertMdastConformance('x [a][{"]"}] y\n\n[{"]: /u\n');
+    assertMdastConformance('[a][{"]"}][b]\n\n[{"]: /u\n\n[b]: /v\n');
+    assertMdastConformance('[a][{"]"}]\n\n[{"]: /u "t"\n');
+  });
+
+  test("in every container", () => {
+    assertMdastConformance('> [a][{"]"}]\n\n[{"]: /u\n');
+    assertMdastConformance('- [a][{"]"}]\n\n[{"]: /u\n');
+    assertMdastConformance('# [a][{"]"}]\n\n[{"]: /u\n');
+  });
+
+  // Controls: the expression survives whole when no label ends inside it.
+  test("an expression the label does not cut keeps its node", () => {
+    assertMdastConformance('[{"]"}][a]\n\n[a]: /u\n');
+    assertMdastConformance('[a][{"x"}]\n\n[{"x"}]: /u\n');
+    assertMdastConformance('x {"]"} y\n');
+  });
+});

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -430,3 +430,19 @@ describe("MDX expression holding the `]` that ends a reference label", () => {
     assertMdastConformance('x {"]"} y\n');
   });
 });
+
+// Found by `fuzz/mdx.test.ts` at seed 3; pre-existing, unrelated to the
+// reference-label case above. A `//` line comment inside an expression is
+// terminated by a lone CR in micromark, so the `}` after it still closes the
+// expression. Sätteri's scanner runs the comment on to end of input and
+// rejects the document. `\n` and `\r\n` are both fine.
+describe("MDX expression comment ended by a lone CR", () => {
+  test.fails("the `}` after the comment still closes the expression", () => {
+    assertMdastConformance("a{//\r}");
+  });
+
+  test("control: the same shape with LF", () => {
+    assertMdastConformance("a{//\n}");
+    assertMdastConformance("a{//\r\n}");
+  });
+});

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -429,6 +429,37 @@ describe("MDX expression holding the `]` that ends a reference label", () => {
     assertMdastConformance('[a][{"x"}]\n\n[{"x"}]: /u\n');
     assertMdastConformance('x {"]"} y\n');
   });
+
+  // The tree comparison above drops positions, so the span is pinned here.
+  test("the tail spans exactly the bytes past the label", () => {
+    const md = '[a][{"]"}]\n\n[{"]: /u\n';
+    const tree = mdxToMdast(md) as { children: Array<{ children: AnyNode[] }> };
+    expect(tree.children[0].children[1]).toEqual({
+      type: "text",
+      value: '"}]',
+      position: {
+        start: { line: 1, column: 8, offset: 7 },
+        end: { line: 1, column: 11, offset: 10 },
+      },
+    });
+  });
+
+  // The tail is emitted as literal text, so inline markup inside it is never
+  // tokenized. Pre-fix those bytes were dropped outright, so this is the
+  // remaining half of the class rather than a regression.
+  describe("divergence: markup in the tail stays literal", () => {
+    test.fails("emphasis", () => {
+      assertMdastConformance('[a][{"]*x*"}]\n\n[{"]: /u\n');
+    });
+
+    test.fails("inline code", () => {
+      assertMdastConformance('[a][{"]`c`"}]\n\n[{"]: /u\n');
+    });
+
+    test.fails("character reference", () => {
+      assertMdastConformance('[a][{"]&amp;"}]\n\n[{"]: /u\n');
+    });
+  });
 });
 
 // Found by `fuzz/mdx.test.ts` at seed 3. A `//` line comment ends at any line

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -536,3 +536,20 @@ describe.each([
     assertMdastConformance(`export const a = 1 /*${eol}${eol}*/${eol}z${eol}`);
   });
 });
+
+// A `\` before a line ending is one JS line continuation, so the string runs on
+// to the next line. CRLF is one ending, and eating only half of it used to end
+// the string on the orphan `\n` and run the expression to end of input.
+describe.each([
+  ["LF", "\n"],
+  ["CRLF", "\r\n"],
+  ["CR", "\r"],
+])("MDX expression string continued over a line ending (%s)", (_name, eol) => {
+  test("a double-quoted string keeps going", () => {
+    assertMdastConformance(`a{"x\\${eol}y"}${eol}`);
+  });
+
+  test("a single-quoted string keeps going", () => {
+    assertMdastConformance(`a{'x\\${eol}y'}${eol}`);
+  });
+});

--- a/packages/satteri/test/conformance/mdx-ast.test.ts
+++ b/packages/satteri/test/conformance/mdx-ast.test.ts
@@ -433,14 +433,27 @@ describe("MDX expression holding the `]` that ends a reference label", () => {
   // The tree comparison above drops positions, so the span is pinned here.
   test("the tail spans exactly the bytes past the label", () => {
     const md = '[a][{"]"}]\n\n[{"]: /u\n';
-    const tree = mdxToMdast(md) as { children: Array<{ children: AnyNode[] }> };
-    expect(tree.children[0].children[1]).toEqual({
+    const tree = mdxToMdast(md) as unknown as { children: Array<{ children: AnyNode[] }> };
+    expect(tree.children[0]?.children[1]).toEqual({
       type: "text",
       value: '"}]',
       position: {
         start: { line: 1, column: 8, offset: 7 },
         end: { line: 1, column: 11, offset: 10 },
       },
+    });
+  });
+
+  // Pre-existing: the expression is handed to oxc before reference resolution
+  // takes its `]`, so a diagnostic outlives the node it was about. The tree the
+  // arena builds is correct; only the error is spurious.
+  describe("divergence: an expression the label cuts still reports its error", () => {
+    test.fails("an expression that does not parse on its own", () => {
+      assertMdastConformance("[a][{x]}]\n\n[{x]: /u\n");
+    });
+
+    test.fails("a nested expression the label cuts", () => {
+      assertMdastConformance('[a][{f({"]"})}]\n\n[{f({"]: /u\n');
     });
   });
 

--- a/website/content/docs/divergences.md
+++ b/website/content/docs/divergences.md
@@ -53,7 +53,7 @@ This only affects astral punctuation and symbols — `𐄁` (U+10101), `😀` (U
 | `remark-parse` + `remark-gfm` | link with no `position`                         |
 | Sätteri                       | link with `position` spanning `www.example.com` |
 
-URLs are unchanged: `[www.example.com/&amp;b` links to `http://www.example.com/&b` on both sides, and the position covers the raw `&amp;`. When a match starts or ends inside a character reference that decodes to more than one character, no exact span exists, and Sätteri reports no position rather than an approximate one.
+URLs are unchanged: `[www.example.com/&amp;b` links to `http://www.example.com/&b` on both sides, and the position covers the raw `&amp;`. Smart punctuation works the same way: the span covers the raw `--`, `...` or `"` run the value was rendered from. When a match starts or ends inside a character reference that decodes to more than one character, no exact span exists, and Sätteri reports no position rather than an approximate one.
 
 ### Paragraph start in a task list item
 

--- a/website/content/docs/divergences.md
+++ b/website/content/docs/divergences.md
@@ -53,7 +53,7 @@ This only affects astral punctuation and symbols — `𐄁` (U+10101), `😀` (U
 | `remark-parse` + `remark-gfm` | link with no `position`                         |
 | Sätteri                       | link with `position` spanning `www.example.com` |
 
-URLs are unchanged: `[www.example.com/&amp;b` links to `http://www.example.com/&b` on both sides, and the position covers the raw `&amp;`. Smart punctuation works the same way: the span covers the raw `--`, `...` or `"` run the value was rendered from. When a match starts or ends inside a character reference that decodes to more than one character, no exact span exists, and Sätteri reports no position rather than an approximate one.
+URLs are unchanged: `[www.example.com/&amp;b` links to `http://www.example.com/&b` on both sides, and the position covers the raw `&amp;`. Smart punctuation works the same way: the span covers the raw `--`, `...` or `"` run the value was rendered from — though under `smartPunctuation` such a link's URL carries the rewritten character, so `[www.example.com/x--` links to `http://www.example.com/x–` where the tokenized `www.example.com/x--` keeps the raw `--`. When a match starts or ends inside a character reference that decodes to more than one character, no exact span exists, and Sätteri reports no position rather than an approximate one.
 
 ### Paragraph start in a task list item
 


### PR DESCRIPTION
Fixes the escape-swallowed constructs, the email/www construct ordering, a dropped byte order mark, find-and-replace positions under smart punctuation, text dropped when an MDX expression holds a reference label's `]`, and MDX line comments, ESM blocks and expression strings that run past a carriage return.

The fuzz suites never enable `smartPunctuation`, so the alignment the position fix adds has no in-tree fuzz coverage: it is guarded by the hand-written cases and an unconditional assert. One million generated inputs were parsed with it on locally against a debug build, with no failure.