### PR TITLE
fix(mdx): resolve the link tail by replaying the line, not walking back

### DIFF
--- a/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
+++ b/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
@@ -4,4 +4,4 @@ cargo/satteri-napi: patch
 npm/satteri: patch
 ---
 
-Fixed a `{` inside an MDX link destination or title raising a parse error when the tail holds an escaped or quoted `)`, as in `[a](\){)`, and stopped a link tail forming from a `[` that is backslash-escaped, inside a code span, or already wrapped by another link.
+Fixed a `{` inside an MDX link destination or title raising a parse error when the tail holds an escaped or quoted `)`, as in `[a](\){)`, and stopped a link tail forming from a `[` that is backslash-escaped, inside a code span, already wrapped by another link, or in an earlier block.

--- a/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
+++ b/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
@@ -4,4 +4,4 @@ cargo/satteri-napi: patch
 npm/satteri: patch
 ---
 
-Fixed a `{` inside an MDX link destination or title raising a parse error when the tail holds an escaped or quoted `)`, as in `[a](\){)`, and stopped a `[` that is backslash-escaped or inside a code span from opening a link tail.
+Fixed a `{` inside an MDX link destination or title raising a parse error when the tail holds an escaped or quoted `)`, as in `[a](\){)`, and stopped a link tail forming from a `[` that is backslash-escaped, inside a code span, or already wrapped by another link.

--- a/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
+++ b/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed a `{` inside an MDX link destination or title raising a parse error when the tail also holds an escaped or quoted `)`, as in `[a](\){)`.

--- a/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
+++ b/.sampo/changesets/mdx-link-tail-brace-escaped-paren.md
@@ -4,4 +4,4 @@ cargo/satteri-napi: patch
 npm/satteri: patch
 ---
 
-Fixed a `{` inside an MDX link destination or title raising a parse error when the tail also holds an escaped or quoted `)`, as in `[a](\){)`.
+Fixed a `{` inside an MDX link destination or title raising a parse error when the tail holds an escaped or quoted `)`, as in `[a](\){)`, and stopped a `[` that is backslash-escaped or inside a code span from opening a link tail.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4315,77 +4315,60 @@ fn scope_end_with_prefix(bytes: &[u8], cur_line_start: usize, prefix: usize) -> 
     i
 }
 
-/// True if the byte at `pos` sits inside a CommonMark link URL `[...](...)`
-/// — i.e. there is an unmatched `(` between `pos` and the start of the
-/// current line, immediately preceded by `]`, that `]` is balanced by an
-/// earlier `[` on the same line, AND the `(` has a matching `)` ahead on
-/// the same line. mdx-js does not evaluate expressions in link URLs (URL
-/// `{x}` is literal text, URL-encoded at render time), so we treat `{`
-/// here as plain text rather than an expression start. This both avoids a
-/// hard error on unmatched `{` inside a valid URL (e.g. `[a]({)`) and
-/// removes a brittle dance where the link resolver previously had to
-/// reabsorb a stray `MdxTextExpression` token.
+/// True if the byte at `pos` sits inside a CommonMark link tail `[...](...)`,
+/// that is, some `](` earlier on the line opens a tail that parses as
+/// destination, optional title, `)` and encloses `pos`. mdx-js does not
+/// evaluate expressions in link URLs (URL `{x}` is literal text, URL-encoded
+/// at render time), so we treat `{` here as plain text rather than an
+/// expression start. This both avoids a hard error on unmatched `{` inside a
+/// valid URL (e.g. `[a]({)`) and removes a brittle dance where the link
+/// resolver previously had to reabsorb a stray `MdxTextExpression` token.
 ///
-/// When the `(` is unmatched (no closing `)` on the line), the link won't
-/// form. mdx-js then falls back to expression scanning and errors on the
-/// dangling `{`. We mirror that by returning false in this case so the
-/// caller can run the expression scanner.
+/// When no such tail encloses `pos` the link won't form. mdx-js then falls
+/// back to expression scanning and errors on a dangling `{`. We mirror that
+/// by returning false so the caller can run the expression scanner.
 ///
-/// CommonMark forbids URLs from spanning a blank line, so per-line scans
-/// are sufficient in both directions.
+/// Line-bounded, so a resource spanning lines is a known divergence.
 #[cfg(feature = "mdx")]
 fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
-    // Fast reject: walkback returns false on first newline, so a `(` past
-    // the current line can't reach pos. Skip the walk when this line has
-    // no `(` before pos.
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
         .map(|i| i + 1)
         .unwrap_or(0);
