### PR TITLE
chore(rust): migrate the workspace to the 2024 edition

### DIFF
--- a/.sampo/changesets/rust-2024-edition.md
+++ b/.sampo/changesets/rust-2024-edition.md
@@ -1,0 +1,9 @@
+---
+cargo/satteri-arena: patch
+cargo/satteri-ast: patch
+cargo/satteri-plugin-api: patch
+cargo/satteri-property-info: patch
+cargo/satteri-pulldown-cmark: patch
+---
+
+Changed the minimum supported Rust version to 1.85, as these crates now build on the 2024 edition.

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-bench"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Benchmarks and profiling harnesses for Sätteri"
 license = "MIT"

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,6 +1,6 @@
 use satteri_arena::{Arena, ArenaBuilder, Hast, StringRef};
-use satteri_ast::hast::codec::encode_element_data;
 use satteri_ast::hast::HastNodeType;
+use satteri_ast::hast::codec::encode_element_data;
 use satteri_ast::patch::{Patch, PatchContent};
 
 /// One keep-children `<span class="link">` Replace per `<a>` element (the link-transform shape).

--- a/crates/satteri-arena/Cargo.toml
+++ b/crates/satteri-arena/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-arena"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 description = "Arena allocator and binary buffer primitives for Sätteri"
 license = "MIT"
 

--- a/crates/satteri-arena/src/lib.rs
+++ b/crates/satteri-arena/src/lib.rs
@@ -20,5 +20,5 @@ pub use arena::{Arena, TypeDataWriter};
 pub use builder::ArenaBuilder;
 pub use codec::{decode_string_ref_data, encode_string_ref_data};
 pub use kind::{ArenaKind, Hast, Mdast};
-pub use line_index::{line_ending_iter, LineIndex, LineIndexCursor};
-pub use node::{ArenaNode, StringRef, NODE_STRUCT_SIZE};
+pub use line_index::{LineIndex, LineIndexCursor, line_ending_iter};
+pub use node::{ArenaNode, NODE_STRUCT_SIZE, StringRef};

