### PR TITLE
test: lock React-cased SVG attribute names to kebab-case output

### DIFF
--- a/.sampo/changesets/react-cased-svg-attributes.md
+++ b/.sampo/changesets/react-cased-svg-attributes.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-ast: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed React-cased SVG property names like `strokeLinecap` and `strokeLinejoin` leaking into HTML output as-is instead of serializing as `stroke-linecap` / `stroke-linejoin`. Attribute-name lookups are now case-insensitive, so every React casing of a known SVG attribute converts.

--- a/.sampo/changesets/react-cased-svg-attributes.md
+++ b/.sampo/changesets/react-cased-svg-attributes.md
@@ -1,7 +1,8 @@
 ---
+cargo/satteri-property-info: patch
 cargo/satteri-ast: patch
 cargo/satteri-napi: patch
 npm/satteri: patch
 ---
 
-Fixed React-cased SVG property names like `strokeLinecap` and `strokeLinejoin` leaking into HTML output as-is instead of serializing as `stroke-linecap` / `stroke-linejoin`. Attribute-name lookups are now case-insensitive, so every React casing of a known SVG attribute converts.
+Fixed React-cased SVG property names like `strokeLinecap` and `strokeLinejoin` leaking into HTML output as-is instead of serializing as `stroke-linecap` / `stroke-linejoin`.

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -338,6 +338,54 @@ mod tests {
     }
 
     #[test]