-    if memchr::memchr(b'(', &bytes[line_start..pos]).is_none() {
-        return false;
+    // A `)` may be escaped or quoted, so paren depth is not countable backwards.
+    let mut end = pos;
+    let mut cached_line_end = None;
+    while let Some(rel) = memchr::memrchr(b']', &bytes[line_start..end]) {
+        let rbracket = line_start + rel;
+        end = rbracket;
+        if bytes.get(rbracket + 1) != Some(&b'(') {
+            continue;
+        }
+        let line_end = *cached_line_end.get_or_insert_with(|| {
+            memchr::memchr2(b'\n', b'\r', &bytes[pos..]).map_or(bytes.len(), |i| pos + i)
+        });
+        if link_tail_well_formed(bytes, rbracket + 1, pos, line_end)
+            && has_label_start(bytes, rbracket)
+        {
+            return true;
+        }
     }
-    let mut paren_depth: i32 = 0;
-    let mut i = pos;
-    while i > 0 {
-        i -= 1;
-        match bytes[i] {
+    false
+}
+
+/// True if the `]` at `rbracket` is matched by a `[` earlier on the line.
+#[cfg(feature = "mdx")]
+fn has_label_start(bytes: &[u8], rbracket: usize) -> bool {
+    let mut depth: i32 = 1;
+    let mut j = rbracket;
+    while j > 0 {
+        j -= 1;
+        match bytes[j] {
             b'\n' | b'\r' => return false,
-            b')' => paren_depth += 1,
-            b'(' => {
-                if paren_depth == 0 {
-                    // Unmatched `(` to our left. If it's immediately
-                    // preceded by `]`, this is the link-tail open. Verify
-                    // and return.
-                    if i > 0 && bytes[i - 1] == b']' {
-                        let mut j = i - 1; // position of `]`
-                        let mut bracket_depth: i32 = 1;
-                        while j > 0 {
-                            j -= 1;
-                            match bytes[j] {
-                                b'\n' | b'\r' => return false,
-                                b']' => bracket_depth += 1,
-                                b'[' => {
-                                    bracket_depth -= 1;
-                                    if bracket_depth == 0 {
-                                        // Bracket pair matches. Confirm the
-                                        // `(` closes properly and any quoted
-                                        // title is closed.
-                                        return link_tail_well_formed(bytes, i, pos);
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        return false;
-                    }
-                    // Otherwise: this `(` may be a paren-delimited title
-                    // open inside an outer `](...)` link tail (e.g.
-                    // `[a](/u (ti{w))`). Continue walking — we'll find the
-                    // outer `](` if it exists. Leave `paren_depth` at 0
-                    // (effectively treating this `(` as already matched
-                    // by a `)` past `pos`).
-                } else {
-                    paren_depth -= 1;
+            b']' => depth += 1,
+            b'[' => {
+                depth -= 1;
+                if depth == 0 {
+                    return true;
                 }
             }
             _ => {}
@@ -4401,10 +4384,7 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
 /// link won't form, so any `{` inside it should be treated as an expression
 /// start.
 #[cfg(feature = "mdx")]
-fn link_tail_well_formed(bytes: &[u8], lparen: usize, pos: usize) -> bool {
-    let line_end =
-        memchr::memchr2(b'\n', b'\r', &bytes[lparen..]).map_or(bytes.len(), |i| lparen + i);
-
+fn link_tail_well_formed(bytes: &[u8], lparen: usize, pos: usize, line_end: usize) -> bool {
     let mut i = lparen + 1;
     i += scan_while(&bytes[i..line_end], is_space_or_tab);
     let Some(dest_end) = scan_link_tail_dest(bytes, i, line_end) else {

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4492,7 +4492,13 @@ fn earlier_lines_are_ambiguous(bytes: &[u8], scope_start: usize, line_start: usi
     if matches!(bytes.get(line_start), Some(b'{') | Some(b'<')) {
         return true;
     }
-    memchr::memchr(b'<', &bytes[scope_start..line_start]).is_some()
+    // Only a `<` that can open a tag competes with the label; `5 < 6` cannot.
+    memchr::memchr_iter(b'<', &bytes[scope_start..line_start]).any(|rel| {
+        matches!(
+            bytes.get(scope_start + rel + 1),
+            Some(c) if c.is_ascii_alphabetic() || matches!(c, b'/' | b'>' | b'!' | b'?' | b'_' | b'$')
+        )
+    })
 }
 
 /// End of the line holding `i`.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4315,13 +4315,9 @@ fn scope_end_with_prefix(bytes: &[u8], cur_line_start: usize, prefix: usize) -> 
     i
 }
 
-/// A link tail that never closes is only known to have failed once its scan
-/// reaches the line end, so an adversarial line could otherwise force one full
-/// rescan per `](`. Past this many failures the replay gives up and reports
-/// `pos` as outside a tail, which errs toward the expression scanner and so
-/// toward rejecting rather than accepting.
+/// Deeper label starts are taken as links, which only ever withholds a tail.
 #[cfg(feature = "mdx")]
-const LINK_TAIL_MAX_FAILED_SCANS: u32 = 32;
+const LINK_LABEL_MAX_TRACKED_DEPTH: u32 = 64;
 
 /// True if the byte at `pos` sits inside a CommonMark link tail `[...](...)`,
 /// that is, some `](` earlier on the line opens a tail that parses as
@@ -4342,55 +4338,141 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
         .map(|i| i + 1)
         .unwrap_or(0);
-    // A tail enclosing `pos` has its `](` wholly before `pos`.
+    // A tail is line-bounded, so one enclosing `pos` opens on `pos`'s own line.
     if !memchr::memchr_iter(b']', &bytes[line_start..pos])
         .any(|rel| bytes.get(line_start + rel + 1) == Some(&b'('))
     {
         return false;
     }
-    let line_end = memchr::memchr2(b'\n', b'\r', &bytes[pos..]).map_or(bytes.len(), |i| pos + i);
+    match replay_link_tails(bytes, pos, line_start, line_end_at(bytes, pos)) {
+        TailReplay::Inside => true,
+        TailReplay::Outside => false,
+        // Only now is the paragraph worth the walk it costs to find.
+        TailReplay::StrandedLabel => {
+            let paragraph_start = lazy_paragraph_start(bytes, pos);
+            paragraph_start < line_start
+                && matches!(
+                    replay_link_tails(bytes, pos, paragraph_start, scope_for_inline(bytes, pos).1),
+                    TailReplay::Inside
+                )
+        }
+    }
+}
 
-    // Escapes and code spans only resolve left to right, so the line is replayed.
-    let mut label_starts: u32 = 0;
-    let mut failed_tails: u32 = 0;
-    let mut i = line_start;
+#[cfg(feature = "mdx")]
+enum TailReplay {
+    Inside,
+    Outside,
+    /// A `](` needed a label start that `from` was too late to have seen.
+    StrandedLabel,
+}
+
+/// Replays `from..pos` the way micromark tokenizes inline content, tracking the
+/// constructs that can own a bracket, and reports where `pos` landed.
+#[cfg(feature = "mdx")]
+fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) -> TailReplay {
+    let mut depth: u32 = 0;
+    let mut image_kinds: u64 = 0;
+    let mut inactive_below: u32 = 0;
+    let mut stranded = false;
+    let mut i = from;
     while i < pos {
         match bytes[i] {
-            b'\\' if i + 1 < line_end && is_ascii_punctuation(bytes[i + 1]) => i += 2,
+            b'\\' if i + 1 < scope_end && is_ascii_punctuation(bytes[i + 1]) => i += 2,
             b'`' => {
-                let run = 1 + scan_ch_repeat(&bytes[i + 1..line_end], b'`');
-                i = code_span_end(bytes, i + run, line_end, run).unwrap_or(i + run);
+                let run = 1 + scan_ch_repeat(&bytes[i + 1..scope_end], b'`');
+                match code_span_end(bytes, i + run, scope_end, run) {
+                    // `pos` is code text, literal for the same reason a URL's is.
+                    Some(end) if end > pos => return TailReplay::Inside,
+                    Some(end) => i = end,
+                    None => i += run,
+                }
+            }
+            b'!' if bytes.get(i + 1) == Some(&b'[') => {
+                depth += 1;
+                if depth <= LINK_LABEL_MAX_TRACKED_DEPTH {
+                    image_kinds |= 1 << (depth - 1);
+                }
+                i += 2;
             }
             b'[' => {
-                label_starts += 1;
+                depth += 1;
+                if depth <= LINK_LABEL_MAX_TRACKED_DEPTH {
+                    image_kinds &= !(1 << (depth - 1));
+                }
                 i += 1;
             }
             b']' => {
-                if label_starts > 0 {
-                    label_starts -= 1;
-                    if bytes.get(i + 1) == Some(&b'(') {
-                        match link_tail_close(bytes, i + 1, line_end) {
-                            Some(rparen) if rparen > pos => return true,
-                            Some(rparen) => {
-                                i = rparen + 1;
-                                continue;
-                            }
-                            // A failed tail rescans to the line end, so cap them.
-                            None => {
-                                failed_tails += 1;
-                                if failed_tails > LINK_TAIL_MAX_FAILED_SCANS {
-                                    return false;
-                                }
-                            }
-                        }
+                if depth == 0 {
+                    stranded |= bytes.get(i + 1) == Some(&b'(');
+                    i += 1;
+                    continue;
+                }
+                let is_image =
+                    depth <= LINK_LABEL_MAX_TRACKED_DEPTH && image_kinds & (1 << (depth - 1)) != 0;
+                let active = is_image || depth > inactive_below;
+                depth -= 1;
+                inactive_below = inactive_below.min(depth);
+                if active
+                    && bytes.get(i + 1) == Some(&b'(')
+                    && let Some(rparen) = link_tail_close(bytes, i + 1, line_end_at(bytes, i))
+                {
+                    if rparen > pos {
+                        return TailReplay::Inside;
                     }
+                    // A link, unlike an image, deactivates the starts around it.
+                    if !is_image {
+                        inactive_below = depth;
+                    }
+                    i = rparen + 1;
+                    continue;
                 }
                 i += 1;
             }
             _ => i += 1,
         }
     }
-    false
+    if stranded {
+        TailReplay::StrandedLabel
+    } else {
+        TailReplay::Outside
+    }
+}
+
+/// Start of the paragraph holding `pos`, treating a line whose container
+/// prefix is shallower than its predecessor's as a lazy continuation of it.
+#[cfg(feature = "mdx")]
+fn lazy_paragraph_start(bytes: &[u8], pos: usize) -> usize {
+    let mut line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let mut prefix = leading_container_prefix(&bytes[line_start..]);
+    while line_start > 0 && !line_opens_list_item(bytes, line_start) {
+        let mut prev_end = line_start - 1;
+        if prev_end > 0 && bytes[prev_end] == b'\n' && bytes[prev_end - 1] == b'\r' {
+            prev_end -= 1;
+        }
+        let prev_start = memchr::memrchr2(b'\n', b'\r', &bytes[..prev_end])
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let prev_line = &bytes[prev_start..prev_end];
+        if prev_line.iter().all(|&b| b == b' ' || b == b'\t') {
+            break;
+        }
+        let prev_prefix = leading_container_prefix(prev_line);
+        if prev_prefix < prefix {
+            break;
+        }
+        prefix = prev_prefix;
+        line_start = prev_start;
+    }
+    line_start
+}
+
+/// End of the line holding `i`.
+#[cfg(feature = "mdx")]
+fn line_end_at(bytes: &[u8], i: usize) -> usize {
+    memchr::memchr2(b'\n', b'\r', &bytes[i..]).map_or(bytes.len(), |k| i + k)
 }
 
 /// End of the code span opened by a `run`-long backtick run, per CommonMark's
@@ -4483,6 +4565,8 @@ fn scan_link_tail_title(bytes: &[u8], start: usize, line_end: usize) -> Option<u
         b'(' => b')',
         _ => return None,
     };
+    // An escaped close is still a close byte, so this rejects without accepting.
+    memchr::memchr(close, &bytes[start + 1..line_end])?;
 
     let mut i = start + 1;
     while i < line_end {

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4369,14 +4369,14 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bo
         return false;
     }
     let line_end = line_end_at(bytes, pos);
-    match replay_link_tails(bytes, pos, line_start, line_end) {
+    match replay_link_tails(bytes, pos, line_start, line_end, scope_start >= line_start) {
         TailReplay::Inside => true,
         TailReplay::Outside => false,
         // `scope_start` is the block's own start, so this cannot cross into one.
         TailReplay::NeedsScope => {
             scope_start < line_start
                 && matches!(
-                    replay_link_tails(bytes, pos, scope_start, line_end),
+                    replay_link_tails(bytes, pos, scope_start, line_end, true),
                     TailReplay::Inside
                 )
         }
@@ -4395,13 +4395,22 @@ enum TailReplay {
 /// Replays `from..pos` the way micromark tokenizes inline content, tracking the
 /// constructs that can own a bracket, and reports where `pos` landed.
 #[cfg(feature = "mdx")]
-fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) -> TailReplay {
+fn replay_link_tails(
+    bytes: &[u8],
+    pos: usize,
+    from: usize,
+    scope_end: usize,
+    at_block_start: bool,
+) -> TailReplay {
     let mut depth: u32 = 0;
     let mut image_kinds: u64 = 0;
     let mut inactive_below: u32 = 0;
     let mut closes = TitleCloses::default();
     let mut needs_scope = false;
     let mut i = from;
+    // Refreshed only when `i` crosses a newline; rescanning per candidate makes
+    // an ordinary line of links quadratic.
+    let mut tail_line_end = line_end_at(bytes, from);
     while i < pos {
         match bytes[i] {
             b'\\' if i + 1 < scope_end && is_ascii_punctuation(bytes[i + 1]) => i += 2,
@@ -4409,8 +4418,14 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
                 needs_scope = true;
                 let run = 1 + scan_ch_repeat(&bytes[i + 1..scope_end], b'`');
                 match code_span_end(bytes, i + run, scope_end, run) {
-                    // `pos` is code text, literal for the same reason a URL's is.
-                    Some(end) if end > pos => return TailReplay::Inside,
+                    // Only a replay from the block start can vouch for a pairing.
+                    Some(end) if end > pos => {
+                        return if at_block_start {
+                            TailReplay::Inside
+                        } else {
+                            TailReplay::NeedsScope
+                        };
+                    }
                     Some(end) => i = end,
                     None => i += run,
                 }
@@ -4435,6 +4450,9 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
                     i += 1;
                     continue;
                 }
+                if i >= tail_line_end {
+                    tail_line_end = line_end_at(bytes, i);
+                }
                 let is_image =
                     depth <= LINK_LABEL_MAX_TRACKED_DEPTH && image_kinds & (1 << (depth - 1)) != 0;
                 let active = is_image || depth > inactive_below;
@@ -4442,8 +4460,7 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
                 inactive_below = inactive_below.min(depth);
                 if active
                     && bytes.get(i + 1) == Some(&b'(')
-                    && let Some(rparen) =
-                        link_tail_close(bytes, i + 1, line_end_at(bytes, i), &mut closes)
+                    && let Some(rparen) = link_tail_close(bytes, i + 1, tail_line_end, &mut closes)
                 {
                     if rparen > pos {
                         return TailReplay::Inside;

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4375,6 +4375,7 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bo
         // `scope_start` is the block's own start, so this cannot cross into one.
         TailReplay::NeedsScope => {
             scope_start < line_start
+                && !earlier_lines_are_ambiguous(bytes, scope_start, line_start)
                 && matches!(
                     replay_link_tails(bytes, pos, scope_start, line_end, true),
                     TailReplay::Inside
@@ -4482,6 +4483,16 @@ fn replay_link_tails(
     } else {
         TailReplay::Outside
     }
+}
+
+/// True if an earlier line of the block could hand `line_start` a construct
+/// mdx-js resolves against the code span or tag satteri would keep.
+#[cfg(feature = "mdx")]
+fn earlier_lines_are_ambiguous(bytes: &[u8], scope_start: usize, line_start: usize) -> bool {
+    if matches!(bytes.get(line_start), Some(b'{') | Some(b'<')) {
+        return true;
+    }
+    memchr::memchr(b'<', &bytes[scope_start..line_start]).is_some()
 }
 
 /// End of the line holding `i`.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4315,6 +4315,14 @@ fn scope_end_with_prefix(bytes: &[u8], cur_line_start: usize, prefix: usize) -> 
     i
 }
 
+/// A link tail that never closes is only known to have failed once its scan
+/// reaches the line end, so an adversarial line could otherwise force one full
+/// rescan per `](`. Past this many failures the replay gives up and reports
+/// `pos` as outside a tail, which errs toward the expression scanner and so
+/// toward rejecting rather than accepting.
+#[cfg(feature = "mdx")]
+const LINK_TAIL_MAX_FAILED_SCANS: u32 = 32;
+
 /// True if the byte at `pos` sits inside a CommonMark link tail `[...](...)`,
 /// that is, some `](` earlier on the line opens a tail that parses as
 /// destination, optional title, `)` and encloses `pos`. mdx-js does not
@@ -4334,62 +4342,80 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
         .map(|i| i + 1)
         .unwrap_or(0);
-    // A `)` may be escaped or quoted, so paren depth is not countable backwards.
-    let mut end = pos;
-    let mut cached_line_end = None;
-    while let Some(rel) = memchr::memrchr(b']', &bytes[line_start..end]) {
-        let rbracket = line_start + rel;
-        end = rbracket;
-        if bytes.get(rbracket + 1) != Some(&b'(') {
-            continue;
-        }
-        let line_end = *cached_line_end.get_or_insert_with(|| {
-            memchr::memchr2(b'\n', b'\r', &bytes[pos..]).map_or(bytes.len(), |i| pos + i)
-        });
-        if link_tail_well_formed(bytes, rbracket + 1, pos, line_end)
-            && has_label_start(bytes, rbracket)
-        {
-            return true;
-        }
+    // A tail enclosing `pos` has its `](` wholly before `pos`.
+    if !memchr::memchr_iter(b']', &bytes[line_start..pos])
+        .any(|rel| bytes.get(line_start + rel + 1) == Some(&b'('))
+    {
+        return false;
     }
-    false
-}
+    let line_end = memchr::memchr2(b'\n', b'\r', &bytes[pos..]).map_or(bytes.len(), |i| pos + i);
 
-/// True if the `]` at `rbracket` is matched by a `[` earlier on the line.
-#[cfg(feature = "mdx")]
-fn has_label_start(bytes: &[u8], rbracket: usize) -> bool {
-    let mut depth: i32 = 1;
-    let mut j = rbracket;
-    while j > 0 {
-        j -= 1;
-        match bytes[j] {
-            b'\n' | b'\r' => return false,
-            b']' => depth += 1,
-            b'[' => {
-                depth -= 1;
-                if depth == 0 {
-                    return true;
-                }
+    // Escapes and code spans only resolve left to right, so the line is replayed.
+    let mut label_starts: u32 = 0;
+    let mut failed_tails: u32 = 0;
+    let mut i = line_start;
+    while i < pos {
+        match bytes[i] {
+            b'\\' if i + 1 < line_end && is_ascii_punctuation(bytes[i + 1]) => i += 2,
+            b'`' => {
+                let run = 1 + scan_ch_repeat(&bytes[i + 1..line_end], b'`');
+                i = code_span_end(bytes, i + run, line_end, run).unwrap_or(i + run);
             }
-            _ => {}
+            b'[' => {
+                label_starts += 1;
+                i += 1;
+            }
+            b']' => {
+                if label_starts > 0 {
+                    label_starts -= 1;
+                    if bytes.get(i + 1) == Some(&b'(') {
+                        match link_tail_close(bytes, i + 1, line_end) {
+                            Some(rparen) if rparen > pos => return true,
+                            Some(rparen) => {
+                                i = rparen + 1;
+                                continue;
+                            }
+                            // A failed tail rescans to the line end, so cap them.
+                            None => {
+                                failed_tails += 1;
+                                if failed_tails > LINK_TAIL_MAX_FAILED_SCANS {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+                i += 1;
+            }
+            _ => i += 1,
         }
     }
     false
 }
 
-/// True if the link tail opening at `lparen` parses as `(`, destination,
-/// optional whitespace-separated title, `)` on this line, and `pos` sits
-/// inside it. Used as a tighter check for `is_inside_link_url_parens`: a
-/// malformed tail (e.g. a plain URL followed by non-title bytes) means the
-/// link won't form, so any `{` inside it should be treated as an expression
-/// start.
+/// End of the code span opened by a `run`-long backtick run, per CommonMark's
+/// equal-length pairing, within a single line.
 #[cfg(feature = "mdx")]
-fn link_tail_well_formed(bytes: &[u8], lparen: usize, pos: usize, line_end: usize) -> bool {
+fn code_span_end(bytes: &[u8], from: usize, line_end: usize, run: usize) -> Option<usize> {
+    let mut i = from;
+    while let Some(rel) = memchr::memchr(b'`', &bytes[i..line_end]) {
+        let start = i + rel;
+        let len = 1 + scan_ch_repeat(&bytes[start + 1..line_end], b'`');
+        if len == run {
+            return Some(start + len);
+        }
+        i = start + len;
+    }
+    None
+}
+
+/// Index of the `)` closing the link tail opened at `lparen`, if it parses as
+/// `(`, destination, optional whitespace-separated title, `)` on this line.
+#[cfg(feature = "mdx")]
+fn link_tail_close(bytes: &[u8], lparen: usize, line_end: usize) -> Option<usize> {
     let mut i = lparen + 1;
     i += scan_while(&bytes[i..line_end], is_space_or_tab);
-    let Some(dest_end) = scan_link_tail_dest(bytes, i, line_end) else {
-        return false;
-    };
+    let dest_end = scan_link_tail_dest(bytes, i, line_end)?;
     i = dest_end + scan_while(&bytes[dest_end..line_end], is_space_or_tab);
     // Without separating whitespace the delimiter was part of the destination.
     if i > dest_end
@@ -4398,7 +4424,7 @@ fn link_tail_well_formed(bytes: &[u8], lparen: usize, pos: usize, line_end: usiz
         i = title_end + scan_while(&bytes[title_end..line_end], is_space_or_tab);
     }
 
-    i < line_end && bytes[i] == b')' && pos < i
+    (i < line_end && bytes[i] == b')').then_some(i)
 }
 
 /// End of the link destination starting at `start`, mirroring

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -653,6 +653,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                                     label_start,
                                     Some(label_end),
                                     TableParseMode::Disabled,
+                                    label_start,
                                 );
                                 self.tree.pop();
                             }
@@ -1215,7 +1216,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 body: ItemBody::TableCell,
             });
             self.tree.push();
-            let (next_ix, _brk) = self.parse_line(ix, None, TableParseMode::Active);
+            let (next_ix, _brk) = self.parse_line(ix, None, TableParseMode::Active, ix);
 
             self.tree[cell_ix].item.end = next_ix;
             self.tree.pop();
@@ -1336,7 +1337,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         });
         self.tree.push();
         if label_start < label_end {
-            self.parse_line(label_start, Some(label_end), TableParseMode::Disabled);
+            self.parse_line(
+                label_start,
+                Some(label_end),
+                TableParseMode::Disabled,
+                label_start,
+            );
         }
         self.tree.pop();
     }
@@ -1382,7 +1388,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             } else {
                 TableParseMode::Disabled
             };
-            let (next_ix, brk) = self.parse_line(ix, None, scan_mode);
+            let (next_ix, brk) = self.parse_line(ix, None, scan_mode, start_ix);
 
             // break out when we find a table
             if let Some(Item {
@@ -1633,7 +1639,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             }
 
             if let Some(tail_start) = tail_start {
-                self.parse_line(tail_start, Some(header_end), TableParseMode::Disabled);
+                self.parse_line(
+                    tail_start,
+                    Some(header_end),
+                    TableParseMode::Disabled,
+                    tail_start,
+                );
             }
         }
 
@@ -1787,6 +1798,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         start: usize,
         end: Option<usize>,
         mode: TableParseMode,
+        scope_start: usize,
     ) -> (usize, Option<Item>) {
         let bytes = self.text.as_bytes();
         let bytes = match end {
@@ -2142,7 +2154,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     // LaTeX (`\frac{-b}{2a}`) are math text, not expressions —
                     // matching block `$$` and the autolink math-span check.
                     if is_inside_code_span(bytes, ix)
-                        || is_inside_link_url_parens(bytes, ix)
+                        || is_inside_link_url_parens(bytes, ix, scope_start)
                         || is_inside_open_inline_jsx_tag(bytes, ix)
                         || (self.options.has_math() && is_inside_math_span(bytes, ix))
                     {
@@ -2385,7 +2397,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         // re-entering the inline scanner over the `[…]` span.
                         if label_start < label_end {
                             self.tree.push();
-                            self.parse_line(label_start, Some(label_end), TableParseMode::Disabled);
+                            self.parse_line(
+                                label_start,
+                                Some(label_end),
+                                TableParseMode::Disabled,
+                                label_start,
+                            );
                             self.tree.pop();
                         }
                         begin_text = end_pos;
@@ -3262,11 +3279,16 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             None
         };
         let (end, content_end, attrs) = if let Some((block, header_end)) = attr_block {
-            self.parse_line(ix, Some(block.block_open), TableParseMode::Disabled);
+            self.parse_line(ix, Some(block.block_open), TableParseMode::Disabled, ix);
             // Reparse the trailing directive run separately so it keeps its own `{...}`.
             let content_end = match block.tail_start {
                 Some(tail_start) => {
-                    self.parse_line(tail_start, Some(header_end), TableParseMode::Disabled);
+                    self.parse_line(
+                        tail_start,
+                        Some(header_end),
+                        TableParseMode::Disabled,
+                        tail_start,
+                    );
                     header_end
                 }
                 None => block.block_open,
@@ -3282,7 +3304,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             } else {
                 None
             };
-            let (line_ix, line_brk) = self.parse_line(ix, line_end, TableParseMode::Disabled);
+            let (line_ix, line_brk) = self.parse_line(ix, line_end, TableParseMode::Disabled, ix);
             ix = line_ix;
             // Backslash at end is actually hard line break
             if let Some(Item {
@@ -4332,9 +4354,11 @@ const LINK_LABEL_MAX_TRACKED_DEPTH: u32 = 64;
 /// back to expression scanning and errors on a dangling `{`. We mirror that
 /// by returning false so the caller can run the expression scanner.
 ///
-/// Line-bounded, so a resource spanning lines is a known divergence.
+/// Line-bounded, so a resource spanning lines is a known divergence. Label
+/// starts are not: `scope_start` is where the enclosing block's inline content
+/// begins, so one on an earlier line of the same block still counts.
 #[cfg(feature = "mdx")]
-fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
+fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bool {
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
         .map(|i| i + 1)
         .unwrap_or(0);
@@ -4344,15 +4368,15 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
     {
         return false;
     }
-    match replay_link_tails(bytes, pos, line_start, line_end_at(bytes, pos)) {
+    let line_end = line_end_at(bytes, pos);
+    match replay_link_tails(bytes, pos, line_start, line_end) {
         TailReplay::Inside => true,
         TailReplay::Outside => false,
-        // Only now is the paragraph worth the walk it costs to find.
-        TailReplay::StrandedLabel => {
-            let paragraph_start = lazy_paragraph_start(bytes, pos);
-            paragraph_start < line_start
+        // `scope_start` is the block's own start, so this cannot cross into one.
+        TailReplay::NeedsScope => {
+            scope_start < line_start
                 && matches!(
-                    replay_link_tails(bytes, pos, paragraph_start, scope_for_inline(bytes, pos).1),
+                    replay_link_tails(bytes, pos, scope_start, line_end),
                     TailReplay::Inside
                 )
         }
@@ -4363,8 +4387,9 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize) -> bool {
 enum TailReplay {
     Inside,
     Outside,
-    /// A `](` needed a label start that `from` was too late to have seen.
-    StrandedLabel,
+    /// The line alone cannot answer: a `](` wanted a label start it never saw,
+    /// or a backtick run whose pair may live on an earlier line.
+    NeedsScope,
 }
 
 /// Replays `from..pos` the way micromark tokenizes inline content, tracking the
@@ -4374,12 +4399,14 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
     let mut depth: u32 = 0;
     let mut image_kinds: u64 = 0;
     let mut inactive_below: u32 = 0;
-    let mut stranded = false;
+    let mut closes = TitleCloses::default();
+    let mut needs_scope = false;
     let mut i = from;
     while i < pos {
         match bytes[i] {
             b'\\' if i + 1 < scope_end && is_ascii_punctuation(bytes[i + 1]) => i += 2,
             b'`' => {
+                needs_scope = true;
                 let run = 1 + scan_ch_repeat(&bytes[i + 1..scope_end], b'`');
                 match code_span_end(bytes, i + run, scope_end, run) {
                     // `pos` is code text, literal for the same reason a URL's is.
@@ -4404,7 +4431,7 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
             }
             b']' => {
                 if depth == 0 {
-                    stranded |= bytes.get(i + 1) == Some(&b'(');
+                    needs_scope |= bytes.get(i + 1) == Some(&b'(');
                     i += 1;
                     continue;
                 }
@@ -4415,7 +4442,8 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
                 inactive_below = inactive_below.min(depth);
                 if active
                     && bytes.get(i + 1) == Some(&b'(')
-                    && let Some(rparen) = link_tail_close(bytes, i + 1, line_end_at(bytes, i))
+                    && let Some(rparen) =
+                        link_tail_close(bytes, i + 1, line_end_at(bytes, i), &mut closes)
                 {
                     if rparen > pos {
                         return TailReplay::Inside;
@@ -4432,41 +4460,11 @@ fn replay_link_tails(bytes: &[u8], pos: usize, from: usize, scope_end: usize) ->
             _ => i += 1,
         }
     }
-    if stranded {
-        TailReplay::StrandedLabel
+    if needs_scope {
+        TailReplay::NeedsScope
     } else {
         TailReplay::Outside
     }
-}
-
-/// Start of the paragraph holding `pos`, treating a line whose container
-/// prefix is shallower than its predecessor's as a lazy continuation of it.
-#[cfg(feature = "mdx")]
-fn lazy_paragraph_start(bytes: &[u8], pos: usize) -> usize {
-    let mut line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
-        .map(|i| i + 1)
-        .unwrap_or(0);
-    let mut prefix = leading_container_prefix(&bytes[line_start..]);
-    while line_start > 0 && !line_opens_list_item(bytes, line_start) {
-        let mut prev_end = line_start - 1;
-        if prev_end > 0 && bytes[prev_end] == b'\n' && bytes[prev_end - 1] == b'\r' {
-            prev_end -= 1;
-        }
-        let prev_start = memchr::memrchr2(b'\n', b'\r', &bytes[..prev_end])
-            .map(|i| i + 1)
-            .unwrap_or(0);
-        let prev_line = &bytes[prev_start..prev_end];
-        if prev_line.iter().all(|&b| b == b' ' || b == b'\t') {
-            break;
-        }
-        let prev_prefix = leading_container_prefix(prev_line);
-        if prev_prefix < prefix {
-            break;
-        }
-        prefix = prev_prefix;
-        line_start = prev_start;
-    }
-    line_start
 }
 
 /// End of the line holding `i`.
@@ -4494,14 +4492,19 @@ fn code_span_end(bytes: &[u8], from: usize, line_end: usize, run: usize) -> Opti
 /// Index of the `)` closing the link tail opened at `lparen`, if it parses as
 /// `(`, destination, optional whitespace-separated title, `)` on this line.
 #[cfg(feature = "mdx")]
-fn link_tail_close(bytes: &[u8], lparen: usize, line_end: usize) -> Option<usize> {
+fn link_tail_close(
+    bytes: &[u8],
+    lparen: usize,
+    line_end: usize,
+    closes: &mut TitleCloses,
+) -> Option<usize> {
     let mut i = lparen + 1;
     i += scan_while(&bytes[i..line_end], is_space_or_tab);
     let dest_end = scan_link_tail_dest(bytes, i, line_end)?;
     i = dest_end + scan_while(&bytes[dest_end..line_end], is_space_or_tab);
     // Without separating whitespace the delimiter was part of the destination.
     if i > dest_end
-        && let Some(title_end) = scan_link_tail_title(bytes, i, line_end)
+        && let Some(title_end) = scan_link_tail_title(bytes, i, line_end, closes)
     {
         i = title_end + scan_while(&bytes[title_end..line_end], is_space_or_tab);
     }
@@ -4552,33 +4555,82 @@ fn scan_link_tail_dest(bytes: &[u8], start: usize, line_end: usize) -> Option<us
     (nest == 0).then_some(i)
 }
 
+/// Running answer to "where does the next unescaped `\"`, `'` or `)` start".
+/// Tail attempts move forward, so each byte of a line is examined once per
+/// delimiter however many malformed tails ask.
+#[cfg(feature = "mdx")]
+#[derive(Default)]
+struct TitleCloses {
+    line_end: usize,
+    asked_from: [usize; 3],
+    found_at: [usize; 3],
+}
+
+#[cfg(feature = "mdx")]
+impl TitleCloses {
+    fn find(
+        &mut self,
+        bytes: &[u8],
+        kind: usize,
+        close: u8,
+        start: usize,
+        line_end: usize,
+    ) -> Option<usize> {
+        if self.line_end != line_end {
+            *self = Self {
+                line_end,
+                asked_from: [usize::MAX; 3],
+                found_at: [0; 3],
+            };
+        }
+        let cached = self.asked_from[kind];
+        if cached != usize::MAX && start >= cached && start <= self.found_at[kind] {
+            return (self.found_at[kind] < line_end).then_some(self.found_at[kind]);
+        }
+        // An escaped close is still a close byte, so absence settles it outright.
+        let mut i = if memchr::memchr(close, &bytes[start..line_end]).is_some() {
+            let mut j = start;
+            while j < line_end {
+                if bytes[j] == close {
+                    break;
+                }
+                if bytes[j] == b'\\' && j + 1 < line_end && is_ascii_punctuation(bytes[j + 1]) {
+                    j += 1;
+                }
+                j += 1;
+            }
+            j
+        } else {
+            line_end
+        };
+        i = i.min(line_end);
+        self.asked_from[kind] = start;
+        self.found_at[kind] = i;
+        (i < line_end).then_some(i)
+    }
+}
+
 /// End of the link title starting at `start`, mirroring `scan_link_title`
 /// within a single line: an unescaped `(` inside a paren title is content.
 #[cfg(feature = "mdx")]
-fn scan_link_tail_title(bytes: &[u8], start: usize, line_end: usize) -> Option<usize> {
+fn scan_link_tail_title(
+    bytes: &[u8],
+    start: usize,
+    line_end: usize,
+    closes: &mut TitleCloses,
+) -> Option<usize> {
     if start >= line_end {
         return None;
     }
-    let close = match bytes[start] {
-        b'\'' => b'\'',
-        b'"' => b'"',
-        b'(' => b')',
+    let (kind, close) = match bytes[start] {
+        b'\'' => (0, b'\''),
+        b'"' => (1, b'"'),
+        b'(' => (2, b')'),
         _ => return None,
     };
-    // An escaped close is still a close byte, so this rejects without accepting.
-    memchr::memchr(close, &bytes[start + 1..line_end])?;
-
-    let mut i = start + 1;
-    while i < line_end {
-        if bytes[i] == close {
-            return Some(i + 1);
-        }
-        if bytes[i] == b'\\' && i + 1 < line_end && is_ascii_punctuation(bytes[i + 1]) {
-            i += 1;
-        }
-        i += 1;
-    }
-    None
+    closes
+        .find(bytes, kind, close, start + 1, line_end)
+        .map(|i| i + 1)
 }
 
 /// True if the byte at `pos` is the first content char of its source line,

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -668,6 +668,16 @@ describe("MDX conformance: markdown elements", () => {
     await assertBothReject("```\nfence [x\n```\n](\\){)");
   });
 
+  test("a backtick closing an earlier line's span doesn't open a new one", async () => {
+    await assertMdxConformance("`x\n`a](b{1}`");
+    await assertMdxConformance("`x\n`a](b{1}`y");
+    await assertMdxConformance("``x\n``a](b{1}``");
+  });
+
+  test("a line of links with braces parses like any other", async () => {
+    await assertMdxConformance("[a](/u{x}) ".repeat(20));
+  });
+
   test("a label start earlier in the same paragraph does open one", async () => {
     await assertMdxConformance("[x\n\\[a]({)");
     await assertMdxConformance("> [x\n\\[a]({)");

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -689,6 +689,12 @@ describe("MDX conformance: markdown elements", () => {
     await assertMdxConformance("[`x`\n\\[a]({)");
   });
 
+  test("an angle bracket that cannot open a tag still lends its label start", async () => {
+    await assertMdxConformance("See the 5 < 6\n[a\nb](/u{z)");
+    await assertMdxConformance("a < b [x](/u{z)");
+    await assertBothReject("See a<3\n[a\nb](/u{z)");
+  });
+
   test("a label start earlier in the same paragraph does open one", async () => {
     await assertMdxConformance("[x\n\\[a]({)");
     await assertMdxConformance("> [x\n\\[a]({)");

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -661,6 +661,19 @@ describe("MDX conformance: markdown elements", () => {
     await assertMdxConformance("[a](x ".repeat(33) + "[b](/u{)");
   });
 
+  test("a label start in an earlier block does not open a tail", async () => {
+    await assertBothReject("# h [x\n](\\){)");
+    await assertBothReject("# h [x\n\\[a](\\){)");
+    await assertBothReject("---\n](\\){)");
+    await assertBothReject("```\nfence [x\n```\n](\\){)");
+  });
+
+  test("a label start earlier in the same paragraph does open one", async () => {
+    await assertMdxConformance("[x\n\\[a]({)");
+    await assertMdxConformance("> [x\n\\[a]({)");
+    await assertMdxConformance("- [x\n\\[a]({)");
+  });
+
   // Inline JSX spanning multiple paragraph lines must NOT be interrupted by a
   // later `</div>` (or other type-1/6 HTML tag) on its own line, because MDX
   // disables HTML blocks entirely. Without this, the paragraph splits at

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -618,6 +618,25 @@ describe("MDX conformance: markdown elements", () => {
     await assertBothReject("[a](/u){w");
   });
 
+  test("an escaped bracket is not a label delimiter, so no tail forms", async () => {
+    await assertBothReject("\\[a](\\){)");
+    await assertBothReject("[\\](\\){)");
+    await assertBothReject("[a\\](\\){)");
+    await assertBothReject("!\\[a](\\){)");
+    await assertBothReject('\\[a](/u "b](c {z")');
+  });
+
+  test("a `[` inside a code span is not a label start", async () => {
+    await assertBothReject("`[a`](\\){)");
+    await assertBothReject('`x[y` a](/u "b](c {z")');
+    await assertMdxConformance("`[a` [b](/u{z})");
+  });
+
+  test("a label start is consumed by the first `]`, not reused", async () => {
+    await assertBothReject("[a](/u) b](\\){)");
+    await assertMdxConformance("[a](/u) [b](\\){)");
+  });
+
   // Inline JSX spanning multiple paragraph lines must NOT be interrupted by a
   // later `</div>` (or other type-1/6 HTML tag) on its own line, because MDX
   // disables HTML blocks entirely. Without this, the paragraph splits at

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -678,6 +678,17 @@ describe("MDX conformance: markdown elements", () => {
     await assertMdxConformance("[a](/u{x}) ".repeat(20));
   });
 
+  test("an earlier line holding an open construct withholds its label start", async () => {
+    await assertBothReject("<div>html [x</div>\n]({)");
+    await assertBothReject("[`\n{`)]({)");
+    await assertBothReject("[`\n<`](><\\]`{! )");
+  });
+
+  test("an earlier line whose span closes here still lends its label start", async () => {
+    await assertMdxConformance("[`{\n`](}u{>!`{}[\\\\)");
+    await assertMdxConformance("[`x`\n\\[a]({)");
+  });
+
   test("a label start earlier in the same paragraph does open one", async () => {
     await assertMdxConformance("[x\n\\[a]({)");
     await assertMdxConformance("> [x\n\\[a]({)");

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -599,6 +599,25 @@ describe("MDX conformance: markdown elements", () => {
     await assertBothReject("[a](/u {w)");
   });
 
+  test("a `)` before the `{` that isn't the tail close keeps the tail", async () => {
+    await assertMdxConformance("[a](\\){)");
+    await assertMdxConformance('[a](/u "){")');
+    await assertMdxConformance("[a](<){>)");
+    await assertMdxConformance("![a](\\){)");
+    await assertMdxConformance("[a](/u (a\\){b))");
+  });
+
+  test("a `](` inside a title doesn't hide the tail that encloses it", async () => {
+    await assertMdxConformance('[a](/u "b](c {z")');
+    await assertMdxConformance("[a](/u (b](c {z))");
+    await assertMdxConformance('[a](/u "b](c {z}")');
+  });
+
+  test("a tail that closes before the `{` leaves it an expression", async () => {
+    await assertBothReject("[a](\\){)}");
+    await assertBothReject("[a](/u){w");
+  });
+
   // Inline JSX spanning multiple paragraph lines must NOT be interrupted by a
   // later `</div>` (or other type-1/6 HTML tag) on its own line, because MDX
   // disables HTML blocks entirely. Without this, the paragraph splits at

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -637,6 +637,30 @@ describe("MDX conformance: markdown elements", () => {
     await assertMdxConformance("[a](/u) [b](\\){)");
   });
 
+  test("an inner link deactivates the label starts around it", async () => {
+    await assertBothReject("[[a](/u)](\\){)");
+    await assertBothReject("[x [a](/u) y](\\){)");
+    // An image does not, so a linked image still takes a tail.
+    await assertMdxConformance("[![a](/i)](/u{z})");
+    await assertMdxConformance("[![a](/i)](\\){)");
+  });
+
+  test("a `{` inside a code span stays code text", async () => {
+    await assertMdxConformance("[a(`](!{{`[`})");
+    await assertMdxConformance("`a](b {c`");
+  });
+
+  test("a label start on an earlier line of the paragraph still counts", async () => {
+    await assertMdxConformance("[x\n\\[a]({)");
+    await assertMdxConformance("[a\n\\[](\\){)");
+    await assertMdxConformance("> [x\n\\[a]({)");
+  });
+
+  test("many malformed tails before the `{` do not change its meaning", async () => {
+    await assertMdxConformance("[a](x ".repeat(32) + "[b](/u{)");
+    await assertMdxConformance("[a](x ".repeat(33) + "[b](/u{)");
+  });
+
   // Inline JSX spanning multiple paragraph lines must NOT be interrupted by a
   // later `</div>` (or other type-1/6 HTML tag) on its own line, because MDX
   // disables HTML blocks entirely. Without this, the paragraph splits at


### PR DESCRIPTION
A `{` inside an MDX link destination or title is literal text, and satteri decided that by walking left from the brace to find the `](` opening the tail. That is the wrong direction: whether a `)` is structural, whether a `[` is backslash-escaped or inside a code span, whether an enclosing label start is still live, and where the enclosing block even began are all decidable only left to right. So the walk counted raw parens and lost the tail whenever a `)` was escaped, quoted, or inside a pointy destination, and it matched a `[` lexically even when that `[` could not open a label. `[a](\){)` and `[a](/u "b](c {z")` raised a parse error where @mdx-js/mdx compiles them, while `\[a](\){)` and `` `x[y` a](/u "b](c {z") `` were accepted where @mdx-js/mdx errors. This replaces the walk with a forward replay the way micromark tokenizes inline content: character escapes, code spans, a label-start stack that distinguishes image from link starts, the rule that a created link deactivates every label start still open around it, and a resource attempt at each `]` that pops a live one. The replay runs over the brace's own line and widens only when the line cannot answer, to the inline start of the block the parser is already in rather than to a paragraph guessed from the bytes; `parse_line` now carries that start, which is the one piece of context this decision cannot reconstruct from raw bytes. Widening is withheld in two cases: when the brace's own line begins with a `{` or a `<`, which competes with the label directly, and when an earlier line of the block holds an angle bracket that could open a tag. An angle bracket that cannot open one, as in `5 < 6`, withholds nothing.

Against @mdx-js/mdx 3.1.1, counted per corpus with both binaries run on every input and newly divergent meaning diverges here and agrees on the base: single-line 1,018,612 inputs, 4,276 fixed, 0 newly divergent; multi-line 247,966 inputs, 2,586 fixed, 0 newly divergent; block-boundary 103,771 inputs, 644 fixed, 0 newly divergent. Both sides of the widening guard are worth stating, because it is a trade rather than a free win: without it this branch fixed 8,320 inputs but left 139 accept-direction divergences, and with it the total is 7,506 fixed and none left in those corpora, so 832 fixes are forgone. Those 832 are not one shape. In these corpora every one trips the tag-capable angle bracket condition, across two lead shapes, while review of a separate corpus splits its equivalent set three ways: an unclosed code span on an earlier line, a tag-capable angle bracket, and a group that trips only the leading-brace condition and involves nothing left open across a line break at all. What is true of all of them is that each also diverges on the base, so this is never worse than the base, only less good than the unguarded version was while that version was shipping the 139.

Attribution is causal rather than by shape: rebuilding with this decision stubbed out and re-running every divergent input shows which ones only diverge because of it, and across all 21,291 divergent inputs in the three corpora above that number is 0. That zero is scoped to those corpora and is not a general claim. Four inputs found by a separate minimizer do survive, and they have been verified here: all four agree on the base, diverge on this branch in the accept direction, and agree again once the decision is stubbed out, so all four are caused by it. All four are multi-line. Review places them inside the resources-spanning-lines class this PR scopes out, and after checking each I only partly agree: one of the four has its resource opening on one line and closing on the next, which is squarely that class, but the other three have their resource entirely on the second line and only their label spanning the break, which is the case the widening path exists to handle rather than a case it excludes. They are recorded here as a known gap in that path rather than as covered by the existing scope-out.

The title guard that one stray closing byte could defeat is now a running cursor, so a repeated malformed title costs the same whether or not a `)` appears later, and the line end a tail is bounded by is carried through the replay instead of rescanned per candidate, which an ordinary line of links made quadratic. Of eight cachegrind workloads, six are faster than base, `tails` is +0.09%, and a long single line of links each holding an expression is +85% at a ratio that no longer grows with length; before the line-end fix that shape was 3.5x at 250 links and 8.4x at 1,000. Stacks on #213. Resources spanning lines remain divergent and out of scope, which the doc comment states.
