### PR TITLE
fix(emphasis): scope the tilde attention marker to GFM strikethrough

### DIFF
--- a/.sampo/changesets/gfm-disabled-tilde-emphasis.md
+++ b/.sampo/changesets/gfm-disabled-tilde-emphasis.md
@@ -1,5 +1,6 @@
 ---
 cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
 npm/satteri: patch
 ---
 

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -2080,11 +2080,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                         mode,
                         self.options,
                     );
-                    let is_valid_seq = c != b'~'
-                        || count == 2
-                        || (count == 1
-                            && (self.options.contains(Options::ENABLE_STRIKETHROUGH)
-                                || self.options.contains(Options::ENABLE_SUBSCRIPT)));
+                    let is_valid_seq = delim_run_is_valid(c, count, self.options);
 
                     if (can_open || can_close) && is_valid_seq {
                         self.tree.append_text(begin_text, ix, backslash_escaped);
@@ -4852,20 +4848,18 @@ fn delim_run_flags(
     )
 }
 
-/// `~` only forces an adjacent run open or closed while an extension gives it meaning.
-fn is_tilde_marker(c: char, options: Options) -> bool {
-    c == '~'
-        && (options.contains(Options::ENABLE_STRIKETHROUGH)
-            || options.contains(Options::ENABLE_SUBSCRIPT))
+/// Only GFM strikethrough ever adds `~` to micromark's attention markers.
+fn is_attention_marker(c: char, options: Options) -> bool {
+    c == '*' || c == '_' || (c == '~' && options.contains(Options::ENABLE_STRIKETHROUGH))
+}
+
+fn tilde_is_delimiter(options: Options) -> bool {
+    options.contains(Options::ENABLE_STRIKETHROUGH) || options.contains(Options::ENABLE_SUBSCRIPT)
 }
 
 /// A run of `~` only means anything at the lengths its extensions define.
 pub(crate) fn delim_run_is_valid(c: u8, count: usize, options: Options) -> bool {
-    c != b'~'
-        || count == 2
-        || (count == 1
-            && (options.contains(Options::ENABLE_STRIKETHROUGH)
-                || options.contains(Options::ENABLE_SUBSCRIPT)))
+    c != b'~' || count == 2 || (count == 1 && tilde_is_delimiter(options))
 }
 
 /// The delimiter run a `\` at `ix` would swallow, when the byte after it ends
@@ -5511,26 +5505,18 @@ fn delim_run_can_open(
         }
     }
     let delim = suffix.bytes().next().unwrap();
-    if delim == b'*'
-        && (next_char == '*' || next_char == '_' || is_tilde_marker(next_char, options))
-    {
+    if delim == b'*' && is_attention_marker(next_char, options) {
         return true;
     }
     if (delim == b'*' || delim == b'^') && !is_punctuation(next_char) {
         return true;
     }
-    // `~~` (and longer) follows the same flanking rules as `**`: it can open
-    // when followed by a non-punctuation char, OR when followed by punctuation
-    // BUT preceded by whitespace/punctuation (handled by the fall-through at
-    // the end of this function). Previously we returned `true` unconditionally
-    // here, which let `a~~/foo~~` open a strikethrough — GFM rejects that.
+    // GFM holds `~~` to the same flanking rules as `**`, so `a~~/foo~~` must not open.
     if delim == b'~' && run_len > 1 && !is_punctuation(next_char) {
         return true;
     }
     let prev_char = s[..ix].chars().last().unwrap();
-    // See the matching comment in `delim_run_can_close`: the
-    // `prev_char == '~'` shortcut bypasses standard flanking and lets pairing
-    // walk across escaped tildes, so it's now gated on subscript mode only.
+    // Subscript is intraword by design (`H~2~O`), unlike GFM strikethrough.
     if delim == b'~' && options.contains(Options::ENABLE_SUBSCRIPT) && !is_punctuation(next_char) {
         return true;
     }
@@ -5582,9 +5568,7 @@ fn delim_run_can_close(
         }
     }
     let delim = suffix.bytes().next().unwrap();