+    fn react_cased_svg_properties_convert() {
+        // Issue #193: React's own casing (`strokeLinecap`, not the canonical
+        // hast `strokeLineCap`) must also resolve through the table.
+        assert_eq!(svg("strokeLinecap"), "stroke-linecap");
+        assert_eq!(svg("strokeLinejoin"), "stroke-linejoin");
+        assert_eq!(svg("strokeDasharray"), "stroke-dasharray");
+        assert_eq!(svg("strokeDashoffset"), "stroke-dashoffset");
+        assert_eq!(svg("strokeMiterlimit"), "stroke-miterlimit");
+        assert_eq!(svg("xlinkHref"), "xlink:href");
+        assert_eq!(svg("xmlnsXlink"), "xmlns:xlink");
+    }
+
+    #[test]
+    fn react_camelization_of_every_kebab_svg_attribute_converts() {
+        // For every kebab/namespaced SVG attribute, the React-style
+        // camelization (drop `-`/`:`, uppercase the next letter) must map back
+        // to that attribute. aria-*/data-* are exempt: React keeps them kebab.
+        for (key, _, attribute, _) in super::SVG_TABLE {
+            // Rows are keyed in both attribute and property form; take the
+            // attribute-keyed row so each attribute is checked once.
+            if key != attribute
+                || attribute.starts_with("aria-")
+                || attribute.starts_with("data-")
+                || !attribute.contains(['-', ':'])
+            {
+                continue;
+            }
+            let mut react = String::with_capacity(attribute.len());
+            let mut upper = false;
+            for c in attribute.chars() {
+                if c == '-' || c == ':' {
+                    upper = true;
+                } else if upper {
+                    react.extend(c.to_uppercase());
+                    upper = false;
+                } else {
+                    react.push(c);
+                }
+            }
+            assert_eq!(
+                &property_to_attribute(&react, true),
+                attribute,
+                "react name {react}"
+            );
+        }
+    }
+
+    #[test]
     fn svg_lowercased_attributes() {
         assert_eq!(svg("crossOrigin"), "crossorigin");
         assert_eq!(svg("hrefLang"), "hreflang");

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -357,8 +357,8 @@ mod tests {
         // to that attribute. aria-*/data-* are exempt: React keeps them kebab.
         let mut checked = 0;
         for (key, _, attribute, _) in super::SVG_TABLE {
-            // Rows are keyed in both attribute and property form; take the
-            // attribute-keyed row so each attribute is checked once.
+            // Rows are keyed in both attribute and lowercased-property form;
+            // take the attribute-keyed row so each attribute is checked once.
             if key != attribute
                 || attribute.starts_with("aria-")
                 || attribute.starts_with("data-")
@@ -385,8 +385,8 @@ mod tests {
             );
             checked += 1;
         }
-        // Guard against the sweep going vacuous if the table keying changes:
-        // the stroke/fill/font families alone exceed this floor.
+        // Guard against the sweep silently going vacuous if the table keying
+        // changes; 96 attributes qualify at the time of writing.
         assert!(checked >= 50, "only {checked} attributes swept");
     }
 

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -355,6 +355,7 @@ mod tests {
         // For every kebab/namespaced SVG attribute, the React-style
         // camelization (drop `-`/`:`, uppercase the next letter) must map back
         // to that attribute. aria-*/data-* are exempt: React keeps them kebab.
+        let mut checked = 0;
         for (key, _, attribute, _) in super::SVG_TABLE {
             // Rows are keyed in both attribute and property form; take the
             // attribute-keyed row so each attribute is checked once.
@@ -382,7 +383,11 @@ mod tests {
                 attribute,
                 "react name {react}"
             );
+            checked += 1;
         }
+        // Guard against the sweep going vacuous if the table keying changes:
+        // the stroke/fill/font families alone exceed this floor.
+        assert!(checked >= 50, "only {checked} attributes swept");
     }
 
     #[test]

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -340,54 +340,22 @@ mod tests {
     #[test]
     fn react_cased_svg_properties_convert() {
         // Issue #193: React's own casing (`strokeLinecap`, not the canonical
-        // hast `strokeLineCap`) must also resolve through the table.
+        // hast `strokeLineCap`) must also resolve through the table. These are
+        // the only SVG names whose React casing differs from the canonical
+        // one; every other row is covered by the reverse-direction test below.
         assert_eq!(svg("strokeLinecap"), "stroke-linecap");
         assert_eq!(svg("strokeLinejoin"), "stroke-linejoin");
         assert_eq!(svg("strokeDasharray"), "stroke-dasharray");
         assert_eq!(svg("strokeDashoffset"), "stroke-dashoffset");
         assert_eq!(svg("strokeMiterlimit"), "stroke-miterlimit");
+        assert_eq!(svg("xlinkActuate"), "xlink:actuate");
+        assert_eq!(svg("xlinkArcrole"), "xlink:arcrole");
         assert_eq!(svg("xlinkHref"), "xlink:href");
+        assert_eq!(svg("xlinkRole"), "xlink:role");
+        assert_eq!(svg("xlinkShow"), "xlink:show");
+        assert_eq!(svg("xlinkTitle"), "xlink:title");
+        assert_eq!(svg("xlinkType"), "xlink:type");
         assert_eq!(svg("xmlnsXlink"), "xmlns:xlink");
-    }
-
-    #[test]
-    fn react_camelization_of_every_kebab_svg_attribute_converts() {
-        // For every kebab/namespaced SVG attribute, the React-style
-        // camelization (drop `-`/`:`, uppercase the next letter) must map back
-        // to that attribute. aria-*/data-* are exempt: React keeps them kebab.
-        let mut checked = 0;
-        for (key, _, attribute, _) in super::SVG_TABLE {
-            // Rows are keyed in both attribute and lowercased-property form;
-            // take the attribute-keyed row so each attribute is checked once.
-            if key != attribute
-                || attribute.starts_with("aria-")
-                || attribute.starts_with("data-")
-                || !attribute.contains(['-', ':'])
-            {
-                continue;
-            }
-            let mut react = String::with_capacity(attribute.len());
-            let mut upper = false;
-            for c in attribute.chars() {
-                if c == '-' || c == ':' {
-                    upper = true;
-                } else if upper {
-                    react.extend(c.to_uppercase());
-                    upper = false;
-                } else {
-                    react.push(c);
-                }
-            }
-            assert_eq!(
-                &property_to_attribute(&react, true),
-                attribute,
-                "react name {react}"
-            );
-            checked += 1;
-        }
-        // Guard against the sweep silently going vacuous if the table keying
-        // changes; 96 attributes qualify at the time of writing.
-        assert!(checked >= 50, "only {checked} attributes swept");
     }
 
     #[test]

--- a/packages/satteri/test/html-plugin.test.ts
+++ b/packages/satteri/test/html-plugin.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../index.js";
 import { HastReader } from "../src/hast/hast-reader.js";
 import { visitHastHandle, resolveSubscriptions } from "../src/hast/hast-visitor.js";
-import { markdownToHtml, defineMdastPlugin } from "../src/index.js";
+import { markdownToHtml, defineMdastPlugin, defineHastPlugin } from "../src/index.js";
 import type { MdastNode } from "../src/types.js";
 import type { HastNode } from "../src/hast/hast-materializer.js";
 import type { HastVisitorContext, HastVisitorInstance } from "../src/hast/hast-visitor.js";
@@ -216,6 +216,27 @@ describe("HAST plugins affecting HTML output", () => {
     dropHandle(handle);
     expect(texts).toContain("Hello ");
     expect(texts).toContain("world");
+  });
+
+  test("appended SVG child converts React-cased properties to kebab-case (#193)", () => {
+    const plugin = defineHastPlugin({
+      name: "svg-append",
+      element: {
+        filter: ["p"],
+        visit(node, ctx) {
+          ctx.appendChild(node, {
+            type: "element",
+            tagName: "svg",
+            properties: { strokeWidth: "1.2", strokeLinecap: "round", strokeLinejoin: "miter" },
+            children: [],
+          });
+        },
+      },
+    });
+    const { html } = markdownToHtml("hello", { hastPlugins: [plugin] });
+    expect(html).toContain(
+      '<svg stroke-width="1.2" stroke-linecap="round" stroke-linejoin="miter">',
+    );
   });
 
   test("HAST visitor: setProperty mutation is applied to elements", () => {

--- a/packages/satteri/test/html-plugin.test.ts
+++ b/packages/satteri/test/html-plugin.test.ts
@@ -228,7 +228,14 @@ describe("HAST plugins affecting HTML output", () => {
             type: "element",
             tagName: "svg",
             properties: { strokeWidth: "1.2", strokeLinecap: "round", strokeLinejoin: "miter" },
-            children: [],
+            children: [
+              {
+                type: "element",
+                tagName: "path",
+                properties: { strokeLinecap: "round", fillRule: "evenodd" },
+                children: [],
+              },
+            ],
           });
         },
       },
@@ -237,6 +244,8 @@ describe("HAST plugins affecting HTML output", () => {
     expect(html).toContain(
       '<svg stroke-width="1.2" stroke-linecap="round" stroke-linejoin="miter">',
     );
+    // Descendants inherit the SVG schema, not just the <svg> element itself.
+    expect(html).toContain('<path stroke-linecap="round" fill-rule="evenodd">');
   });
 
   test("HAST visitor: setProperty mutation is applied to elements", () => {


### PR DESCRIPTION
Closes #193.

**The bug** (satteri 0.9.5): plugin properties written in React casing, such as `strokeLinecap`, were copied into HTML output unchanged. Browsers ignore `strokeLinecap="round"`; they need `stroke-linecap="round"`.

**The fix already exists on `main`.** PR #140 replaced the old name-conversion code with a table lookup that ignores letter case. I verified this with the repro from the issue: the HTML output is kebab-case now. But no test proves it, and the changelog does not mention it.

**This PR adds tests and a changelog entry. It has no runtime changes.**

- A Rust test that checks all 13 SVG names whose React spelling differs from the spelling in the table (`strokeLinecap`, `xlinkHref`, and the rest). All other names are identical in both spellings, and an existing test already covers them.
- A JS test that mirrors the repro from the issue: a plugin appends an `<svg>` element with a `<path>` child, both with React-cased props. The test checks that the HTML output is kebab-case on both elements.
- A changeset, so the fix appears in the changelog of the next release.

**Found during review, not fixed here:** on the MDX path with `elementAttributeNameCase: "html"`, a nested `<svg>` element's own attributes still skip the SVG name table. Filed as #208. Root-node `setProperty` casing is also separate (#192).