### PR TITLE
fix(mdx): emit text-only static groups as plain text nodes

### DIFF
--- a/.sampo/changesets/mdx-optimize-static-text-only-group.md
+++ b/.sampo/changesets/mdx-optimize-static-text-only-group.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-mdxjs: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed whitespace between adjacent components disappearing in MDX compiled with static optimization enabled.

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -398,19 +398,17 @@ fn is_static_subtree(view: &Arena<Hast>, node_id: u32, config: &OptimizeStaticCo
     }
 }
 
-/// Try to render a static subtree to an HTML string. Returns false if not static.
-fn try_render_static(
-    view: &Arena<Hast>,
-    node_id: u32,
-    config: &OptimizeStaticConfig,
-    out: &mut String,
-    space: Space,
-) -> bool {
-    if !is_static_subtree(view, node_id, config) {
-        return false;
+fn is_text_node(view: &Arena<Hast>, node_id: u32) -> bool {
+    matches!(
+        HastNodeType::from_u8(view.get_node(node_id).node_type),
+        Some(HastNodeType::Text)
+    )
+}
+
+fn render_static_group(view: &Arena<Hast>, node_ids: &[u32], out: &mut String, space: Space) {
+    for &node_id in node_ids {
+        satteri_ast::hast::render_node(node_id, view, out, false, space == Space::Svg);
     }
-    satteri_ast::hast::render_node(node_id, view, out, false, space == Space::Svg);
-    true
 }
 
 /// Create a JSX node that injects raw HTML according to the optimization config.
@@ -496,25 +494,38 @@ fn all<'a>(
         while i < child_count {
             let child_id = context.view.get_children(parent_id)[i];
 
-            let mut html_buf = String::new();
-            if try_render_static(context.view, child_id, config, &mut html_buf, context.space) {
+            if is_static_subtree(context.view, child_id, config) {
                 // Accumulate consecutive static siblings
+                let group_start = i;
+                let mut text_only = is_text_node(context.view, child_id);
                 i += 1;
                 while i < child_count {
                     let next_id = context.view.get_children(parent_id)[i];
-                    if !try_render_static(
-                        context.view,
-                        next_id,
-                        config,
-                        &mut html_buf,
-                        context.space,
-                    ) {
+                    if !is_static_subtree(context.view, next_id, config) {
                         break;
                     }
+                    text_only &= is_text_node(context.view, next_id);
                     i += 1;
                 }
-                if !html_buf.is_empty() {
-                    result.push(create_raw_html_jsx(context.allocator, &html_buf, config));
+                if text_only {
+                    // Text carries no markup, and hosts may discard a whitespace-only raw-HTML carrier.
+                    for j in group_start..i {
+                        let text_id = context.view.get_children(parent_id)[j];
+                        if let Some(child) = transform_text(context, text_id) {
+                            result.push(child);
+                        }
+                    }
+                } else {
+                    let mut html_buf = String::new();
+                    render_static_group(
+                        context.view,
+                        &context.view.get_children(parent_id)[group_start..i],
+                        &mut html_buf,
+                        context.space,
+                    );
+                    if !html_buf.is_empty() {
+                        result.push(create_raw_html_jsx(context.allocator, &html_buf, config));
+                    }
                 }
             } else {
                 if let Some(child) = one(context, child_id, explicit_jsxs)? {

--- a/crates/satteri-mdxjs-rs/tests/test.rs
+++ b/crates/satteri-mdxjs-rs/tests/test.rs
@@ -642,6 +642,134 @@ fn optimize_static_nested_dynamic_prevents_collapse()
     Ok(())
 }
 
+// Issue withastro/compiler-rs#127: Astro's `renderJSX` drops a whitespace-only HTMLString.
+#[test]
+fn optimize_static_keeps_whitespace_between_components()
+-> Result<(), satteri_arena::mdx_types::Message> {
+    let result = compile(
+        "<Span>hello</Span> <Span>world</Span>",
+        &Options {
+            optimize_static: Some(OptimizeStaticConfig::default()),
+            ..Default::default()
+        },
+        MDX_OPTS,
+    )?;
+    assert!(
+        result.contains("\"\\n\""),
+        "separator should be a plain string child: {result}"
+    );
+    assert!(
+        !result.contains("set:html"),
+        "text-only children should not be routed through the raw-HTML prop: {result}"
+    );
+    Ok(())
+}
+
+#[test]
+fn optimize_static_keeps_whitespace_between_inline_components()
+-> Result<(), satteri_arena::mdx_types::Message> {
+    let result = compile(
+        "Prose before <Span>hello</Span> <Span>world</Span> prose after.",
+        &Options {
+            optimize_static: Some(OptimizeStaticConfig::default()),
+            ..Default::default()
+        },
+        MDX_OPTS,
+    )?;
+    assert!(
+        result.contains("\" \""),
+        "inline separator should be a plain string child: {result}"
+    );
+    assert!(
+        !result.contains("set:html"),
+        "text-only children should not be routed through the raw-HTML prop: {result}"
+    );
+    Ok(())
+}
+
+#[test]
+fn optimize_static_text_only_group_is_not_html_escaped()
+-> Result<(), satteri_arena::mdx_types::Message> {
+    let result = compile(
+        "<Span>a</Span> & < <Span>b</Span>",
+        &Options {
+            optimize_static: Some(OptimizeStaticConfig::default()),
+            ..Default::default()
+        },
+        MDX_OPTS,
+    )?;
+    assert!(
+        result.contains("\" & < \""),
+        "text-only group should keep its characters verbatim: {result}"
+    );
+    assert!(
+        !result.contains("&amp;") && !result.contains("&lt;"),
+        "text-only group should not be HTML-escaped: {result}"
+    );
+    Ok(())
+}
+
+#[test]
+fn optimize_static_raw_and_comment_groups_stay_raw_html()
+-> Result<(), satteri_arena::mdx_types::Message> {
+    use satteri_arena::{ArenaBuilder, Hast};
+    use satteri_ast::hast::HastNodeType;
+    use satteri_ast::hast::codec::{encode_element_data, encode_text_data};
+    use satteri_mdxjs::compile_hast_arena;
+
+    let mut builder = ArenaBuilder::<Hast>::new(String::new());
+    builder.open_node_raw(HastNodeType::Root as u8);
+
+    let ignored_paragraph = |builder: &mut ArenaBuilder<Hast>| {
+        let tag = builder.alloc_string("p");
+        let value = builder.alloc_string("x");
+        builder.open_node_raw(HastNodeType::Element as u8);
+        builder.set_data_current(&encode_element_data(tag, &[]));
+        let text = builder.add_leaf_raw(HastNodeType::Text as u8);
+        builder
+            .arena_mut()
+            .set_type_data(text, &encode_text_data(value));
+        builder.close_node();
+    };
+
+    ignored_paragraph(&mut builder);
+    let comment_value = builder.alloc_string(" keep me ");
+    let comment = builder.add_leaf_raw(HastNodeType::Comment as u8);
+    builder
+        .arena_mut()
+        .set_type_data(comment, &encode_text_data(comment_value));
+
+    ignored_paragraph(&mut builder);
+    let raw_value = builder.alloc_string("<hr data-keep>");
+    let raw = builder.add_leaf_raw(HastNodeType::Raw as u8);
+    builder
+        .arena_mut()
+        .set_type_data(raw, &encode_text_data(raw_value));
+
+    builder.close_node();
+    let arena = builder.finish();
+
+    let result = compile_hast_arena(
+        &arena,
+        &Options {
+            optimize_static: Some(OptimizeStaticConfig {
+                ignore_elements: vec!["p".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )?;
+    assert!(
+        result.contains("\"set:html\": \"<!-- keep me -->\""),
+        "a comment-only group should keep the raw-HTML prop: {result}"
+    );
+    assert!(
+        result.contains("\"set:html\": \"<hr data-keep>\""),
+        "a raw-only group should keep the raw-HTML prop: {result}"
+    );
+    Ok(())
+}
+
 // optimize_static component override detection tests
 
 #[test]

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -1097,6 +1097,18 @@ describe("mdxToJs", () => {
     expect(js).toContain("Dynamic");
   });
 
+  // Issue withastro/compiler-rs#127: Astro's `renderJSX` drops a whitespace-only HTMLString.
+  test("optimizeStatic keeps whitespace between components as a plain string", () => {
+    const { code: js } = mdxToJs("<Span>hello</Span> <Span>world</Span>", {
+      optimizeStatic: {
+        component: "Fragment",
+        prop: "set:html",
+      },
+    });
+    expect(js).toContain('"\\n"');
+    expect(js).not.toContain("set:html");
+  });
+
   test("optimizeStatic off by default", () => {
     const { code: js } = mdxToJs("# Hello\n\nWorld");
     expect(js).not.toContain("set:html");


### PR DESCRIPTION
Fixes whitespace between adjacent custom components being dropped in MDX when static optimization is enabled (reported as withastro/compiler-rs#127).