-    if delim == b'*'
-        && (prev_char == '*' || prev_char == '_' || is_tilde_marker(prev_char, options))
-    {
+    if delim == b'*' && is_attention_marker(prev_char, options) {
         return true;
     }
     if (delim == b'*' || delim == b'^') && !is_punctuation(prev_char) {
@@ -5593,10 +5577,7 @@ fn delim_run_can_close(
     if delim == b'~' && run_len > 1 && !is_punctuation(prev_char) {
         return true;
     }
-    // The `prev_char == '~'` shortcut historically let any `~`-adjacent run
-    // close, but that bypasses GFM's strict flanking rules and lets a run
-    // pair across an escaped (literal) `~`. Subscript mode depends on the
-    // relaxed pairing, so gate the shortcut on it.
+    // Subscript is intraword by design (`H~2~O`), unlike GFM strikethrough.
     if delim == b'~' && options.contains(Options::ENABLE_SUBSCRIPT) {
         return true;
     }
@@ -5633,9 +5614,7 @@ fn special_bytes(options: &Options) -> [bool; 256] {
     if options.contains(Options::ENABLE_TABLES) {
         bytes[b'|' as usize] = true;
     }
-    if options.contains(Options::ENABLE_STRIKETHROUGH)
-        || options.contains(Options::ENABLE_SUBSCRIPT)
-    {
+    if tilde_is_delimiter(*options) {
         bytes[b'~' as usize] = true;
     }
     if options.contains(Options::ENABLE_SUPERSCRIPT) {

--- a/crates/satteri-pulldown-cmark/tests/html.rs
+++ b/crates/satteri-pulldown-cmark/tests/html.rs
@@ -334,7 +334,7 @@ fn heading_attributes_disabled_keeps_literal_text() {
 }
 
 #[test]
-fn tilde_never_opens_emphasis_without_a_tilde_extension() {
+fn tilde_never_opens_emphasis_without_strikethrough() {
     assert_eq!("<p>a*~*</p>\n", parse_to_html("a*~*"));
     assert_eq!("<p>a*~x~*</p>\n", parse_to_html("a*~x~*"));
     assert_eq!("<p>a**~**</p>\n", parse_to_html("a**~**"));
@@ -349,5 +349,45 @@ fn tilde_opens_emphasis_with_strikethrough() {
     assert_eq!(
         "<p>a<em><del>x</del></em></p>\n",
         parse_to_html_ext("a*~x~*", Options::ENABLE_STRIKETHROUGH)
+    );
+    assert_eq!(
+        "<p>a<em><del>x</del></em></p>\n",
+        parse_to_html_ext("a*~~x~~*", Options::ENABLE_STRIKETHROUGH)
+    );
+}
+
+#[test]
+fn subscript_and_superscript_leave_an_intraword_star_run_closed() {
+    assert_eq!(
+        "<p>a*<sub>x</sub>*</p>\n",
+        parse_to_html_ext("a*~x~*", Options::ENABLE_SUBSCRIPT)
+    );
+    assert_eq!(
+        "<p>a*<sup>x</sup>*</p>\n",
+        parse_to_html_ext("a*^x^*", Options::ENABLE_SUPERSCRIPT)
+    );
+    assert_eq!(
+        "<p><em><sub>x</sub></em></p>\n",
+        parse_to_html_ext("*~x~*", Options::ENABLE_SUBSCRIPT)
+    );
+    assert_eq!(
+        "<p><em><sup>x</sup></em></p>\n",
+        parse_to_html_ext("*^x^*", Options::ENABLE_SUPERSCRIPT)
+    );
+    assert_eq!(
+        "<p>H<sub>2</sub>O</p>\n",
+        parse_to_html_ext("H~2~O", Options::ENABLE_SUBSCRIPT)
+    );
+}
+
+#[test]
+fn an_inert_tilde_run_does_not_open_emphasis_under_subscript() {
+    assert_eq!(
+        "<p>a*~~x~~*</p>\n",
+        parse_to_html_ext("a*~~x~~*", Options::ENABLE_SUBSCRIPT)
+    );
+    assert_eq!(
+        "<p>a~~x~~b</p>\n",
+        parse_to_html_ext("a~~x~~b", Options::ENABLE_SUBSCRIPT)
     );
 }


### PR DESCRIPTION
Follows up #212, which gated the `~` attention marker on strikethrough or subscript. micromark sources that marker from `micromark-extension-gfm-strikethrough` and nowhere else, and the shortcut it mirrors exists for no other reason, so the gate is now strikethrough alone. That also leaves `~` under subscript symmetric with `^` under superscript, which never forced an adjacent `*` run open or closed.

The visible effect is confined to intraword tilde with subscript on and GFM off: `a*~x~*` now parses as `a*<sub>x</sub>*` rather than `a<em><sub>x</sub></em>`, matching what `a*^x^*` already did, and `a*~~x~~*` stays literal now that a `~~` run subscript cannot use no longer opens emphasis. `*~x~*`, `H~2~O` and `a~x~b` are unchanged, and GFM output is byte-identical to #212 across the 29,969 case differential corpus.