--- a/crates/satteri-arena/src/mdx_types.rs
+++ b/crates/satteri-arena/src/mdx_types.rs
@@ -137,22 +137,22 @@ impl Location {
 
     #[must_use]
     pub fn to_point(&self, offset: usize) -> Option<Point> {
-        if let Some(end) = self.indices.last() {
-            if offset < *end {
-                let mut index = 0;
-                while index < self.indices.len() {
-                    if self.indices[index] > offset {
-                        break;
-                    }
-                    index += 1;
+        if let Some(end) = self.indices.last()
+            && offset < *end
+        {
+            let mut index = 0;
+            while index < self.indices.len() {
+                if self.indices[index] > offset {
+                    break;
                 }
-                let previous = if index > 0 {
-                    self.indices[index - 1]
-                } else {
-                    0
-                };
-                return Some(Point::new(index + 1, offset + 1 - previous, offset));
+                index += 1;
             }
+            let previous = if index > 0 {
+                self.indices[index - 1]
+            } else {
+                0
+            };
+            return Some(Point::new(index + 1, offset + 1 - previous, offset));
         }
         None
     }

--- a/crates/satteri-ast/Cargo.toml
+++ b/crates/satteri-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-ast"
 version = "0.4.2"
-edition = "2021"
+edition = "2024"
 description = "MDAST and HAST node types, codecs, tree operations, and conversion for Sätteri"
 license = "MIT"
 

--- a/crates/satteri-ast/src/convert.rs
+++ b/crates/satteri-ast/src/convert.rs
@@ -1,16 +1,16 @@
 //! Convert an MDAST arena to a HAST arena.
 
 use rustc_hash::FxHashMap;
-use satteri_arena::{decode_string_ref_data, Arena, ArenaBuilder, Hast, Mdast, StringRef};
+use satteri_arena::{Arena, ArenaBuilder, Hast, Mdast, StringRef, decode_string_ref_data};
 
-use crate::hast::codec::encode_element_data_into;
 use crate::hast::HastNodeType;
+use crate::hast::codec::encode_element_data_into;
 use crate::mdast::{
-    decode_code_data, decode_custom_data, decode_definition_data, decode_description_details_data,
-    decode_footnote_definition_data, decode_heading_data, decode_image_data,
-    decode_image_reference_alt, decode_link_data, decode_list_data, decode_list_item_data,
-    decode_math_data, decode_reference_data, decode_table_alignments, ColumnAlign, ListItemData,
-    MdastNodeType,
+    ColumnAlign, ListItemData, MdastNodeType, decode_code_data, decode_custom_data,
+    decode_definition_data, decode_description_details_data, decode_footnote_definition_data,
+    decode_heading_data, decode_image_data, decode_image_reference_alt, decode_link_data,
+    decode_list_data, decode_list_item_data, decode_math_data, decode_reference_data,
+    decode_table_alignments,
 };
 #[cfg(feature = "mdx")]
 use crate::mdast::{
@@ -2469,7 +2469,7 @@ mod hast_convert_tests {
         arena.set_node_data(node_id, json.as_bytes().to_vec());
     }
 
-    use crate::hast::{hast_arena_to_html, HastNodeType};
+    use crate::hast::{HastNodeType, hast_arena_to_html};
 
     fn parse_md(source: &str) -> Arena<Mdast> {
         let (arena, _) =

--- a/crates/satteri-ast/src/convert.rs
+++ b/crates/satteri-ast/src/convert.rs
@@ -2382,12 +2382,12 @@ fn convert_mdx_jsx_element(
     builder.set_data_current(&encoded);
     // Propagate `node_data` (e.g. `_mdxExplicitJsx` for source-parsed nodes,
     // or any other plugin-attached metadata) from mdast to hast.
-    if let Some(mdast_nd) = view.get_node_data(node_id) {
-        if !mdast_nd.is_empty() {
-            let id = builder.current_node_id();
-            let copy = mdast_nd.to_vec();
-            builder.arena_mut().set_node_data(id, copy);
-        }
+    if let Some(mdast_nd) = view.get_node_data(node_id)
+        && !mdast_nd.is_empty()
+    {
+        let id = builder.current_node_id();
+        let copy = mdast_nd.to_vec();
+        builder.arena_mut().set_node_data(id, copy);
     }
     copy_position(node_id, view, builder);
 

--- a/crates/satteri-ast/src/convert.rs
+++ b/crates/satteri-ast/src/convert.rs
@@ -2088,7 +2088,7 @@ fn emit_gfm_footnotes_section(
             .iter()
             .enumerate()
             .rev()
-            .find(|(_, &cid)| view.get_node(cid).node_type == MdastNodeType::Paragraph as u8)
+            .find(|&(_, &cid)| view.get_node(cid).node_type == MdastNodeType::Paragraph as u8)
             .map(|(i, _)| i);
 
         let total_refs = ctx

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -117,7 +117,7 @@ impl StitchRecognizer {
         claimed
             .iter()
             .enumerate()
-            .filter(|(_, &was_claimed)| !was_claimed)
+            .filter(|&(_, &was_claimed)| !was_claimed)
             .map(|(index, _)| format!("{}{}", self.prefix, index))
             .collect()
     }

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -238,12 +238,11 @@ impl TreeSink for HtmlSink {
     fn append(&self, parent: &usize, child: NodeOrText<usize>) {
         let mut nodes = self.nodes.borrow_mut();
         let parent = *parent;
-        if let NodeOrText::AppendText(text) = &child {
-            if let Some(&last) = nodes[parent].children.last() {
-                if push_text(&mut nodes, last, text) {
-                    return;
-                }
-            }
+        if let NodeOrText::AppendText(text) = &child
+            && let Some(&last) = nodes[parent].children.last()
+            && push_text(&mut nodes, last, text)
+        {
+            return;
         }
         let child = match child {
             NodeOrText::AppendText(text) => new_node(&mut nodes, NodeData::Text { contents: text }),

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -10,18 +10,18 @@ use std::cell::{Cell, Ref, RefCell};
 use html5ever::interface::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::tendril::{StrTendril, TendrilSink};
 use html5ever::{
-    parse_document, parse_fragment, tree_builder::TreeBuilderOpts, Attribute, LocalName, Namespace,
-    ParseOpts, QualName,
+    Attribute, LocalName, Namespace, ParseOpts, QualName, parse_document, parse_fragment,
+    tree_builder::TreeBuilderOpts,
 };
 use satteri_arena::{Arena, ArenaBuilder, Hast, StringRef};
-use satteri_property_info::{find_property, PropKind};
+use satteri_property_info::{PropKind, find_property};
 
+use crate::hast::HastNodeType;
 use crate::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
     encode_element_data,
 };
 use crate::hast::render::{is_void_element, render_node_inner};
-use crate::hast::HastNodeType;
 #[cfg(feature = "mdx")]
 use crate::mdast::codec::{
     decode_mdx_jsx_attr, decode_mdx_jsx_attr_count, decode_mdx_jsx_element_name,

--- a/crates/satteri-ast/src/hast/mod.rs
+++ b/crates/satteri-ast/src/hast/mod.rs
@@ -9,8 +9,8 @@ pub mod properties;
 pub mod render;
 
 pub use crate::convert::{
-    mdast_arena_to_hast_arena, mdast_arena_to_hast_arena_into,
-    mdast_arena_to_hast_arena_with_options, Backref, ConvertOptions,
+    Backref, ConvertOptions, mdast_arena_to_hast_arena, mdast_arena_to_hast_arena_into,
+    mdast_arena_to_hast_arena_with_options,
 };
 #[cfg(feature = "from-html")]
 pub use from_html::{html_fragment_to_wrap_arena, html_to_hast_arena, raw_to_hast_arena};

--- a/crates/satteri-ast/src/hast/render.rs
+++ b/crates/satteri-ast/src/hast/render.rs
@@ -2,11 +2,11 @@
 
 use satteri_arena::{Arena, Hast};
 
+use crate::hast::HastNodeType;
 use crate::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
 };
 use crate::hast::properties::property_to_attribute;
-use crate::hast::HastNodeType;
 use crate::shared::{
     PROP_BOOL_FALSE, PROP_BOOL_TRUE, PROP_COMMA_SEP, PROP_COMMA_SEP_NUM, PROP_INT, PROP_SPACE_SEP,
     PROP_STRING,

--- a/crates/satteri-ast/src/patch.rs
+++ b/crates/satteri-ast/src/patch.rs
@@ -1518,11 +1518,7 @@ mod tests {
                 .map(|&c| walk(arena, c))
                 .sum::<usize>()
         }
-        if arena.is_empty() {
-            0
-        } else {
-            walk(arena, 0)
-        }
+        if arena.is_empty() { 0 } else { walk(arena, 0) }
     }
 
     /// Build the "# Hello\n\nWorld" arena for testing.

--- a/crates/satteri-ast/src/patch.rs
+++ b/crates/satteri-ast/src/patch.rs
@@ -933,10 +933,8 @@ fn apply_patches_impl<K: ArenaKind>(
     }
     // Strict callers reject stranded patches here, before the first arena
     // mutation, so the arena survives the error untouched.
-    if strict {
-        if let Some(&anchor) = dropped_set.iter().min() {
-            return Err(CommandError::PatchOnRemovedSubtree(anchor));
-        }
+    if strict && let Some(&anchor) = dropped_set.iter().min() {
+        return Err(CommandError::PatchOnRemovedSubtree(anchor));
     }
 
     // Referring anchors wait for the target's patches and patches inside it.

--- a/crates/satteri-ast/tests/arena_reuse.rs
+++ b/crates/satteri-ast/tests/arena_reuse.rs
@@ -2,13 +2,12 @@
 
 use satteri_arena::{Arena, ArenaKind, Hast};
 use satteri_ast::hast::{
-    hast_arena_to_html, mdast_arena_to_hast_arena_into, mdast_arena_to_hast_arena_with_options,
-    ConvertOptions,
+    ConvertOptions, hast_arena_to_html, mdast_arena_to_hast_arena_into,
+    mdast_arena_to_hast_arena_with_options,
 };
 use satteri_pulldown_cmark::Options;
 
-const DOC: &str =
-    "# Héllo wörld\n\nSome *ünïcode…* text with [a link](https://example.com) and `code`.\n\n- one\n- twö\n\n| a | b |\n|---|---|\n| 1 | 2 |\n";
+const DOC: &str = "# Héllo wörld\n\nSome *ünïcode…* text with [a link](https://example.com) and `code`.\n\n- one\n- twö\n\n| a | b |\n|---|---|\n| 1 | 2 |\n";
 
 fn dirty_arena<K: ArenaKind>() -> Arena<K> {
     let mut arena = Arena::<K>::new("stale source from a previous document".to_string());

--- a/crates/satteri-ast/tests/convert_positions.rs
+++ b/crates/satteri-ast/tests/convert_positions.rs
@@ -4,14 +4,15 @@
 //! (or, for synthesized leaves like the checkbox `<input>`, the parent
 //! MDAST node's position).
 
-use satteri_arena::{decode_string_ref_data, Arena, ArenaBuilder, Hast, Mdast};
+use satteri_arena::{Arena, ArenaBuilder, Hast, Mdast, decode_string_ref_data};
 use satteri_ast::hast::{
+    HastNodeType,
     codec::{decode_element_prop, decode_element_prop_count, decode_element_tag},
-    mdast_arena_to_hast_arena, HastNodeType,
+    mdast_arena_to_hast_arena,
 };
 use satteri_ast::mdast::{
-    codec::{encode_definition_data, encode_reference_data},
     MdastNodeType,
+    codec::{encode_definition_data, encode_reference_data},
 };
 
 fn parse(md: &str) -> Arena<Mdast> {

--- a/crates/satteri-ast/tests/patch.rs
+++ b/crates/satteri-ast/tests/patch.rs
@@ -5,7 +5,7 @@
 use satteri_arena::{Arena, ArenaBuilder, ArenaKind, Hast, Mdast};
 use satteri_ast::hast::HastNodeType;
 use satteri_ast::mdast::MdastNodeType;
-use satteri_ast::patch::{apply_patches_in_place, apply_patches_strict, Patch, PatchContent};
+use satteri_ast::patch::{Patch, PatchContent, apply_patches_in_place, apply_patches_strict};
 
 /// Compare the reachable trees of two arenas: shapes, positions, node_data.
 fn assert_skeleton_eq<K: ArenaKind>(a: &Arena<K>, b: &Arena<K>, ida: u32, idb: u32, path: &str) {
@@ -51,11 +51,7 @@ fn reachable_count<K: ArenaKind>(arena: &Arena<K>) -> usize {
             .map(|&c| walk(arena, c))
             .sum::<usize>()
     }
-    if arena.is_empty() {
-        0
-    } else {
-        walk(arena, 0)
-    }
+    if arena.is_empty() { 0 } else { walk(arena, 0) }
 }
 
 /// Strict entry matching the old `rebuild` contract: dropped patches panic.
@@ -548,7 +544,8 @@ fn list_start_survives_source_base_remap() {
     let ordered = data[4] != 0;
 
     assert_eq!(
-        start, 1,
+        start,
+        1,
         "ordered list start must round-trip as 1, not be polluted by source_base ({} bytes appended)",
         rebuilt.string_pool().len()
     );

--- a/crates/satteri-ast/tests/raw_buffer.rs
+++ b/crates/satteri-ast/tests/raw_buffer.rs
@@ -1,7 +1,7 @@
 //! Integration tests for raw buffer export.
 
 use satteri_arena::{ArenaBuilder, Mdast, NODE_STRUCT_SIZE};
-use satteri_ast::mdast::{encode_heading_data, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, encode_heading_data};
 
 fn build_test_arena() -> satteri_arena::Arena<Mdast> {
     let mut builder = ArenaBuilder::<Mdast>::new("# Hello\n\nParagraph.".to_string());

--- a/crates/satteri-ast/tests/string_refs.rs
+++ b/crates/satteri-ast/tests/string_refs.rs
@@ -1,7 +1,7 @@
 //! Integration tests for StringRef and get_str.
 
 use satteri_arena::{
-    decode_string_ref_data, encode_string_ref_data, Arena, ArenaBuilder, Mdast, StringRef,
+    Arena, ArenaBuilder, Mdast, StringRef, decode_string_ref_data, encode_string_ref_data,
 };
 use satteri_ast::mdast::MdastNodeType;
 

--- a/crates/satteri-ast/tests/type_data.rs
+++ b/crates/satteri-ast/tests/type_data.rs
@@ -2,9 +2,9 @@
 
 use satteri_arena::{ArenaBuilder, Mdast, StringRef};
 use satteri_ast::mdast::{
-    decode_code_data, decode_heading_data, decode_link_data, decode_list_data, encode_code_data,
-    encode_heading_data, encode_link_data, encode_list_data, encode_table_data, ColumnAlign,
-    MdastNodeType,
+    ColumnAlign, MdastNodeType, decode_code_data, decode_heading_data, decode_link_data,
+    decode_list_data, encode_code_data, encode_heading_data, encode_link_data, encode_list_data,
+    encode_table_data,
 };
 
 #[test]

--- a/crates/satteri-napi-binding/Cargo.toml
+++ b/crates/satteri-napi-binding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-napi"
 version = "0.4.7"
-edition = "2021"
+edition = "2024"
 description = "NAPI bindings exposing the Sätteri pipeline to Node.js"
 license = "MIT"
 publish = false

--- a/crates/satteri-napi-binding/src/lib.rs
+++ b/crates/satteri-napi-binding/src/lib.rs
@@ -500,12 +500,10 @@ fn parse_mdast_pooled(
         satteri_pulldown_cmark::parse_no_positions_into(source, opts, reuse)
     };
     #[cfg(feature = "mdx")]
-    if mdx {
-        if let Some((offset, msg)) = mdx_errors.first() {
-            return Err(napi::Error::from_reason(
-                satteri_mdxjs::parse_error_to_message(source, *offset, msg).to_string(),
-            ));
-        }
+    if mdx && let Some((offset, msg)) = mdx_errors.first() {
+        return Err(napi::Error::from_reason(
+            satteri_mdxjs::parse_error_to_message(source, *offset, msg).to_string(),
+        ));
     }
     #[cfg(not(feature = "mdx"))]
     let _ = (mdx, mdx_errors);

--- a/crates/satteri-plugin-api/Cargo.toml
+++ b/crates/satteri-plugin-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-plugin-api"
 version = "0.4.2"
-edition = "2021"
+edition = "2024"
 description = "Rust plugin trait, typed visitors, and runner for Sätteri"
 license = "MIT"
 

--- a/crates/satteri-plugin-api/src/commands.rs
+++ b/crates/satteri-plugin-api/src/commands.rs
@@ -104,7 +104,7 @@ impl NodeBuilder {
     }
 
     pub fn text(value_offset: u32, value_len: u32) -> Self {
-        use satteri_arena::{encode_string_ref_data, StringRef};
+        use satteri_arena::{StringRef, encode_string_ref_data};
         let string_ref = StringRef {
             offset: value_offset,
             len: value_len,

--- a/crates/satteri-plugin-api/src/context.rs
+++ b/crates/satteri-plugin-api/src/context.rs
@@ -46,8 +46,8 @@ impl<'a> PluginContext<'a> {
 
     /// Extract all text content from a subtree (depth-first concatenation)
     pub fn extract_text(&self, node_id: u32) -> String {
-        use satteri_ast::mdast::codec::decode_string_ref_data;
         use satteri_ast::mdast::MdastNodeType;
+        use satteri_ast::mdast::codec::decode_string_ref_data;
         let node = self.arena.get_node(node_id);
         if node.node_type == MdastNodeType::Text as u8
             || node.node_type == MdastNodeType::InlineCode as u8

--- a/crates/satteri-plugin-api/src/generated/encode.rs
+++ b/crates/satteri-plugin-api/src/generated/encode.rs
@@ -6,12 +6,12 @@ use crate::generated::wire_constants::{
 };
 #[cfg(feature = "mdx")]
 use crate::js_commands::intern_mdx_jsx_attrs;
-use crate::js_commands::{alloc_opt_str, FieldCollector, HastFieldCollector};
+use crate::js_commands::{FieldCollector, HastFieldCollector, alloc_opt_str};
 use satteri_arena::{ArenaBuilder, Hast, Mdast, StringRef};
 use satteri_ast::hast::codec::encode_element_data;
 #[cfg(feature = "mdx")]
 use satteri_ast::mdast::codec::encode_mdx_jsx_element_data;
-use satteri_ast::mdast::codec::{encode_directive_data, encode_table_data, ColumnAlign};
+use satteri_ast::mdast::codec::{ColumnAlign, encode_directive_data, encode_table_data};
 use satteri_ast::shared::{PROP_BOOL_FALSE, PROP_BOOL_TRUE};
 
 /// Largest fixed-field `type_data` layout; callers stack-allocate this much.

--- a/crates/satteri-plugin-api/src/generated/wire_constants.rs
+++ b/crates/satteri-plugin-api/src/generated/wire_constants.rs
@@ -35,7 +35,7 @@ pub const OF_ORDERED: u8 = 13;
 pub const OF_SPREAD: u8 = 14;
 pub const OF_TAGNAME: u8 = 15; // HAST element tag name
 pub const OF_EXPLICIT: u8 = 16; // MDX JSX `_mdxExplicitJsx` flag
-                                // One past the highest op-field id; sizes per-node field scratch tables.
+// One past the highest op-field id; sizes per-node field scratch tables.
 pub const OF_FIELD_COUNT: usize = 17;
 
 // Command bytes (0x01–0x0F range). Each is followed by [nodeId: u32 LE];

--- a/crates/satteri-plugin-api/src/js_commands.rs
+++ b/crates/satteri-plugin-api/src/js_commands.rs
@@ -23,9 +23,9 @@
 use satteri_arena::{Arena, ArenaBuilder, ArenaKind, Hast, Mdast, StringRef};
 use satteri_ast::commands::CommandError;
 use satteri_ast::hast::codec::decode_element_tag;
-use satteri_ast::hast::{is_void_element, HastNodeType};
-use satteri_ast::mdast::codec::*;
+use satteri_ast::hast::{HastNodeType, is_void_element};
 use satteri_ast::mdast::MdastNodeType;
+use satteri_ast::mdast::codec::*;
 use satteri_ast::patch::{Patch, PatchContent, REF_NODE_TYPE};
 #[cfg(feature = "mdx")]
 use satteri_ast::shared::{MDX_ATTR_BOOLEAN_PROP, MDX_ATTR_LITERAL_PROP, MDX_ATTR_SPREAD};
@@ -33,7 +33,7 @@ use satteri_ast::shared::{
     PROP_BOOL_FALSE, PROP_BOOL_TRUE, PROP_INT, PROP_NULL, PROP_SPACE_SEP, PROP_STRING,
 };
 
-use crate::generated::prop_slots::{mdast_prop_slot, MdastPropSlot};
+use crate::generated::prop_slots::{MdastPropSlot, mdast_prop_slot};
 use crate::generated::wire_constants::*;
 
 struct BufReader<'a> {
@@ -339,8 +339,8 @@ fn emit_ref_node<K: ArenaKind>(ref_id: u32, builder: &mut ArenaBuilder<K>) -> u3
 // Generated per-type arena encoder, driven by the node registry. See
 // `crates/satteri-layout-codegen`.
 use crate::generated::encode::{
-    encode_hast_tail_from_ops, encode_mdast_tail_from_ops, encode_mdast_type_data_from_ops,
-    MAX_FIXED_TYPE_DATA,
+    MAX_FIXED_TYPE_DATA, encode_hast_tail_from_ops, encode_mdast_tail_from_ops,
+    encode_mdast_type_data_from_ops,
 };
 
 pub(crate) fn alloc_opt_str<K: ArenaKind>(

--- a/crates/satteri-plugin-api/src/lib.rs
+++ b/crates/satteri-plugin-api/src/lib.rs
@@ -11,9 +11,9 @@ pub use commands::{BuiltNode, Command, NewNode, NodeBuilder};
 pub use context::{Diagnostic, PluginContext, Severity};
 pub use data::{DataMap, DataValue, TypedDataMap};
 pub use js_commands::{
-    apply_hast_commands, apply_hast_commands_lenient, apply_mdast_commands,
+    MdastCommandOptions, apply_hast_commands, apply_hast_commands_lenient, apply_mdast_commands,
     apply_mdast_commands_lenient, apply_mdast_commands_lenient_with_options,
-    apply_mdast_commands_with_options, MdastCommandOptions,
+    apply_mdast_commands_with_options,
 };
 pub use plugin::{NodeView, Plugin, PluginMeta, VisitResult};
 pub use runner::{PluginRunResult, PluginRunner};

--- a/crates/satteri-plugin-api/src/runner.rs
+++ b/crates/satteri-plugin-api/src/runner.rs
@@ -5,7 +5,7 @@ use crate::plugin::{NodeView, Plugin, VisitResult};
 use crate::typed_nodes::*;
 use satteri_arena::{Arena, ArenaBuilder, Mdast};
 use satteri_ast::mdast::MdastNodeType;
-use satteri_ast::patch::{apply_patches_strict, Patch, PatchContent};
+use satteri_ast::patch::{Patch, PatchContent, apply_patches_strict};
 
 /// Result of running plugins against an arena.
 pub struct PluginRunResult {

--- a/crates/satteri-plugin-api/src/runner.rs
+++ b/crates/satteri-plugin-api/src/runner.rs
@@ -92,14 +92,14 @@ impl PluginRunner {
 
             if has_cmds {
                 let patches = commands_to_patches(commands.iter().collect(), &current_arena);
-                if !patches.is_empty() {
-                    if let Err(err) = apply_patches_strict(&mut current_arena, &patches) {
-                        all_diagnostics.push(Diagnostic {
-                            message: format!("invalid patch combination: {err}"),
-                            node_id: None,
-                            severity: Severity::Error,
-                        });
-                    }
+                if !patches.is_empty()
+                    && let Err(err) = apply_patches_strict(&mut current_arena, &patches)
+                {
+                    all_diagnostics.push(Diagnostic {
+                        message: format!("invalid patch combination: {err}"),
+                        node_id: None,
+                        severity: Severity::Error,
+                    });
                 }
                 all_commands.extend(commands);
             }

--- a/crates/satteri-plugin-api/src/typed_nodes.rs
+++ b/crates/satteri-plugin-api/src/typed_nodes.rs
@@ -1,6 +1,6 @@
 use satteri_arena::{Arena, ArenaNode, Mdast};
-use satteri_ast::mdast::codec::*;
 use satteri_ast::mdast::MdastNodeType;
+use satteri_ast::mdast::codec::*;
 
 /// Position info extracted from an ArenaNode
 #[derive(Debug, Clone, Copy)]

--- a/crates/satteri-plugin-api/tests/commands.rs
+++ b/crates/satteri-plugin-api/tests/commands.rs
@@ -1,5 +1,5 @@
 use satteri_arena::{Arena, ArenaBuilder, Mdast, StringRef};
-use satteri_ast::mdast::{codec::*, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, codec::*};
 use satteri_plugin_api::*;
 
 fn build_test_arena() -> Arena<Mdast> {

--- a/crates/satteri-plugin-api/tests/patch_integration.rs
+++ b/crates/satteri-plugin-api/tests/patch_integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests verifying that PluginRunner actually applies structural commands.
 
 use satteri_arena::{Arena, ArenaBuilder, Mdast, StringRef};
-use satteri_ast::mdast::{codec::*, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, codec::*};
 use satteri_plugin_api::*;
 
 /// In-place apply leaves detached garbage; assertions must only consider

--- a/crates/satteri-plugin-api/tests/plugin_basics.rs
+++ b/crates/satteri-plugin-api/tests/plugin_basics.rs
@@ -1,5 +1,5 @@
 use satteri_arena::{Arena, ArenaBuilder, Mdast, StringRef};
-use satteri_ast::mdast::{codec::*, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, codec::*};
 use satteri_plugin_api::*;
 
 /// Build a simple arena:

--- a/crates/satteri-plugin-api/tests/runner.rs
+++ b/crates/satteri-plugin-api/tests/runner.rs
@@ -1,5 +1,5 @@
 use satteri_arena::{Arena, ArenaBuilder, Mdast, StringRef};
-use satteri_ast::mdast::{codec::*, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, codec::*};
 use satteri_plugin_api::*;
 
 fn build_test_arena() -> Arena<Mdast> {

--- a/crates/satteri-property-info/Cargo.toml
+++ b/crates/satteri-property-info/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri-property-info"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "HTML/SVG attribute ↔ hast-property name mapping and value-coercion hints for Sätteri, a Rust port of the property-information package"
 license = "MIT"
 

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -53,11 +53,7 @@ impl PropKind {
 }
 
 fn table(in_svg: bool) -> Table {
-    if in_svg {
-        SVG_TABLE
-    } else {
-        HTML_TABLE
-    }
+    if in_svg { SVG_TABLE } else { HTML_TABLE }
 }
 
 /// Lowercase `name` for a table lookup; borrows when already lowercase.
@@ -210,7 +206,7 @@ fn format_data_attribute(suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{find_property, property_to_attribute, PropKind};
+    use super::{PropKind, find_property, property_to_attribute};
 
     fn html(name: &str) -> std::borrow::Cow<'_, str> {
         property_to_attribute(name, false)

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -111,10 +111,8 @@ pub fn property_to_attribute(name: &str, in_svg: bool) -> Cow<'_, str> {
     }
     // Schema lookup must beat the generic `data-*` fallback: `dataType` is a
     // real SVG attribute (→ `datatype`), not a custom `data-type`.
-    if in_svg {
-        if let Some(attr) = attribute_of(name, true) {
-            return Cow::Borrowed(attr);
-        }
+    if in_svg && let Some(attr) = attribute_of(name, true) {
+        return Cow::Borrowed(attr);
     }
     if let Some(rest) = strip_namespace_prefix(name, "data") {
         return Cow::Owned(format_data_attribute(rest));

--- a/crates/satteri-pulldown-cmark/Cargo.toml
+++ b/crates/satteri-pulldown-cmark/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 description = "A fork of the pulldown-cmark crate with MDX extensions, used in the satteri project."
-edition = "2021"
+edition = "2024"
 
 build = "build.rs"
 

--- a/crates/satteri-pulldown-cmark/src/arena_build.rs
+++ b/crates/satteri-pulldown-cmark/src/arena_build.rs
@@ -456,20 +456,20 @@ fn parse_inner(
                         // spread computation — mirrors the regular-close
                         // arm's blockquote handling but inline here since
                         // ListItem close has its own arm. See §B.
-                        if let Some(&(snap_kind, snap_len)) = container_jsx_snapshot.last() {
-                            if snap_kind == MdastNodeType::ListItem {
-                                container_jsx_snapshot.pop();
-                                while jsx_stack.len() > snap_len {
-                                    let (name, offset, _is_flow) = jsx_stack.pop().unwrap();
-                                    let loc = byte_offset_to_line_col(source, offset as usize);
-                                    mdx_errors.push((
+                        if let Some(&(snap_kind, snap_len)) = container_jsx_snapshot.last()
+                            && snap_kind == MdastNodeType::ListItem
+                        {
+                            container_jsx_snapshot.pop();
+                            while jsx_stack.len() > snap_len {
+                                let (name, offset, _is_flow) = jsx_stack.pop().unwrap();
+                                let loc = byte_offset_to_line_col(source, offset as usize);
+                                mdx_errors.push((
                                         offset as usize,
                                         format!(
                                             "Expected a closing tag for `<{name}>` ({loc}) before the end of `listItem`"
                                         ),
                                     ));
-                                    builder.close_node();
-                                }
+                                builder.close_node();
                             }
                         }
                         let id = builder.current_node_id();
@@ -679,20 +679,19 @@ fn parse_inner(
                             ItemBody::Paragraph
                                 | ItemBody::TightParagraph
                                 | ItemBody::DirectiveLabel
-                        ) {
-                            if let Some(opened_at) = paragraph_open_depth.pop() {
-                                while builder.stack_depth() > opened_at {
-                                    if let Some((name, offset, _is_flow)) = jsx_stack.pop() {
-                                        let loc = byte_offset_to_line_col(source, offset as usize);
-                                        mdx_errors.push((
+                        ) && let Some(opened_at) = paragraph_open_depth.pop()
+                        {
+                            while builder.stack_depth() > opened_at {
+                                if let Some((name, offset, _is_flow)) = jsx_stack.pop() {
+                                    let loc = byte_offset_to_line_col(source, offset as usize);
+                                    mdx_errors.push((
                                             offset as usize,
                                             format!(
                                                 "Expected a closing tag for `<{name}>` ({loc}) before the end of `paragraph`"
                                             ),
                                         ));
-                                    }
-                                    builder.close_node();
                                 }
+                                builder.close_node();
                             }
                         }
                         // Drain unclosed JSX opens that were pushed inside a
@@ -704,27 +703,26 @@ fn parse_inner(
                             ItemBody::ListItem(..) => Some(MdastNodeType::ListItem),
                             _ => None,
                         };
-                        if let Some(kind) = container_kind_for_drain {
-                            if let Some(&(snap_kind, snap_len)) = container_jsx_snapshot.last() {
-                                if snap_kind == kind {
-                                    container_jsx_snapshot.pop();
-                                    while jsx_stack.len() > snap_len {
-                                        let (name, offset, _is_flow) = jsx_stack.pop().unwrap();
-                                        let loc = byte_offset_to_line_col(source, offset as usize);
-                                        let container_label = match kind {
-                                            MdastNodeType::Blockquote => "blockQuote",
-                                            MdastNodeType::ListItem => "listItem",
-                                            _ => "container",
-                                        };
-                                        mdx_errors.push((
+                        if let Some(kind) = container_kind_for_drain
+                            && let Some(&(snap_kind, snap_len)) = container_jsx_snapshot.last()
+                            && snap_kind == kind
+                        {
+                            container_jsx_snapshot.pop();
+                            while jsx_stack.len() > snap_len {
+                                let (name, offset, _is_flow) = jsx_stack.pop().unwrap();
+                                let loc = byte_offset_to_line_col(source, offset as usize);
+                                let container_label = match kind {
+                                    MdastNodeType::Blockquote => "blockQuote",
+                                    MdastNodeType::ListItem => "listItem",
+                                    _ => "container",
+                                };
+                                mdx_errors.push((
                                             offset as usize,
                                             format!(
                                                 "Expected a closing tag for `<{name}>` ({loc}) before the end of `{container_label}`"
                                             ),
                                         ));
-                                        builder.close_node();
-                                    }
-                                }
+                                builder.close_node();
                             }
                         }
                         let id = builder.current_node_id();
@@ -975,13 +973,12 @@ fn parse_inner(
                         builder.set_data_current(&[depth]);
                         // Conveyed as `data.hProperties`, which the mdast->hast
                         // pass emits as `id`/`class`/custom attributes.
-                        if let Some(heading_ix) = heading_ix {
-                            if let Some(json) =
+                        if let Some(heading_ix) = heading_ix
+                            && let Some(json) =
                                 encode_heading_h_properties(&inner.allocs[heading_ix])
-                            {
-                                let heading_id = builder.current_node_id();
-                                builder.arena_mut().set_node_data(heading_id, json);
-                            }
+                        {
+                            let heading_id = builder.current_node_id();
+                            builder.arena_mut().set_node_data(heading_id, json);
                         }
                         inner.tree.push();
                     }
@@ -1724,20 +1721,19 @@ fn parse_inner(
                         let checked_val = if checked { 1 } else { 0 };
                         let depth = builder.stack_depth();
                         for i in (0..depth).rev() {
-                            if let Some(node_id) = builder.stack_node_id(i) {
-                                if builder.arena_ref().get_node(node_id).node_type
+                            if let Some(node_id) = builder.stack_node_id(i)
+                                && builder.arena_ref().get_node(node_id).node_type
                                     == MdastNodeType::ListItem as u8
-                                {
-                                    let prev = builder.arena_ref().get_type_data(node_id).to_vec();
-                                    let prev_spread = prev.get(1).copied().unwrap_or(0) != 0;
-                                    let data = ListItemData {
-                                        checked: checked_val,
-                                        spread: prev_spread,
-                                    }
-                                    .to_bytes();
-                                    builder.arena_mut().set_type_data(node_id, &data);
-                                    break;
+                            {
+                                let prev = builder.arena_ref().get_type_data(node_id).to_vec();
+                                let prev_spread = prev.get(1).copied().unwrap_or(0) != 0;
+                                let data = ListItemData {
+                                    checked: checked_val,
+                                    spread: prev_spread,
                                 }
+                                .to_bytes();
+                                builder.arena_mut().set_type_data(node_id, &data);
+                                break;
                             }
                         }
                         inner.tree.next_sibling(cur_ix);

--- a/crates/satteri-pulldown-cmark/src/arena_build.rs
+++ b/crates/satteri-pulldown-cmark/src/arena_build.rs
@@ -3,14 +3,14 @@
 
 use alloc::borrow::Cow;
 
-use satteri_arena::{line_ending_iter, Arena, ArenaBuilder, LineIndex, Mdast, StringRef};
+use satteri_arena::{Arena, ArenaBuilder, LineIndex, Mdast, StringRef, line_ending_iter};
 use satteri_ast::mdast::{
-    encode_directive_data, encode_image_reference_data, encode_reference_data, encode_table_data,
     CodeData, ColumnAlign, DefinitionData, DescriptionDetailsData, FootnoteDefinitionData,
     ImageData, LinkData, ListData, ListItemData, MathData, MdastNodeType, ReferenceData,
+    encode_directive_data, encode_image_reference_data, encode_reference_data, encode_table_data,
 };
 #[cfg(feature = "mdx")]
-use satteri_ast::mdast::{encode_mdx_jsx_element_data, ExpressionData};
+use satteri_ast::mdast::{ExpressionData, encode_mdx_jsx_element_data};
 #[cfg(feature = "mdx")]
 use satteri_ast::shared::{
     MDX_ATTR_BOOLEAN_PROP, MDX_ATTR_EXPRESSION_PROP, MDX_ATTR_LITERAL_PROP, MDX_ATTR_SPREAD,
@@ -2152,11 +2152,7 @@ fn normalize_inline_html_wrap(src: &str) -> Option<String> {
         }
         out.push_str(&src[line_start..i]);
     }
-    if out == src {
-        None
-    } else {
-        Some(out)
-    }
+    if out == src { None } else { Some(out) }
 }
 
 fn reference_end(
@@ -2515,7 +2511,7 @@ fn encode_jsx_element_data(jsx: &JsxElementData<'_>, builder: &mut ArenaBuilder<
 /// `test/conformance/autolink-path.test.ts` holds remark to the same tables.
 #[cfg(test)]
 mod autolink_path_probe {
-    use super::{parse_inner, Arena, Mdast, MdastNodeType, Options};
+    use super::{Arena, Mdast, MdastNodeType, Options, parse_inner};
     use satteri_ast::mdast::decode_link_data;
 
     /// The JS conformance features: GFM, no frontmatter, no math.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -202,14 +202,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             let content_probe = start_ix + line_start.bytes_scanned();
             let has_content =
                 content_probe < bytes.len() && scan_blank_line(&bytes[content_probe..]).is_none();
-            if has_content {
-                if let Some(up) = self.tree.peek_up() {
-                    if let ItemBody::ListItem(_, _) = self.tree[up].item.body {
-                        if self.tree[up].child.is_some() {
-                            self.mark_enclosing_listitem_spread();
-                        }
-                    }
-                }
+            if has_content
+                && let Some(up) = self.tree.peek_up()
+                && let ItemBody::ListItem(_, _) = self.tree[up].item.body
+                && self.tree[up].child.is_some()
+            {
+                self.mark_enclosing_listitem_spread();
             }
         }
 
@@ -532,11 +530,10 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 });
                 if let Some(ItemBody::DefinitionList(is_tight)) =
                     self.tree.peek_up().map(|cur| &mut self.tree[cur].item.body)
+                    && self.last_line_blank
                 {
-                    if self.last_line_blank {
-                        *is_tight = false;
-                        self.last_line_blank = false;
-                    }
+                    *is_tight = false;
+                    self.last_line_blank = false;
                 }
                 self.tree.push();
                 if let Some(n) = scan_blank_line(&bytes[after_marker_index..]) {
@@ -839,17 +836,19 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         // Metadata blocks cannot be indented, and — matching remark-frontmatter
         // — only match at the very start of the document. `doc_start` is 0
         // normally, or 3 when a UTF-8 BOM was stripped.
-        if indent == 0 && ix == self.doc_start && self.tree.spine_len() == 0 {
-            if let Some((_n, metadata_block_ch)) = scan_metadata_block(
+        if indent == 0
+            && ix == self.doc_start
+            && self.tree.spine_len() == 0
+            && let Some((_n, metadata_block_ch)) = scan_metadata_block(
                 &bytes[ix..],
                 self.options
                     .contains(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS),
                 self.options
                     .contains(Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS),
-            ) {
-                self.finish_list(start_ix);
-                return self.parse_metadata_block(ix, metadata_block_ch);
-            }
+            )
+        {
+            self.finish_list(start_ix);
+            return self.parse_metadata_block(ix, metadata_block_ch);
         }
 
         // MDX blocks, must be checked before HTML blocks since JSX looks like HTML.
@@ -865,82 +864,79 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     .tree
                     .walk_spine()
                     .all(|&ix| matches!(self.tree[ix].item.body, ItemBody::List(..)));
-            if at_root_for_esm {
-                if let Some(end_ix) = scan_mdx_esm(&bytes[ix..]) {
-                    let mut final_end = end_ix;
+            if at_root_for_esm && let Some(end_ix) = scan_mdx_esm(&bytes[ix..]) {
+                let mut final_end = end_ix;
 
-                    // If the scanned ESM block is incomplete (e.g. an export
-                    // spanning a blank line), retry across blank lines using
-                    // oxc — matching the reference mdxjs behavior.
-                    let candidate = self.text[ix..ix + final_end].trim_end();
-                    if !candidate.is_empty() {
-                        use crate::mdx::EsmParseResult;
-                        let mut allocator = oxc_allocator::Allocator::default();
-                        match crate::mdx::try_parse_esm(candidate, &mut allocator) {
-                            EsmParseResult::Complete => {}
-                            EsmParseResult::Incomplete => {
-                                let mut pos = ix + final_end;
-                                loop {
-                                    let blank_start = pos;
-                                    while pos < bytes.len()
-                                        && (bytes[pos] == b'\n'
-                                            || bytes[pos] == b'\r'
-                                            || bytes[pos] == b' '
-                                            || bytes[pos] == b'\t')
+                // If the scanned ESM block is incomplete (e.g. an export
+                // spanning a blank line), retry across blank lines using
+                // oxc — matching the reference mdxjs behavior.
+                let candidate = self.text[ix..ix + final_end].trim_end();
+                if !candidate.is_empty() {
+                    use crate::mdx::EsmParseResult;
+                    let mut allocator = oxc_allocator::Allocator::default();
+                    match crate::mdx::try_parse_esm(candidate, &mut allocator) {
+                        EsmParseResult::Complete => {}
+                        EsmParseResult::Incomplete => {
+                            let mut pos = ix + final_end;
+                            loop {
+                                let blank_start = pos;
+                                while pos < bytes.len()
+                                    && (bytes[pos] == b'\n'
+                                        || bytes[pos] == b'\r'
+                                        || bytes[pos] == b' '
+                                        || bytes[pos] == b'\t')
+                                {
+                                    pos += 1;
+                                }
+                                if pos == blank_start || pos >= bytes.len() {
+                                    break;
+                                }
+                                let chunk_start = pos;
+                                while pos < bytes.len() {
+                                    pos += scan_nextline(&bytes[pos..]);
+                                    if pos < bytes.len()
+                                        && (bytes[pos] == b'\n' || bytes[pos] == b'\r')
                                     {
-                                        pos += 1;
-                                    }
-                                    if pos == blank_start || pos >= bytes.len() {
                                         break;
-                                    }
-                                    let chunk_start = pos;
-                                    while pos < bytes.len() {
-                                        pos += scan_nextline(&bytes[pos..]);
-                                        if pos < bytes.len()
-                                            && (bytes[pos] == b'\n' || bytes[pos] == b'\r')
-                                        {
-                                            break;
-                                        }
-                                    }
-                                    if pos == chunk_start {
-                                        break;
-                                    }
-                                    final_end = pos - ix;
-                                    let candidate = self.text[ix..ix + final_end].trim_end();
-                                    match crate::mdx::try_parse_esm(candidate, &mut allocator) {
-                                        EsmParseResult::Complete => break,
-                                        EsmParseResult::Incomplete => continue,
-                                        EsmParseResult::Error => break,
                                     }
                                 }
+                                if pos == chunk_start {
+                                    break;
+                                }
+                                final_end = pos - ix;
+                                let candidate = self.text[ix..ix + final_end].trim_end();
+                                match crate::mdx::try_parse_esm(candidate, &mut allocator) {
+                                    EsmParseResult::Complete => break,
+                                    EsmParseResult::Incomplete => continue,
+                                    EsmParseResult::Error => break,
+                                }
                             }
-                            EsmParseResult::Error => {}
                         }
+                        EsmParseResult::Error => {}
                     }
-
-                    self.finish_list(start_ix);
-                    return self.parse_mdx_esm(ix, ix + final_end);
                 }
+
+                self.finish_list(start_ix);
+                return self.parse_mdx_esm(ix, ix + final_end);
             }
 
             // MDX JSX flow: line starting with `<` followed by component name or fragment
-            if bytes[ix] == b'<' {
-                if let Some(end_ix) =
+            if bytes[ix] == b'<'
+                && let Some(end_ix) =
                     self.scan_mdx_flow_in_container(ix, |b, c| scan_mdx_jsx_block(b, c))
-                {
-                    self.finish_list(start_ix);
-                    let result = self.parse_mdx_jsx_flow(ix, ix + end_ix);
-                    // A blank line inside the consumed flow block means the
-                    // enclosing list item is "loose" (spread=true). remark
-                    // detects this naturally since its tokenizer reads line-
-                    // by-line; we consume the whole block atomically, so we
-                    // have to inspect the span here.
-                    if contains_blank_line(&bytes[ix..ix + end_ix]) {
-                        self.last_line_blank = true;
-                        self.mark_enclosing_listitem_spread();
-                    }
-                    return result;
+            {
+                self.finish_list(start_ix);
+                let result = self.parse_mdx_jsx_flow(ix, ix + end_ix);
+                // A blank line inside the consumed flow block means the
+                // enclosing list item is "loose" (spread=true). remark
+                // detects this naturally since its tokenizer reads line-
+                // by-line; we consume the whole block atomically, so we
+                // have to inspect the span here.
+                if contains_blank_line(&bytes[ix..ix + end_ix]) {
+                    self.last_line_blank = true;
+                    self.mark_enclosing_listitem_spread();
                 }
+                return result;
             }
 
             // MDX expression flow: line starting with `{`
@@ -1014,11 +1010,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             return self.parse_fenced_code_block(ix, indent, fence_ch, n);
         }
 
-        if self.options.contains(Options::ENABLE_MATH_MULTI_DOLLAR) {
-            if let Some(n) = scan_math_fence(&bytes[ix..]) {
-                self.finish_list(start_ix);
-                return self.parse_math_block(ix, indent, n);
-            }
+        if self.options.contains(Options::ENABLE_MATH_MULTI_DOLLAR)
+            && let Some(n) = scan_math_fence(&bytes[ix..])
+        {
+            self.finish_list(start_ix);
+            return self.parse_math_block(ix, indent, n);
         }
 
         // parse refdef
@@ -1432,19 +1428,18 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             };
             if !is_indented {
                 let ix_new = ix + line_start.bytes_scanned();
-                if current_container {
-                    if let Some(ix_setext) =
+                if current_container
+                    && let Some(ix_setext) =
                         self.parse_setext_heading(ix_new, node_ix, trailing_backslash_pos.is_some())
-                    {
-                        if let Some(pos) = trailing_backslash_pos {
-                            self.tree.append_text(pos, pos + 1, false);
-                        }
-                        self.pop(ix_setext);
-                        if body == ItemBody::MaybeDefinitionListTitle {
-                            self.finish_list(ix);
-                        }
-                        return ix_setext;
+                {
+                    if let Some(pos) = trailing_backslash_pos {
+                        self.tree.append_text(pos, pos + 1, false);
                     }
+                    self.pop(ix_setext);
+                    if body == ItemBody::MaybeDefinitionListTitle {
+                        self.finish_list(ix);
+                    }
+                    return ix_setext;
                 }
                 // first check for non-empty lists, then for other interrupts
                 let suffix = &bytes[ix_new..];
@@ -2034,38 +2029,36 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                             .unwrap_or(start);
                         if let Some((email_start, email_end, full_url)) =
                             scan_email_forward_from_atext(bytes, ix, begin_text, paragraph_floor)
+                            && email_start >= candidate_floor
                         {
-                            if email_start >= candidate_floor {
-                                let d = AutolinkDetection {
-                                    start: email_start,
-                                    end: email_end,
-                                    link_type: LinkType::Email,
-                                    url: full_url
-                                        .strip_prefix("mailto:")
-                                        .map(str::to_owned)
-                                        .unwrap_or(full_url),
-                                };
-                                if defer_autolink_decision(bytes, paragraph_floor, ix, self.options)
-                                {
-                                    candidate_floor = email_start + 1;
-                                    // Fall through to attention handling: a
-                                    // marker that fires splices those
-                                    // delimiters away, and a blocked one
-                                    // wanted them.
-                                    self.append_autolink_marker(d, begin_text, backslash_escaped);
-                                    if email_start > begin_text {
-                                        backslash_escaped = false;
-                                    }
-                                    begin_text = email_start;
-                                } else {
-                                    candidate_floor = email_end;
-                                    self.append_autolink_link(d, begin_text, backslash_escaped);
+                            let d = AutolinkDetection {
+                                start: email_start,
+                                end: email_end,
+                                link_type: LinkType::Email,
+                                url: full_url
+                                    .strip_prefix("mailto:")
+                                    .map(str::to_owned)
+                                    .unwrap_or(full_url),
+                            };
+                            if defer_autolink_decision(bytes, paragraph_floor, ix, self.options) {
+                                candidate_floor = email_start + 1;
+                                // Fall through to attention handling: a
+                                // marker that fires splices those
+                                // delimiters away, and a blocked one
+                                // wanted them.
+                                self.append_autolink_marker(d, begin_text, backslash_escaped);
+                                if email_start > begin_text {
                                     backslash_escaped = false;
-                                    begin_text = email_end;
-                                    last_inline_emission_end = email_end;
-                                    let skip = email_end.saturating_sub(ix + 1);
-                                    return LoopInstruction::ContinueAndSkip(skip);
                                 }
+                                begin_text = email_start;
+                            } else {
+                                candidate_floor = email_end;
+                                self.append_autolink_link(d, begin_text, backslash_escaped);
+                                backslash_escaped = false;
+                                begin_text = email_end;
+                                last_inline_emission_end = email_end;
+                                let skip = email_end.saturating_sub(ix + 1);
+                                return LoopInstruction::ContinueAndSkip(skip);
                             }
                         }
                     }
@@ -3067,11 +3060,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             if n_containers < self.tree.spine_len() {
                 break;
             }
-            if let (_, 0) = calc_indent(&bytes[ix..], 4) {
-                if let Some(n) = scan_closing_metadata_block(&bytes[ix..], metadata_block_ch) {
-                    ix += n;
-                    break;
-                }
+            if let (_, 0) = calc_indent(&bytes[ix..], 4)
+                && let Some(n) = scan_closing_metadata_block(&bytes[ix..], metadata_block_ch)
+            {
+                ix += n;
+                break;
             }
             let remaining_space = line_start.remaining_space();
             ix += line_start.bytes_scanned();
@@ -3149,20 +3142,18 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     /// and end current list if it's a lone, empty item
     fn finish_list(&mut self, ix: usize) {
         self.finish_empty_list_item();
-        if let Some(node_ix) = self.tree.peek_up() {
-            if let ItemBody::List(_, _, _) | ItemBody::DefinitionList(_) =
+        if let Some(node_ix) = self.tree.peek_up()
+            && let ItemBody::List(_, _, _) | ItemBody::DefinitionList(_) =
                 self.tree[node_ix].item.body
-            {
-                self.pop(ix);
-            }
+        {
+            self.pop(ix);
         }
         if self.last_line_blank {
-            if let Some(node_ix) = self.tree.peek_grandparent() {
-                if let ItemBody::List(ref mut is_tight, _, _)
+            if let Some(node_ix) = self.tree.peek_grandparent()
+                && let ItemBody::List(ref mut is_tight, _, _)
                 | ItemBody::DefinitionList(ref mut is_tight) = self.tree[node_ix].item.body
-                {
-                    *is_tight = false;
-                }
+            {
+                *is_tight = false;
             }
             self.last_line_blank = false;
         }
@@ -3179,16 +3170,15 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     }
 
     fn finish_empty_list_item(&mut self) {
-        if let Some(begin_list_item) = self.begin_list_item {
-            if self.last_line_blank {
-                // A list item can begin with at most one blank line.
-                if let Some(node_ix) = self.tree.peek_up() {
-                    if let ItemBody::ListItem(_, _) | ItemBody::DefinitionListDefinition(..) =
-                        self.tree[node_ix].item.body
-                    {
-                        self.pop(begin_list_item);
-                    }
-                }
+        if let Some(begin_list_item) = self.begin_list_item
+            && self.last_line_blank
+        {
+            // A list item can begin with at most one blank line.
+            if let Some(node_ix) = self.tree.peek_up()
+                && let ItemBody::ListItem(_, _) | ItemBody::DefinitionListDefinition(..) =
+                    self.tree[node_ix].item.body
+            {
+                self.pop(begin_list_item);
             }
         }
         self.begin_list_item = None;
@@ -3199,14 +3189,14 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     fn continue_list(&mut self, start: usize, ch: u8, index: u64) {
         self.finish_empty_list_item();
         if let Some(node_ix) = self.tree.peek_up() {
-            if let ItemBody::List(ref mut is_tight, existing_ch, _) = self.tree[node_ix].item.body {
-                if existing_ch == ch {
-                    if self.last_line_blank {
-                        *is_tight = false;
-                        self.last_line_blank = false;
-                    }
-                    return;
+            if let ItemBody::List(ref mut is_tight, existing_ch, _) = self.tree[node_ix].item.body
+                && existing_ch == ch
+            {
+                if self.last_line_blank {
+                    *is_tight = false;
+                    self.last_line_blank = false;
                 }
+                return;
             }
             // TODO: this is not the best choice for end; maybe get end from last list item.
             self.finish_list(start);
@@ -3383,11 +3373,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         }
         i += 1;
         self.finish_list(start);
-        if let Some(node_ix) = self.tree.peek_up() {
-            if let ItemBody::FootnoteDefinition(..) = self.tree[node_ix].item.body {
-                // finish previous footnote if it's still open
-                self.pop(start);
-            }
+        if let Some(node_ix) = self.tree.peek_up()
+            && let ItemBody::FootnoteDefinition(..) = self.tree[node_ix].item.body
+        {
+            // finish previous footnote if it's still open
+            self.pop(start);
         }
         i += scan_space_or_tab(&bytes[i..]);
         self.allocs
@@ -3542,10 +3532,11 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 }
                 b'\\' => {
                     bytecount += 1;
-                    if let Some(c) = bytes.get(bytecount) {
-                        if c != &b'\r' && c != &b'\n' {
-                            bytecount += 1;
-                        }
+                    if let Some(c) = bytes.get(bytecount)
+                        && c != &b'\r'
+                        && c != &b'\n'
+                    {
+                        bytecount += 1;
                     }
                 }
                 c if c == closing_delim => {
@@ -3828,12 +3819,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         let mut spans: Vec<(usize, usize)> = Vec::new();
         let mut i = header_start;
         while i < header_end {
-            if bytes[i] == b':' {
-                if let Some(end) = scan_heading_text_directive(self.text, bytes, i, header_end) {
-                    spans.push((i, end));
-                    i = end;
-                    continue;
-                }
+            if bytes[i] == b':'
+                && let Some(end) = scan_heading_text_directive(self.text, bytes, i, header_end)
+            {
+                spans.push((i, end));
+                i = end;
+                continue;
             }
             i += 1;
         }
@@ -4714,10 +4705,10 @@ fn prev_line_has_open_inline_jsx(bytes: &[u8], ix: usize, has_math: bool) -> boo
             offset = i + 1;
             continue;
         }
-        if let Some(len) = crate::mdx::scan_mdx_inline_jsx(&bytes[pos..]) {
-            if pos + len > ix {
-                return true;
-            }
+        if let Some(len) = crate::mdx::scan_mdx_inline_jsx(&bytes[pos..])
+            && pos + len > ix
+        {
+            return true;
         }
         offset = i + 1;
     }
@@ -4772,10 +4763,10 @@ fn is_inside_open_inline_jsx_tag(bytes: &[u8], pos: usize) -> bool {
             i = j + 2;
             continue;
         }
-        if let Some(len) = crate::mdx::scan_mdx_inline_jsx(&bytes[j..]) {
-            if j + len > pos {
-                return true;
-            }
+        if let Some(len) = crate::mdx::scan_mdx_inline_jsx(&bytes[j..])
+            && j + len > pos
+        {
+            return true;
         }
         i = j + 1;
     }
@@ -4976,12 +4967,11 @@ fn detect_gfm_autolink(
             }
             // GFM registers the email construct ahead of www at the same
             // offset, so an `@` the www span would swallow wins instead.
-            if is_www {
-                if let Some(email) =
+            if is_www
+                && let Some(email) =
                     detect_email_inside_www(bytes, ix, end, paragraph_start, begin_text)
-                {
-                    return Some(email);
-                }
+            {
+                return Some(email);
             }
             Some(AutolinkDetection {
                 start,
@@ -5330,21 +5320,23 @@ fn parse_directive_after_colons<'a>(
     let mut label_end = 0usize;
 
     // Label (no space allowed between name and [)
-    if pos < bytes.len() && bytes[pos] == b'[' {
-        if let Some((ls, le, consumed)) = scan_directive_label(&bytes[pos..]) {
-            label_start = pos + ls;
-            label_end = pos + le;
-            pos += consumed;
-        }
+    if pos < bytes.len()
+        && bytes[pos] == b'['
+        && let Some((ls, le, consumed)) = scan_directive_label(&bytes[pos..])
+    {
+        label_start = pos + ls;
+        label_end = pos + le;
+        pos += consumed;
     }
 
     // Attributes (no space allowed between label/name and {)
     let mut attributes = Vec::new();
-    if pos < bytes.len() && bytes[pos] == b'{' {
-        if let Some((attrs, consumed)) = scan_directive_attributes(&bytes[pos..]) {
-            attributes = attrs;
-            pos += consumed;
-        }
+    if pos < bytes.len()
+        && bytes[pos] == b'{'
+        && let Some((attrs, consumed)) = scan_directive_attributes(&bytes[pos..])
+    {
+        attributes = attrs;
+        pos += consumed;
     }
 
     Some((

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -530,7 +530,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     end: after_marker_index, // will get updated later if item not empty
                     body: ItemBody::DefinitionListDefinition(indent, loose),
                 });
-                if let Some(ItemBody::DefinitionList(ref mut is_tight)) =
+                if let Some(ItemBody::DefinitionList(is_tight)) =
                     self.tree.peek_up().map(|cur| &mut self.tree[cur].item.body)
                 {
                     if self.last_line_blank {

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -10,16 +10,16 @@ use unicase::UniCase;
 #[cfg(feature = "mdx")]
 use crate::mdx::*;
 use crate::{
-    linklabel::{scan_link_label_rest, LinkLabel},
+    HeadingLevel, LinkType, MetadataBlockKind, Options,
+    linklabel::{LinkLabel, scan_link_label_rest},
     parse::{
-        scan_containers, Allocations, AutolinkCandidate, DirectiveAttrData, FootnoteDef,
-        HeadingAttributes, Item, ItemBody, LinkDef, LINK_MAX_NESTED_PARENS,
+        Allocations, AutolinkCandidate, DirectiveAttrData, FootnoteDef, HeadingAttributes, Item,
+        ItemBody, LINK_MAX_NESTED_PARENS, LinkDef, scan_containers,
     },
     post_passes::{scan_autolink_literal, scan_email_autolink},
     scanners::*,
     strings::CowStr,
     tree::{Tree, TreeIndex},
-    HeadingLevel, LinkType, MetadataBlockKind, Options,
 };
 
 pub(crate) fn run_first_pass(
@@ -3628,11 +3628,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 return Some(backup);
             }
         }
-        if newlines > 0 {
-            Some(backup)
-        } else {
-            None
-        }
+        if newlines > 0 { Some(backup) } else { None }
     }
 
     /// Checks whether we should break a paragraph on the given input.

--- a/crates/satteri-pulldown-cmark/src/lib.rs
+++ b/crates/satteri-pulldown-cmark/src/lib.rs
@@ -104,7 +104,7 @@ use core::fmt::Display;
 pub use crate::arena_build::MDX_OPTIONS;
 pub use crate::{
     arena_build::{
-        parse, parse_into, parse_no_positions, parse_no_positions_into, DEFAULT_OPTIONS,
+        DEFAULT_OPTIONS, parse, parse_into, parse_no_positions, parse_no_positions_into,
     },
     parse::{
         BrokenLink, BrokenLinkCallback, DefaultParserCallbacks, OffsetIter, Parser,

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -638,13 +638,13 @@ fn check_container_after_newline(
     ix: &mut usize,
     container_check: &Option<ContainerLineCheck<'_>>,
 ) -> Option<()> {
-    if let Some(check) = container_check {
-        if *ix < bytes.len() {
-            if let Some(skip) = check(&bytes[*ix..]) {
-                *ix += skip;
-            } else {
-                return None;
-            }
+    if let Some(check) = container_check
+        && *ix < bytes.len()
+    {
+        if let Some(skip) = check(&bytes[*ix..]) {
+            *ix += skip;
+        } else {
+            return None;
         }
     }
     Some(())
@@ -659,14 +659,14 @@ fn check_container_after_newline_lazy(
     ix: &mut usize,
     container_check: &Option<ContainerLineCheck<'_>>,
 ) -> LineMode {
-    if let Some(check) = container_check {
-        if *ix < bytes.len() {
-            if let Some(skip) = check(&bytes[*ix..]) {
-                *ix += skip;
-                return LineMode::Strict;
-            }
-            return LineMode::Lazy;
+    if let Some(check) = container_check
+        && *ix < bytes.len()
+    {
+        if let Some(skip) = check(&bytes[*ix..]) {
+            *ix += skip;
+            return LineMode::Strict;
         }
+        return LineMode::Lazy;
     }
     LineMode::Strict
 }
@@ -1475,12 +1475,12 @@ pub(crate) fn scan_mdx_jsx_block(
         if pos >= bytes.len() || bytes[pos] == b'\n' || bytes[pos] == b'\r' {
             break;
         }
-        if bytes[pos] == b'<' {
-            if let Some(end) = scan_mdx_jsx_tag_end_inner(&bytes[pos..], container_check, 0) {
-                pos += end;
-                last_was_jsx = true;
-                continue;
-            }
+        if bytes[pos] == b'<'
+            && let Some(end) = scan_mdx_jsx_tag_end_inner(&bytes[pos..], container_check, 0)
+        {
+            pos += end;
+            last_was_jsx = true;
+            continue;
         }
         if bytes[pos] == b'{' {
             // Flow context: child expressions can span multiple lines —
@@ -1536,15 +1536,15 @@ pub(crate) fn scan_mdx_expression_block(
                 continue;
             }
         }
-        if bytes[ix] == b'{' {
-            if let Some(len) = scan_mdx_expression_end(&bytes[ix..], true) {
-                if !last_was_jsx {
-                    return None;
-                }
-                ix += len;
-                last_was_jsx = false;
-                continue;
+        if bytes[ix] == b'{'
+            && let Some(len) = scan_mdx_expression_end(&bytes[ix..], true)
+        {
+            if !last_was_jsx {
+                return None;
             }
+            ix += len;
+            last_was_jsx = false;
+            continue;
         }
         return None;
     }

--- a/crates/satteri-pulldown-cmark/src/mdx.rs
+++ b/crates/satteri-pulldown-cmark/src/mdx.rs
@@ -2201,7 +2201,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 }
 
 use crate::{
-    parse::{scan_containers, JsxAttr, JsxElementData},
+    parse::{JsxAttr, JsxElementData, scan_containers},
     scanners::LineStart,
 };
 

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -33,13 +33,13 @@ use unicase::UniCase;
 #[cfg(feature = "mdx")]
 use crate::mdx::*;
 use crate::{
+    Alignment, BlockQuoteKind, CodeBlockKind, DirectiveKind, Event, HeadingLevel, LinkType,
+    MetadataBlockKind, Options, Tag, TagEnd,
     firstpass::run_first_pass,
-    linklabel::{scan_link_label_rest, FootnoteLabel, LinkLabel, ReferenceLabel},
+    linklabel::{FootnoteLabel, LinkLabel, ReferenceLabel, scan_link_label_rest},
     scanners::*,
     strings::CowStr,
     tree::{Tree, TreeIndex},
-    Alignment, BlockQuoteKind, CodeBlockKind, DirectiveKind, Event, HeadingLevel, LinkType,
-    MetadataBlockKind, Options, Tag, TagEnd,
 };
 
 // Allowing arbitrary depth nested parentheses inside link destinations
@@ -3250,7 +3250,9 @@ where
     }
 
     /// Provides an iterator over all the document's reference definitions.
-    pub fn iter(&'s self) -> impl Iterator<Item = (&'s str, &'s LinkDef<'input>)> + use<'s, 'input> {
+    pub fn iter(
+        &'s self,
+    ) -> impl Iterator<Item = (&'s str, &'s LinkDef<'input>)> + use<'s, 'input> {
         self.0.iter().map(|(k, v)| (k.as_ref(), v))
     }
 }
@@ -3641,7 +3643,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
         ItemBody::SoftBreak => return Event::SoftBreak,
         ItemBody::HardBreak(_) => return Event::HardBreak,
         ItemBody::FootnoteReference(cow_ix) => {
-            return Event::FootnoteReference(allocs.take_cow(cow_ix))
+            return Event::FootnoteReference(allocs.take_cow(cow_ix));
         }
         ItemBody::TaskListMarker(checked) => return Event::TaskListMarker(checked),
         ItemBody::Rule => return Event::Rule,
@@ -3726,7 +3728,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
                 Event::DisplayMath(allocs.take_cow(cow_ix))
             } else {
                 Event::InlineMath(allocs.take_cow(cow_ix))
-            }
+            };
         }
         ItemBody::DefinitionList(_) => Tag::DefinitionList,
         ItemBody::DefinitionListTitle => Tag::DefinitionListTitle,
@@ -3743,11 +3745,11 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &mut Allocations<'a>) ->
         }
         #[cfg(feature = "mdx")]
         ItemBody::MdxFlowExpression(cow_ix) => {
-            return Event::MdxFlowExpression(allocs.take_cow(cow_ix))
+            return Event::MdxFlowExpression(allocs.take_cow(cow_ix));
         }
         #[cfg(feature = "mdx")]
         ItemBody::MdxTextExpression(cow_ix) => {
-            return Event::MdxTextExpression(allocs.take_cow(cow_ix))
+            return Event::MdxTextExpression(allocs.take_cow(cow_ix));
         }
         #[cfg(feature = "mdx")]
         ItemBody::MdxEsm(cow_ix) => return Event::MdxEsm(allocs.take_cow(cow_ix)),
@@ -4287,9 +4289,11 @@ text
         // Without ENABLE_MDX, none of this should be parsed as MDX.
         let events: Vec<_> = Parser::new("import foo from 'bar'\n").collect();
         // Should be a regular paragraph.
-        assert!(events
-            .iter()
-            .any(|e| matches!(e, Event::Start(Tag::Paragraph))));
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Start(Tag::Paragraph)))
+        );
     }
 
     #[cfg(feature = "mdx")]

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -3250,7 +3250,7 @@ where
     }
 
     /// Provides an iterator over all the document's reference definitions.
-    pub fn iter(&'s self) -> impl Iterator<Item = (&'s str, &'s LinkDef<'input>)> {
+    pub fn iter(&'s self) -> impl Iterator<Item = (&'s str, &'s LinkDef<'input>)> + use<'s, 'input> {
         self.0.iter().map(|(k, v)| (k.as_ref(), v))
     }
 }

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -963,12 +963,11 @@ impl<'input> ParserInner<'input> {
                             // stale — clear it so arena_build doesn't extend
                             // the text node's source span back over bytes the
                             // link now owns. Mirrors the inline-link fix.
-                            if new_start > orig_start {
-                                if let ItemBody::Text { backslash_escaped } =
+                            if new_start > orig_start
+                                && let ItemBody::Text { backslash_escaped } =
                                     &mut self.tree[node_ix].item.body
-                                {
-                                    *backslash_escaped = false;
-                                }
+                            {
+                                *backslash_escaped = false;
                             }
                         }
                         continue;
@@ -1003,12 +1002,11 @@ impl<'input> ParserInner<'input> {
                                 // an attribute value). Clear the stale flag
                                 // so arena_build doesn't extend the trail
                                 // back over bytes the HTML now owns.
-                                if new_start > orig_start {
-                                    if let ItemBody::Text { backslash_escaped } =
+                                if new_start > orig_start
+                                    && let ItemBody::Text { backslash_escaped } =
                                         &mut self.tree[node_ix].item.body
-                                    {
-                                        *backslash_escaped = false;
-                                    }
+                                {
+                                    *backslash_escaped = false;
                                 }
                             }
                             continue;
@@ -1319,11 +1317,10 @@ impl<'input> ParserInner<'input> {
                                 matches!(self.tree[ix].item.body, ItemBody::MaybeLinkClose(..))
                             })
                             .unwrap_or(false)
+                        && let Some(node) = self.handle_wikilink(block_text, cur_ix, prev)
                     {
-                        if let Some(node) = self.handle_wikilink(block_text, cur_ix, prev) {
-                            cur = self.tree[node].next;
-                            continue;
-                        }
+                        cur = self.tree[node].next;
+                        continue;
                     }
                     if let Some(tos) = tos_link {
                         // skip rendering if already in a link, unless its an
@@ -1372,12 +1369,11 @@ impl<'input> ParserInner<'input> {
                                 // arena-build position fixup doesn't extend
                                 // the text node's source span back over
                                 // bytes already owned by the link.
-                                if new_start > orig_start {
-                                    if let ItemBody::Text { backslash_escaped } =
+                                if new_start > orig_start
+                                    && let ItemBody::Text { backslash_escaped } =
                                         &mut self.tree[next_node_ix].item.body
-                                    {
-                                        *backslash_escaped = false;
-                                    }
+                                {
+                                    *backslash_escaped = false;
                                 }
                             }
 
@@ -1397,39 +1393,37 @@ impl<'input> ParserInner<'input> {
                                 &self.text[first_bracket_start..first_bracket_end];
                             if let Some((_, ReferenceLabel::Footnote(footlabel))) =
                                 scan_link_label(&self.tree, first_bracket_text, self.options)
+                                && self.allocs.footdefs.contains(&footlabel)
                             {
-                                if self.allocs.footdefs.contains(&footlabel) {
-                                    let footref = self.allocs.allocate_cow(footlabel);
-                                    if let Some(def) = self
-                                        .allocs
-                                        .footdefs
-                                        .get_mut(self.allocs.cows[footref.0].to_owned())
-                                    {
-                                        def.use_count += 1;
-                                    }
-                                    let footnote_ix = if tos.ty == LinkStackTy::Image {
-                                        self.tree[tos.node].next = Some(cur_ix);
-                                        self.tree[tos.node].child = None;
-                                        self.tree[tos.node].item.body =
-                                            ItemBody::SynthesizeChar('!');
-                                        self.tree[cur_ix].item.start =
-                                            self.tree[tos.node].item.start + 1;
-                                        self.tree[tos.node].item.end =
-                                            self.tree[tos.node].item.start + 1;
-                                        cur_ix
-                                    } else {
-                                        tos.node
-                                    };
-                                    self.tree[footnote_ix].next = next;
-                                    self.tree[footnote_ix].child = None;
-                                    self.tree[footnote_ix].item.body =
-                                        ItemBody::FootnoteReference(footref);
-                                    self.tree[footnote_ix].item.end = first_bracket_end;
-                                    prev = Some(footnote_ix);
-                                    cur = next;
-                                    self.link_stack.clear();
-                                    continue;
+                                let footref = self.allocs.allocate_cow(footlabel);
+                                if let Some(def) = self
+                                    .allocs
+                                    .footdefs
+                                    .get_mut(self.allocs.cows[footref.0].to_owned())
+                                {
+                                    def.use_count += 1;
                                 }
+                                let footnote_ix = if tos.ty == LinkStackTy::Image {
+                                    self.tree[tos.node].next = Some(cur_ix);
+                                    self.tree[tos.node].child = None;
+                                    self.tree[tos.node].item.body = ItemBody::SynthesizeChar('!');
+                                    self.tree[cur_ix].item.start =
+                                        self.tree[tos.node].item.start + 1;
+                                    self.tree[tos.node].item.end =
+                                        self.tree[tos.node].item.start + 1;
+                                    cur_ix
+                                } else {
+                                    tos.node
+                                };
+                                self.tree[footnote_ix].next = next;
+                                self.tree[footnote_ix].child = None;
+                                self.tree[footnote_ix].item.body =
+                                    ItemBody::FootnoteReference(footref);
+                                self.tree[footnote_ix].item.end = first_bracket_end;
+                                prev = Some(footnote_ix);
+                                cur = next;
+                                self.link_stack.clear();
+                                continue;
                             }
                             // ok, so its not an inline link. maybe it is a reference
                             // to a defined link?
@@ -1580,60 +1574,58 @@ impl<'input> ParserInner<'input> {
                                     self.link_stack.clear();
                                     continue;
                                 }
-                            } else if let Some((ReferenceLabel::Link(link_label), end)) = label {
-                                if let Some((def_link_type, url, title)) = self
+                            } else if let Some((ReferenceLabel::Link(link_label), end)) = label
+                                && let Some((def_link_type, url, title)) = self
                                     .fetch_link_type_url_title(
                                         link_label,
                                         (self.tree[tos.node].item.start)..end,
                                         link_type,
                                         callbacks,
                                     )
-                                {
-                                    let link_ix =
-                                        self.allocs.allocate_link(def_link_type, url, title, id);
-                                    self.tree[tos.node].item.body = if tos.ty == LinkStackTy::Image
-                                    {
-                                        ItemBody::Image(link_ix)
-                                    } else {
-                                        ItemBody::Link(link_ix)
-                                    };
-                                    let label_node = self.tree[tos.node].next;
+                            {
+                                let link_ix =
+                                    self.allocs.allocate_link(def_link_type, url, title, id);
+                                self.tree[tos.node].item.body = if tos.ty == LinkStackTy::Image {
+                                    ItemBody::Image(link_ix)
+                                } else {
+                                    ItemBody::Link(link_ix)
+                                };
+                                let label_node = self.tree[tos.node].next;
 
-                                    // lets do some tree surgery to add the link to the tree
-                                    // 1st: skip the label node and close node
-                                    self.tree[tos.node].next = node_after_link;
+                                // lets do some tree surgery to add the link to the tree
+                                // 1st: skip the label node and close node
+                                self.tree[tos.node].next = node_after_link;
 
-                                    // then, if it exists, add the label node as a child to the link node
-                                    if label_node != cur {
-                                        self.tree[tos.node].child = label_node;
+                                // then, if it exists, add the label node as a child to the link node
+                                if label_node != cur {
+                                    self.tree[tos.node].child = label_node;
 
-                                        // finally: disconnect list of children
-                                        if let Some(prev_ix) = prev {
-                                            self.tree[prev_ix].next = None;
-                                        }
+                                    // finally: disconnect list of children
+                                    if let Some(prev_ix) = prev {
+                                        self.tree[prev_ix].next = None;
                                     }
+                                }
 
-                                    self.tree[tos.node].item.end = end;
-                                    // No `max(orig_start, end)` clamp here,
-                                    // unlike the inline-link splice: the item at
-                                    // `end - 1` either ends the label or was
-                                    // truncated to it, and the zero-width items
-                                    // that could sit at `end` all sit on a URL
-                                    // or email byte, never a `]`.
-                                    debug_assert!(
-                                        node_after_link.is_none_or(|node_after_ix| {
-                                            self.tree[node_after_ix].item.start >= end
-                                        }),
-                                        "reference splice must not overrun its successor",
-                                    );
+                                self.tree[tos.node].item.end = end;
+                                // No `max(orig_start, end)` clamp here,
+                                // unlike the inline-link splice: the item at
+                                // `end - 1` either ends the label or was
+                                // truncated to it, and the zero-width items
+                                // that could sit at `end` all sit on a URL
+                                // or email byte, never a `]`.
+                                debug_assert!(
+                                    node_after_link.is_none_or(|node_after_ix| {
+                                        self.tree[node_after_ix].item.start >= end
+                                    }),
+                                    "reference splice must not overrun its successor",
+                                );
 
-                                    // set up cur so next node will be node_after_link
-                                    cur = Some(tos.node);
-                                    cur_ix = tos.node;
+                                // set up cur so next node will be node_after_link
+                                cur = Some(tos.node);
+                                cur_ix = tos.node;
 
-                                    if tos.ty == LinkStackTy::Link {
-                                        self.disable_all_links();
-                                    }
+                                if tos.ty == LinkStackTy::Link {
+                                    self.disable_all_links();
                                 }
                             }
                         }
@@ -2232,29 +2224,28 @@ impl<'input> ParserInner<'input> {
                 return None;
             }
 
-            if c == b'\n' || c == b'\r' {
-                if let Some(node_ix) = scan_nodes_to_ix(&self.tree, node, i + 1) {
-                    if self.tree[node_ix].item.start > i {
-                        title.push_str(&text[mark..i]);
-                        // The title's line endings are content, kept byte for byte.
-                        title.push(c as char);
-                        if c == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
-                            title.push('\n');
-                        }
-                        i = self.tree[node_ix].item.start;
-                        mark = i;
-                        continue;
-                    }
+            if (c == b'\n' || c == b'\r')
+                && let Some(node_ix) = scan_nodes_to_ix(&self.tree, node, i + 1)
+                && self.tree[node_ix].item.start > i
+            {
+                title.push_str(&text[mark..i]);
+                // The title's line endings are content, kept byte for byte.
+                title.push(c as char);
+                if c == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
+                    title.push('\n');
                 }
+                i = self.tree[node_ix].item.start;
+                mark = i;
+                continue;
             }
-            if c == b'&' {
-                if let (n, Some(value)) = scan_entity(&bytes[i..]) {
-                    title.push_str(&text[mark..i]);
-                    title.push_str(&value);
-                    i += n;
-                    mark = i;
-                    continue;
-                }
+            if c == b'&'
+                && let (n, Some(value)) = scan_entity(&bytes[i..])
+            {
+                title.push_str(&text[mark..i]);
+                title.push_str(&value);
+                i += n;
+                mark = i;
+                continue;
             }
             if self.tree.is_in_table()
                 && c == b'\\'
@@ -2612,12 +2603,12 @@ fn skip_container_prefixes_with_remaining(
 impl Tree<Item> {
     pub(crate) fn append_text(&mut self, start: usize, end: usize, backslash_escaped: bool) {
         if end > start {
-            if let Some(ix) = self.cur() {
-                if matches!(self[ix].item.body, ItemBody::Text { .. }) && self[ix].item.end == start
-                {
-                    self[ix].item.end = end;
-                    return;
-                }
+            if let Some(ix) = self.cur()
+                && matches!(self[ix].item.body, ItemBody::Text { .. })
+                && self[ix].item.end == start
+            {
+                self[ix].item.end = end;
+                return;
             }
             self.append(Item {
                 start,

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -1192,15 +1192,14 @@ fn build_raw_map(
         });
     };
     let extend_one_to_one = |segs: &mut Vec<Seg>, r: usize, d: usize| {
-        if let Some(last) = segs.last_mut() {
-            if last.is_one_to_one()
-                && (last.d_start + last.d_len) as usize == d
-                && (last.r_start + last.r_len) as usize == r_start + r
-            {
-                last.d_len += 1;
-                last.r_len += 1;
-                return;
-            }
+        if let Some(last) = segs.last_mut()
+            && last.is_one_to_one()
+            && (last.d_start + last.d_len) as usize == d
+            && (last.r_start + last.r_len) as usize == r_start + r
+        {
+            last.d_len += 1;
+            last.r_len += 1;
+            return;
         }
         segs.push(Seg {
             d_start: d as u32,
@@ -1240,23 +1239,24 @@ fn build_raw_map(
         match raw[r] {
             b'&' => {
                 let (len, value) = crate::scanners::scan_entity(&raw[r..]);
-                if let Some(value) = value {
-                    if dec[d..].starts_with(value.as_bytes()) {
-                        push_atomic(&mut segs, r, len, d, value.len());
-                        r += len;
-                        d += value.len();
-                        continue;
-                    }
+                if let Some(value) = value
+                    && dec[d..].starts_with(value.as_bytes())
+                {
+                    push_atomic(&mut segs, r, len, d, value.len());
+                    r += len;
+                    d += value.len();
+                    continue;
                 }
             }
             b'\\' => {
-                if let Some(&next) = raw.get(r + 1) {
-                    if next.is_ascii_punctuation() && dec.get(d) == Some(&next) {
-                        push_atomic(&mut segs, r, 2, d, 1);
-                        r += 2;
-                        d += 1;
-                        continue;
-                    }
+                if let Some(&next) = raw.get(r + 1)
+                    && next.is_ascii_punctuation()
+                    && dec.get(d) == Some(&next)
+                {
+                    push_atomic(&mut segs, r, 2, d, 1);
+                    r += 2;
+                    d += 1;
+                    continue;
                 }
             }
             b'\r' if raw.get(r + 1) == Some(&b'\n') && dec.get(d) == Some(&b'\n') => {

--- a/crates/satteri-pulldown-cmark/src/post_passes.rs
+++ b/crates/satteri-pulldown-cmark/src/post_passes.rs
@@ -19,7 +19,7 @@
 #[cfg(feature = "mdx")]
 use satteri_arena::decode_string_ref_data;
 use satteri_arena::{Arena, ArenaBuilder, Mdast, StringRef};
-use satteri_ast::mdast::{codec::LinkData, MdastNodeType};
+use satteri_ast::mdast::{MdastNodeType, codec::LinkData};
 
 use crate::puncttable::is_punctuation;
 
@@ -1604,7 +1604,7 @@ pub(crate) fn mdx_mark_and_unravel(arena: &mut Arena<Mdast>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_raw_map, RawMap, Smart};
+    use super::{RawMap, Smart, build_raw_map};
 
     const OFF: Smart = Smart {
         quotes: false,

--- a/crates/satteri-pulldown-cmark/src/scanners.rs
+++ b/crates/satteri-pulldown-cmark/src/scanners.rs
@@ -1110,10 +1110,10 @@ pub(crate) fn scan_entity(bytes: &[u8]) -> (usize, Option<CowStr<'static>>) {
         };
     }
     end += scan_while(&bytes[end..], is_ascii_alphanumeric);
-    if bytes.get(end) == Some(&b';') {
-        if let Some(value) = entities::get_entity(&bytes[1..end]) {
-            return (end + 1, Some(value.into()));
-        }
+    if bytes.get(end) == Some(&b';')
+        && let Some(value) = entities::get_entity(&bytes[1..end])
+    {
+        return (end + 1, Some(value.into()));
     }
     (0, None)
 }

--- a/crates/satteri-pulldown-cmark/src/scanners.rs
+++ b/crates/satteri-pulldown-cmark/src/scanners.rs
@@ -27,8 +27,8 @@ use memchr::{memchr, memchr2};
 
 pub(crate) use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 use crate::{
-    entities, parse::HtmlScanGuard, strings::CowStr, Alignment, BlockQuoteKind, HeadingLevel,
-    LinkType,
+    Alignment, BlockQuoteKind, HeadingLevel, LinkType, entities, parse::HtmlScanGuard,
+    strings::CowStr,
 };
 
 type NewlineHandler<'a> = Option<&'a dyn Fn(&[u8]) -> usize>;
@@ -730,11 +730,7 @@ pub(crate) fn scan_hrule(bytes: &[u8]) -> Result<usize, usize> {
         }
         i += 1;
     }
-    if n >= 3 {
-        Ok(i)
-    } else {
-        Err(i)
-    }
+    if n >= 3 { Ok(i) } else { Err(i) }
 }
 
 /// Scan an ATX heading opening sequence.

--- a/crates/satteri-pulldown-cmark/src/strings.rs
+++ b/crates/satteri-pulldown-cmark/src/strings.rs
@@ -102,7 +102,7 @@ pub enum CowStr<'a> {
 mod serde_impl {
     use core::fmt;
 
-    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
     use super::CowStr;
 

--- a/crates/satteri-pulldown-cmark/src/strings.rs
+++ b/crates/satteri-pulldown-cmark/src/strings.rs
@@ -248,9 +248,9 @@ impl<'a> Deref for CowStr<'a> {
 
     fn deref(&self) -> &str {
         match self {
-            CowStr::Boxed(ref b) => b,
+            CowStr::Boxed(b) => b,
             CowStr::Borrowed(b) => b,
-            CowStr::Inlined(ref s) => s.deref(),
+            CowStr::Inlined(s) => s.deref(),
         }
     }
 }

--- a/crates/satteri-pulldown-cmark/tests/directive_inline.rs
+++ b/crates/satteri-pulldown-cmark/tests/directive_inline.rs
@@ -3,8 +3,8 @@
 
 use satteri_arena::{Arena, Mdast, StringRef};
 use satteri_ast::mdast::MdastNodeType;
-use satteri_pulldown_cmark::arena_build::{parse, DEFAULT_OPTIONS};
 use satteri_pulldown_cmark::Options;
+use satteri_pulldown_cmark::arena_build::{DEFAULT_OPTIONS, parse};
 
 fn dir_options() -> Options {
     DEFAULT_OPTIONS | Options::ENABLE_DIRECTIVE

--- a/crates/satteri-pulldown-cmark/tests/empty_list.rs
+++ b/crates/satteri-pulldown-cmark/tests/empty_list.rs
@@ -1,7 +1,7 @@
 use satteri_ast::mdast::MdastNodeType;
 #[cfg(feature = "mdx")]
 use satteri_pulldown_cmark::arena_build::MDX_OPTIONS;
-use satteri_pulldown_cmark::arena_build::{parse, DEFAULT_OPTIONS};
+use satteri_pulldown_cmark::arena_build::{DEFAULT_OPTIONS, parse};
 
 #[test]
 fn empty_list_item_keeps_list() {

--- a/crates/satteri-pulldown-cmark/tests/errors.rs
+++ b/crates/satteri-pulldown-cmark/tests/errors.rs
@@ -70,7 +70,9 @@ fn test_fuzzer_input_9() {
 
 #[test]
 fn test_fuzzer_input_10() {
-    parse_all_options("[[    \t\n   \u{c}\u{c}\u{c}\u{c}\u{c}    {}\n-\r\u{e}\u{0}\u{0}{# }\n\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{0}\u{0}");
+    parse_all_options(
+        "[[    \t\n   \u{c}\u{c}\u{c}\u{c}\u{c}    {}\n-\r\u{e}\u{0}\u{0}{# }\n\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{b}\u{0}\u{0}",
+    );
 }
 
 #[test]

--- a/crates/satteri-pulldown-cmark/tests/gfm_autolink_markers.rs
+++ b/crates/satteri-pulldown-cmark/tests/gfm_autolink_markers.rs
@@ -1,7 +1,7 @@
 //! A deferred autolink marker must never reach `arena_build`; a `debug_assert`
 //! there panics if one does, so rendering under a debug build is the check.
 
-use satteri_pulldown_cmark::{parse, Options};
+use satteri_pulldown_cmark::{Options, parse};
 
 fn html(input: &str) -> String {
     let (arena, _) = parse(input, Options::ENABLE_GFM | Options::ENABLE_MATH);

--- a/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
+++ b/crates/satteri-pulldown-cmark/tests/heading_attrs_directive.rs
@@ -4,10 +4,10 @@
 //! a directive trails it.
 
 use satteri_arena::{Arena, Mdast, StringRef};
-use satteri_ast::mdast::codec::{decode_directive_attr, decode_directive_attr_count};
 use satteri_ast::mdast::MdastNodeType;
-use satteri_pulldown_cmark::arena_build::{parse, DEFAULT_OPTIONS};
+use satteri_ast::mdast::codec::{decode_directive_attr, decode_directive_attr_count};
 use satteri_pulldown_cmark::Options;
+use satteri_pulldown_cmark::arena_build::{DEFAULT_OPTIONS, parse};
 
 fn options() -> Options {
     DEFAULT_OPTIONS | Options::ENABLE_DIRECTIVE | Options::ENABLE_HEADING_ATTRIBUTES

--- a/crates/satteri-pulldown-cmark/tests/math_granular.rs
+++ b/crates/satteri-pulldown-cmark/tests/math_granular.rs
@@ -1,4 +1,4 @@
-use satteri_pulldown_cmark::{parse, Options};
+use satteri_pulldown_cmark::{Options, parse};
 
 fn render(input: &str, opts: Options) -> String {
     let (arena, _) = parse(input, opts);

--- a/crates/satteri-pulldown-cmark/tests/mdx.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx.rs
@@ -712,7 +712,7 @@ fn jsx_flow_closing_tag() {
 
 #[test]
 fn jsx_flow_self_referential_close_tag_in_attribute() {
-    use satteri_pulldown_cmark::{parse, MDX_OPTIONS};
+    use satteri_pulldown_cmark::{MDX_OPTIONS, parse};
     let src = "<CodePreview\n  code={`<CodePreview lang=\"astro\">\n    body\n</CodePreview>`}\n  lang=\"astro\"\n>\n  <CodePreview lang=\"astro\">\n    body\n  </CodePreview>\n</CodePreview>\n";
     let (_arena, errors) = parse(src, MDX_OPTIONS);
     assert!(errors.is_empty(), "unexpected errors: {errors:?}");
@@ -720,7 +720,7 @@ fn jsx_flow_self_referential_close_tag_in_attribute() {
 
 #[test]
 fn jsx_close_tag_in_string_attribute_is_text() {
-    use satteri_pulldown_cmark::{parse, MDX_OPTIONS};
+    use satteri_pulldown_cmark::{MDX_OPTIONS, parse};
     let (_arena, errors) = parse("<Demo code=\"</Demo>\">child</Demo>\n", MDX_OPTIONS);
     assert!(errors.is_empty(), "unexpected errors: {errors:?}");
 }

--- a/crates/satteri-pulldown-cmark/tests/mdx_heading_attributes.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx_heading_attributes.rs
@@ -3,7 +3,7 @@
 //! stays an expression.
 #![cfg(feature = "mdx")]
 
-use satteri_pulldown_cmark::{parse, CowStr, Event, Options, Parser, Tag, MDX_OPTIONS};
+use satteri_pulldown_cmark::{CowStr, Event, MDX_OPTIONS, Options, Parser, Tag, parse};
 
 fn opts() -> Options {
     MDX_OPTIONS | Options::ENABLE_HEADING_ATTRIBUTES

--- a/crates/satteri-pulldown-cmark/tests/mdx_math.rs
+++ b/crates/satteri-pulldown-cmark/tests/mdx_math.rs
@@ -2,9 +2,9 @@
 #![cfg(feature = "mdx")]
 
 use satteri_arena::{Arena, Mdast};
-use satteri_ast::mdast::{decode_math_data, MdastNodeType};
-use satteri_pulldown_cmark::arena_build::parse;
+use satteri_ast::mdast::{MdastNodeType, decode_math_data};
 use satteri_pulldown_cmark::Options;
+use satteri_pulldown_cmark::arena_build::parse;
 
 fn mdx_math_options() -> Options {
     Options::ENABLE_MDX | Options::ENABLE_MATH

--- a/crates/satteri-pulldown-cmark/tests/serde.rs
+++ b/crates/satteri-pulldown-cmark/tests/serde.rs
@@ -22,10 +22,14 @@ mod tests {
             CowStr::Inlined("inline".try_into().unwrap()),
             CowStr::Inlined("".try_into().unwrap()),
         ] {
-            let encoded = bincode::serialize(i).unwrap();
-            let decoded1: CowStr = bincode::deserialize(&encoded).unwrap();
-            let decoded2: String = bincode::deserialize(&encoded).unwrap();
-            let decoded3: &str = bincode::deserialize(&encoded).unwrap();
+            let config = bincode::config::standard();
+            let encoded = bincode::serde::encode_to_vec(i, config).unwrap();
+            let (decoded1, _): (CowStr, _) =
+                bincode::serde::borrow_decode_from_slice(&encoded, config).unwrap();
+            let (decoded2, _): (String, _) =
+                bincode::serde::decode_from_slice(&encoded, config).unwrap();
+            let (decoded3, _): (&str, _) =
+                bincode::serde::borrow_decode_from_slice(&encoded, config).unwrap();
 
             assert_eq!(&decoded1, i);
             assert_eq!(decoded2, i.as_ref());
@@ -74,11 +78,14 @@ mod tests {
         let str = "a borrowed str";
         let string = "a owned str".to_owned();
 
-        let encoded_str = bincode::serialize(&str).unwrap();
-        let encoded_string = bincode::serialize(&string).unwrap();
+        let config = bincode::config::standard();
+        let encoded_str = bincode::serde::encode_to_vec(str, config).unwrap();
+        let encoded_string = bincode::serde::encode_to_vec(&string, config).unwrap();
 
-        let decoded_str: CowStr = bincode::deserialize(&encoded_str).unwrap();
-        let decoded_string: CowStr = bincode::deserialize(&encoded_string).unwrap();
+        let (decoded_str, _): (CowStr, _) =
+            bincode::serde::borrow_decode_from_slice(&encoded_str, config).unwrap();
+        let (decoded_string, _): (CowStr, _) =
+            bincode::serde::borrow_decode_from_slice(&encoded_string, config).unwrap();
 
         assert_eq!(decoded_str.as_ref(), str);
         assert_eq!(decoded_string.as_ref(), string);

--- a/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
+++ b/crates/satteri-pulldown-cmark/tests/smart_punct_granular.rs
@@ -1,4 +1,4 @@
-use satteri_pulldown_cmark::{parse, Options};
+use satteri_pulldown_cmark::{Options, parse};
 
 fn render(input: &str, opts: Options) -> String {
     let (arena, _) = parse(input, opts);

--- a/crates/satteri-pulldown-cmark/tests/source_integrity.rs
+++ b/crates/satteri-pulldown-cmark/tests/source_integrity.rs
@@ -1,4 +1,4 @@
-use satteri_pulldown_cmark::{parse, Options};
+use satteri_pulldown_cmark::{Options, parse};
 
 const ISSUE_MARKDOWN: &str = "This is an MDX page! You can access it using `/mdx`.
 

--- a/crates/satteri/Cargo.toml
+++ b/crates/satteri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "satteri"
 version = "0.2.8"
-edition = "2021"
+edition = "2024"
 description = "High-level Rust API for the Sätteri markdown/MDX pipeline"
 license = "MIT"
 


### PR DESCRIPTION
Moves the eight crates still on the 2021 edition to 2024, with the mechanical `cargo fix`, rustfmt style-edition, and let-chain fallout split into separate commits.