### PR TITLE
fix(links): require whitespace between a destination and its title

### DIFF
--- a/.sampo/changesets/link-title-needs-whitespace.md
+++ b/.sampo/changesets/link-title-needs-whitespace.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed a link title being accepted with no whitespace after a `<...>` destination, so `[a](<u>"t")` is now plain text like in remark.

--- a/crates/satteri-pulldown-cmark/src/parse.rs
+++ b/crates/satteri-pulldown-cmark/src/parse.rs
@@ -2172,9 +2172,13 @@ impl<'input> ParserInner<'input> {
         let dest = unescape(dest, self.tree.is_in_table());
         ix += dest_length;
 
+        let dest_end = ix;
         scan_separator(&mut ix);
 
-        let title = if let Some((bytes_scanned, t)) = self.scan_link_title(underlying, ix, node) {
+        // A title is only reachable through whitespace after the destination.
+        let title = if ix > dest_end
+            && let Some((bytes_scanned, t)) = self.scan_link_title(underlying, ix, node)
+        {
             ix += bytes_scanned;
             scan_separator(&mut ix);
             t

--- a/packages/satteri/test/conformance/link-edge-cases.test.ts
+++ b/packages/satteri/test/conformance/link-edge-cases.test.ts
@@ -274,6 +274,28 @@ describe("MDAST conformance: unescaped `(` inside a parenthesized title (#211)",
   });
 });
 
+describe("MDAST conformance: a link title needs whitespace after the destination", () => {
+  test("a title jammed against a pointy destination is not a link", () => {
+    assertMdastConformance('[a](<x>"t")');
+    assertMdastConformance("[a](<x>(t))");
+    assertMdastConformance("[a](<>'t')");
+    assertMdastConformance('![a](<x>"t")');
+  });
+
+  test("spaces or a line ending still separate a title", () => {
+    assertMdastConformance('[a](<x> "t")');
+    assertMdastConformance('[a](<x>\n"t")');
+    assertMdastConformance("[a](<x>)");
+    // A raw destination swallows the quotes, so this stays one link.
+    assertMdastConformance('[a](/u"t")');
+  });
+
+  test("reference definitions keep the same rule", () => {
+    assertMdastConformance('[a]: <x>"t"\n\n[a]\n');
+    assertMdastConformance('[a]: <x> "t"\n\n[a]\n');
+  });
+});
+
 describe("HTML conformance: YAML metadata block edge cases", () => {
   test("YAML frontmatter with leading blank line consumes the whole block", () => {
     // metadata_blocks_test_4: `---\n\ntitle:...\n---\n` — with frontmatter

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -701,6 +701,24 @@ describe("MDX conformance: markdown elements", () => {
     await assertMdxConformance("- [x\n\\[a]({)");
   });
 
+  test("a title jammed against a pointy destination leaves the `<` to JSX", async () => {
+    await assertBothReject("[a](<>())");
+    await assertBothReject('[a](<x>"")');
+    await assertBothReject('[a](<}>"")');
+    await assertBothReject("[a](</>'')");
+    await assertBothReject("![a](<>())");
+    await assertBothReject('[a]( <>"")');
+  });
+
+  test("a separated title still forms a link and `< >` stays text", async () => {
+    await assertMdxConformance('[a](<x> "t")');
+    await assertMdxConformance('[a](<x>\n"t")');
+    await assertMdxConformance("[a](<x>)");
+    await assertMdxConformance('[a](/u"t")');
+    await assertMdxConformance("[a](< >())");
+    await assertMdxConformance('[a](<u> "t") and [b](<v>) end');
+  });
+
   // Inline JSX spanning multiple paragraph lines must NOT be interrupted by a
   // later `</div>` (or other type-1/6 HTML tag) on its own line, because MDX
   // disables HTML blocks entirely. Without this, the paragraph splits at


### PR DESCRIPTION
satteri accepted a link title jammed straight against a pointy destination, so `[a](<u>"t")` and `[a](<>())` parsed as links. CommonMark only reaches a title through whitespace after the destination, and micromark's resource tokenizer agrees: anything but a space, tab or line ending there has to be the closing `)`. In MDX this was the only class where satteri accepted input @mdx-js/mdx rejects, since mdx-js fails the resource, resumes tokenizing and takes the `<` as a JSX tag or fragment that never closes. satteri already does the same once a tail fails, so the fix is in `scan_inline_link` rather than the JSX scanner: a title is only tried when the separator consumed something.

Across 948,429 generated inputs compared against @mdx-js/mdx 3.1.1 the 75 divergences of this shape go to zero, and a plain CommonMark sweep of 483,487 inputs against remark drops from 566 to 131, both with nothing newly divergent. The rest of that CommonMark residual is a separate multi-line title class that predates this branch. Cost is one comparison on a path that already ran, and cachegrind reads -0.003% Ir on the bench fixture and +0.11% on a synthetic file that is nothing but links. Stacks on #214.
