### PR TITLE
fix(mdx): keep the link tail when the resource spans lines

### DIFF
--- a/.sampo/changesets/mdx-multiline-link-resource-brace.md
+++ b/.sampo/changesets/mdx-multiline-link-resource-brace.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-pulldown-cmark: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed a `{` inside an MDX link destination or title raising a parse error when the link tail spans more than one line, as in `[a](/u\n"ti{tle")`.

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4359,9 +4359,11 @@ const LINK_LABEL_MAX_TRACKED_DEPTH: u32 = 64;
 /// `factoryWhitespace` and `factoryTitle` accepts line endings; only the
 /// destination is line-bounded. `scope_start` is where the enclosing block's
 /// inline content begins, so a tail opening on an earlier line of the same
-/// block still counts. Lazy and list-item continuations are a known
-/// divergence: the forward scan stops at a line that opens a block rather than
-/// tracking the enclosing container.
+/// block still counts, as long as it is the line directly above: a resource
+/// spanning two or more line endings, as in `[a](\n/u\n"ti{tle")`, stays a
+/// known divergence. So do lazy and list-item continuations, since the forward
+/// scan stops at a line that opens a block rather than tracking the enclosing
+/// container.
 #[cfg(feature = "mdx")]
 fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bool {
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
@@ -4409,11 +4411,11 @@ fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bo
         )
 }
 
-/// Whether replaying the whole block could pay off. A whitespace run crosses at
-/// most one line ending, so a tail reaching `pos` from above either opens on
-/// the line before `pos`'s or spans it inside a title; either way one there
-/// must close past `pos`. Cheaper than the block replay and only ever withholds
-/// it, which leaves the `{` an expression.
+/// Whether replaying the whole block could pay off: a `](` on the line
+/// directly above `pos` opens a tail closing past it. Only that line is
+/// scanned, so a tail whose `](` is two or more lines up, which a title
+/// spanning both endings could still carry down, is refused and leaves the `{`
+/// an expression. Cheaper than the block replay and only ever withholds it.
 #[cfg(feature = "mdx")]
 fn tail_reaches_from_line_above(
     bytes: &[u8],

--- a/crates/satteri-pulldown-cmark/src/firstpass.rs
+++ b/crates/satteri-pulldown-cmark/src/firstpass.rs
@@ -4354,34 +4354,90 @@ const LINK_LABEL_MAX_TRACKED_DEPTH: u32 = 64;
 /// back to expression scanning and errors on a dangling `{`. We mirror that
 /// by returning false so the caller can run the expression scanner.
 ///
-/// Line-bounded, so a resource spanning lines is a known divergence. Label
-/// starts are not: `scope_start` is where the enclosing block's inline content
-/// begins, so one on an earlier line of the same block still counts.
+/// A resource may span lines, since `resourceBefore`,
+/// `resourceDestinationAfter` and `resourceTitleAfter` all run
+/// `factoryWhitespace` and `factoryTitle` accepts line endings; only the
+/// destination is line-bounded. `scope_start` is where the enclosing block's
+/// inline content begins, so a tail opening on an earlier line of the same
+/// block still counts. Lazy and list-item continuations are a known
+/// divergence: the forward scan stops at a line that opens a block rather than
+/// tracking the enclosing container.
 #[cfg(feature = "mdx")]
 fn is_inside_link_url_parens(bytes: &[u8], pos: usize, scope_start: usize) -> bool {
     let line_start = memchr::memrchr2(b'\n', b'\r', &bytes[..pos])
         .map(|i| i + 1)
         .unwrap_or(0);
-    // A tail is line-bounded, so one enclosing `pos` opens on `pos`'s own line.
-    if !memchr::memchr_iter(b']', &bytes[line_start..pos])
-        .any(|rel| bytes.get(line_start + rel + 1) == Some(&b'('))
-    {
+    let opens_tail = |from: usize, to: usize| {
+        memchr::memchr_iter(b']', &bytes[from..to])
+            .any(|rel| bytes.get(from + rel + 1) == Some(&b'('))
+    };
+    let on_line = opens_tail(line_start, pos);
+    let earlier = scope_start < line_start && opens_tail(scope_start, line_start);
+    if !on_line && !earlier {
         return false;
     }
     let line_end = line_end_at(bytes, pos);
-    match replay_link_tails(bytes, pos, line_start, line_end, scope_start >= line_start) {
-        TailReplay::Inside => true,
-        TailReplay::Outside => false,
-        // `scope_start` is the block's own start, so this cannot cross into one.
-        TailReplay::NeedsScope => {
-            scope_start < line_start
-                && !earlier_lines_are_ambiguous(bytes, scope_start, line_start)
-                && matches!(
-                    replay_link_tails(bytes, pos, scope_start, line_end, true),
-                    TailReplay::Inside
-                )
+    let prefix = leading_container_prefix(&bytes[line_start..]);
+    // Two reasons to widen: a `](` on this line wanted a label start it never
+    // saw, or a tail on the line above is still open here. Only the second is
+    // worth paying the block replay to guess at.
+    let widen = if on_line {
+        match replay_link_tails(
+            bytes,
+            pos,
+            line_start,
+            line_end,
+            prefix,
+            scope_start >= line_start,
+        ) {
+            TailReplay::Inside => return true,
+            TailReplay::NeedsScope => true,
+            TailReplay::Outside => {
+                earlier && tail_reaches_from_line_above(bytes, line_start, pos, prefix)
+            }
         }
+    } else {
+        tail_reaches_from_line_above(bytes, line_start, pos, prefix)
+    };
+    // `scope_start` is the block's own start, so this cannot cross into one.
+    widen
+        && scope_start < line_start
+        && !earlier_lines_are_ambiguous(bytes, scope_start, line_start)
+        && matches!(
+            replay_link_tails(bytes, pos, scope_start, line_end, prefix, true),
+            TailReplay::Inside
+        )
+}
+
+/// Whether replaying the whole block could pay off. A whitespace run crosses at
+/// most one line ending, so a tail reaching `pos` from above either opens on
+/// the line before `pos`'s or spans it inside a title; either way one there
+/// must close past `pos`. Cheaper than the block replay and only ever withholds
+/// it, which leaves the `{` an expression.
+#[cfg(feature = "mdx")]
+fn tail_reaches_from_line_above(
+    bytes: &[u8],
+    line_start: usize,
+    pos: usize,
+    prefix: usize,
+) -> bool {
+    if line_start == 0 {
+        return false;
     }
+    let mut eol = line_start - 1;
+    if eol > 0 && bytes[eol] == b'\n' && bytes[eol - 1] == b'\r' {
+        eol -= 1;
+    }
+    let above = memchr::memrchr2(b'\n', b'\r', &bytes[..eol])
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let mut closes = TitleCloses::default();
+    memchr::memchr_iter(b']', &bytes[above..eol]).any(|rel| {
+        let rbracket = above + rel;
+        bytes.get(rbracket + 1) == Some(&b'(')
+            && link_tail_close(bytes, rbracket + 1, eol, prefix, &mut closes)
+                .is_some_and(|rparen| rparen > pos)
+    })
 }
 
 #[cfg(feature = "mdx")]
@@ -4401,6 +4457,7 @@ fn replay_link_tails(
     pos: usize,
     from: usize,
     scope_end: usize,
+    prefix: usize,
     at_block_start: bool,
 ) -> TailReplay {
     let mut depth: u32 = 0;
@@ -4461,7 +4518,8 @@ fn replay_link_tails(
                 inactive_below = inactive_below.min(depth);
                 if active
                     && bytes.get(i + 1) == Some(&b'(')
-                    && let Some(rparen) = link_tail_close(bytes, i + 1, tail_line_end, &mut closes)
+                    && let Some(rparen) =
+                        link_tail_close(bytes, i + 1, tail_line_end, prefix, &mut closes)
                 {
                     if rparen > pos {
                         return TailReplay::Inside;
@@ -4530,20 +4588,111 @@ fn link_tail_close(
     bytes: &[u8],
     lparen: usize,
     line_end: usize,
+    prefix: usize,
     closes: &mut TitleCloses,
 ) -> Option<usize> {
-    let mut i = lparen + 1;
-    i += scan_while(&bytes[i..line_end], is_space_or_tab);
+    let (i, line_end) = skip_resource_space(bytes, lparen + 1, line_end, prefix)?;
     let dest_end = scan_link_tail_dest(bytes, i, line_end)?;
-    i = dest_end + scan_while(&bytes[dest_end..line_end], is_space_or_tab);
+    let (mut i, mut line_end) = skip_resource_space(bytes, dest_end, line_end, prefix)?;
     // Without separating whitespace the delimiter was part of the destination.
     if i > dest_end
-        && let Some(title_end) = scan_link_tail_title(bytes, i, line_end, closes)
+        && let Some((title_end, title_line_end)) =
+            scan_link_tail_title(bytes, i, line_end, prefix, closes)
     {
-        i = title_end + scan_while(&bytes[title_end..line_end], is_space_or_tab);
+        (i, line_end) = skip_resource_space(bytes, title_end, title_line_end, prefix)?;
     }
 
     (i < line_end && bytes[i] == b')').then_some(i)
+}
+
+/// Spaces, tabs and line endings between the parts of a resource, following
+/// paragraph continuation lines. Returns the position and its line's end.
+#[cfg(feature = "mdx")]
+fn skip_resource_space(
+    bytes: &[u8],
+    mut at: usize,
+    mut line_end: usize,
+    prefix: usize,
+) -> Option<(usize, usize)> {
+    loop {
+        at += scan_while(&bytes[at..line_end], is_space_or_tab);
+        if at < line_end {
+            return Some((at, line_end));
+        }
+        at = resource_continuation_line(bytes, line_end, prefix)?;
+        line_end = line_end_at(bytes, at);
+    }
+}
+
+/// Where the next line's content starts when a paragraph continues past the
+/// line ending at `eol`.
+#[cfg(feature = "mdx")]
+fn resource_continuation_line(bytes: &[u8], eol: usize, prefix: usize) -> Option<usize> {
+    if eol >= bytes.len() {
+        return None;
+    }
+    let mut next = eol + 1;
+    if bytes[eol] == b'\r' && bytes.get(next) == Some(&b'\n') {
+        next += 1;
+    }
+    let mut i = next;
+    for _ in 0..prefix {
+        i += scan_while_max(&bytes[i..], |b| b == b' ', 3);
+        if bytes.get(i) != Some(&b'>') {
+            return None;
+        }
+        i += 1;
+        if bytes.get(i).is_some_and(|&b| is_space_or_tab(b)) {
+            i += 1;
+        }
+    }
+    let content = i + scan_while(&bytes[i..], is_space_or_tab);
+    match bytes.get(content) {
+        None | Some(b'\n' | b'\r') => None,
+        Some(_) if opens_block(&bytes[content..]) => None,
+        Some(_) => Some(i),
+    }
+}
+
+/// Every branch below fires only on one of these bytes, so the match is a fast
+/// reject for ordinary prose rather than a duplicate of their conditions.
+#[cfg(feature = "mdx")]
+fn opens_block(data: &[u8]) -> bool {
+    let Some(&first) = data.first() else {
+        return true;
+    };
+    if !matches!(
+        first,
+        b'<' | b'|'
+            | b'{'
+            | b':'
+            | b'['
+            | b'#'
+            | b'>'
+            | b'*'
+            | b'-'
+            | b'_'
+            | b'+'
+            | b'='
+            | b'`'
+            | b'~'
+            | b'$'
+            | b'0'..=b'9'
+    ) {
+        return false;
+    }
+    // `:` opens a directive fence or definition-list item, `[^` a footnote
+    // definition; all interrupt a paragraph.
+    matches!(first, b'<' | b'|' | b'{' | b':')
+        || data.starts_with(b"[^")
+        || scan_hrule(data).is_ok()
+        || scan_atx_heading(data).is_some()
+        || scan_code_fence(data).is_some()
+        || scan_setext_heading(data).is_some()
+        || scan_blockquote_start(data).is_some()
+        || scan_listitem(data).is_some()
+        || scan_math_fence(data).is_some()
+        || scan_interrupting_container_extensions_fence(data)
 }
 
 /// End of the link destination starting at `start`, mirroring
@@ -4651,8 +4800,9 @@ fn scan_link_tail_title(
     bytes: &[u8],
     start: usize,
     line_end: usize,
+    prefix: usize,
     closes: &mut TitleCloses,
-) -> Option<usize> {
+) -> Option<(usize, usize)> {
     if start >= line_end {
         return None;
     }
@@ -4662,9 +4812,17 @@ fn scan_link_tail_title(
         b'(' => (2, b')'),
         _ => return None,
     };
-    closes
-        .find(bytes, kind, close, start + 1, line_end)
-        .map(|i| i + 1)
+    // `TitleCloses` is keyed on the line, so crossing is driven from out here
+    // and each line keeps its own memo.
+    let mut from = start + 1;
+    let mut line_end = line_end;
+    loop {
+        if let Some(i) = closes.find(bytes, kind, close, from, line_end) {
+            return Some((i + 1, line_end));
+        }
+        from = resource_continuation_line(bytes, line_end, prefix)?;
+        line_end = line_end_at(bytes, from);
+    }
 }
 
 /// True if the byte at `pos` is the first content char of its source line,

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -1,6 +1,7 @@
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createElement } from "react";
 import { assertMdxConformance, assertMdxMathConformance, assertBothReject } from "./helpers.js";
+import { mdxToMdast } from "../../src/index.js";
 
 const Foo = (props: any) => createElement("div", null, `bar=${props.bar}`);
 const Bar = (props: any) => createElement("em", null, `baz=${props.baz}`);
@@ -616,6 +617,72 @@ describe("MDX conformance: markdown elements", () => {
   test("a tail that closes before the `{` leaves it an expression", async () => {
     await assertBothReject("[a](\\){)}");
     await assertBothReject("[a](/u){w");
+  });
+
+  // Every whitespace run in a resource accepts line endings; only the
+  // destination is line-bounded.
+  test("a resource spanning lines keeps its `{` literal", async () => {
+    await assertMdxConformance("[a]({{{\n)");
+    await assertMdxConformance('[a](/u{\n"t")');
+    await assertMdxConformance('[a](/u "ti{\ntle")');
+    await assertMdxConformance('x\n[a](/u\n"ti{tle") y');
+  });
+
+  test("a resource opening on an earlier line still encloses the `{`", async () => {
+    await assertMdxConformance('[a](/u\n"ti{tle")');
+    await assertMdxConformance("[a](\nu{v})");
+    await assertMdxConformance("[a](}\n({))");
+    await assertMdxConformance('[a](/u "ti\ntl{e")');
+    await assertMdxConformance('![a](/u\n"ti{tle")');
+    await assertMdxConformance('[a](/u\r\n"ti{tle")');
+    await assertMdxConformance('> [a](/u\n> "ti{tle")');
+  });
+
+  test("a block boundary ends the resource, leaving the `{` an expression", async () => {
+    await assertBothReject('[a](/u "a{\n# b")');
+    await assertBothReject('[a](/u "a{\n``` b")');
+    await assertBothReject('[a](/u "a{\n***\nb")');
+    await assertBothReject('[a](/u "a{\n- b")');
+    await assertBothReject('[a](/u "a{\n\nb")');
+    await assertBothReject('[a](/u "a{\n> b")');
+  });
+
+  test("a line ending crosses neither a destination nor a closed tail", async () => {
+    await assertBothReject("[a](/u{\nmore)");
+    await assertBothReject("[a](/u\n) {w");
+  });
+
+  // The dangerous direction: swallowing one of these as title text loses the
+  // expression silently, with no parse error to notice.
+  test("a block boundary keeps a valid `{}` an expression, not title text", async () => {
+    await assertMdxConformance('[a](/u "ti{1+1}\n# tle")');
+    await assertMdxConformance('[a](/u "ti{1+1}\n``` tle")');
+    await assertMdxConformance('[a](/u "ti{1+1}\n- tle")');
+    await assertMdxConformance('[a](/u "ti{1+1}\n> tle")');
+    await assertMdxConformance('[a](/u "ti{1+1}\n***\ntle")');
+    await assertMdxConformance('[a](/u "ti{1+1}\n\ntle")');
+  });
+
+  test("an escaped label opens no tail, so the `{}` stays an expression", async () => {
+    await assertMdxConformance('\\[a](/u "ti{1+1}\ntle")');
+    await assertMdxConformance('x\\[a](/u "ti{1+1}\ntle")');
+    await assertMdxConformance('\\[a](/u "ti{1+1}tle")');
+    await assertMdxConformance('a\\](/u "ti{1+1}\ntle")');
+  });
+
+  // mdx-js has no GFM, so its footnote-blind parse can't be the oracle here;
+  // satteri's own block pass makes the definition, and the inline scan has to
+  // agree with it.
+  test("a footnote definition ends the resource, keeping the `{}` an expression", () => {
+    const tree = mdxToMdast('[a](/u "ti{1+1}\n[^a]: tle")') as { children: unknown[] };
+    const types: string[] = [];
+    const walk = (n: { type?: string; children?: unknown[] }) => {
+      if (n.type) types.push(n.type);
+      for (const c of n.children ?? []) walk(c as { type?: string; children?: unknown[] });
+    };
+    walk(tree as { children?: unknown[] });
+    expect(types).toContain("mdxTextExpression");
+    expect(types).toContain("footnoteDefinition");
   });
 
   test("an escaped bracket is not a label delimiter, so no tail forms", async () => {


### PR DESCRIPTION
A CommonMark resource may span lines: `resourceBefore`, `resourceDestinationAfter` and `resourceTitleAfter` all run `factoryWhitespace`, which accepts line endings, and `factoryTitle` lets a title run across them too. Only the destination is genuinely line-bounded. The tail resolver was line-bounded throughout, so `[a]({{{\n)` and `[a](/u\n"ti{tle")` raised a parse error where @mdx-js/mdx compiles them. `link_tail_close` now follows paragraph continuation lines through the whitespace runs and the title, and a tail opening on an earlier line reaches the brace by replaying the block, which #214 already knows how to do for label starts. Crossing a line ending is refused when the next line is blank, changes blockquote prefix, or could open a block, and that set has to match what satteri's own block pass does, footnote definitions and definition-list markers included, or the inline scan swallows an expression the block pass had already put in its own block. Measured by stubbing each mechanism out rather than by classifying shapes: crossing alone fixes 3,133 of the 4,496 divergences and the block replay a further 1,343. Across four corpora, all run on both binaries per input, the multi-line sweep goes 4,509 to 33 divergent, the container and block-boundary sweep 95,325 to 54,875, the 764,691 single-line inputs are unchanged, and an over-suppression corpus of 1,545 inputs that must keep their expression is unchanged; newly divergent is 0 in every one of the four. The reference is remark with GFM and math, matching satteri's own option set.

This was rebuilt against the forward replay that #214 landed rather than rebased onto it. Three things that earlier revisions of this branch carried are deleted by intent, not lost in the move: the backward line walk, which the replay starting at `scope_start` replaces; a bracket-escape check, since the replay already skips escaped punctuation and main handles `\[a](/u "ti{1+1}\ntle")` correctly on its own; and a title-close memo, which `TitleCloses` supersedes with a better interval formulation, so the crossing loop wraps it per line rather than re-keying it. What remains of the old work is the block-boundary refusals and the tests that guard them. The block replay is expensive, so it is only paid when a tail on the line above actually closes past the brace, a whitespace run crossing at most one line ending; without that gate `tails` cost 80.6% more and `then-brace` 42.2%. With it, cachegrind Ir with `#[inline(never)]` puts every workload within 0.6%: `realistic` and `document.mdx` flat, `nolink` +0.28%, `prose` +0.25%, `tails` +0.50%, `then-brace` +0.18%, `para:80` +0.60%, the adversarial unterminated-title curves 0.05% cheaper, and the shape this fixes 42.7% cheaper. Twenty multi-line inputs remain, all divergent on main too, and stubbing the guards out shows they refuse them redundantly rather than dividing them: disabling `earlier_lines_are_ambiguous` alone still leaves all twenty, disabling the `{` and `<` refusals in `opens_block` alone leaves nineteen, and disabling both reaches all twenty at the price of 1,475 newly over-suppressed inputs. They look like `[a](\n{}{)` and `[a](\n< {>)`, where the brace's line opens with `{` or `<`. A resource spanning two or more line endings, as in `[a](\n/u\n"ti{tle")`, is not fixed either: the widening only scans the line directly above the brace, so a `](` further up, which a title spanning both endings could still carry down, is refused. That shape errors on main too, so it is an unfixed class rather than a regression, and the single break case `[a](/u\n"ti{tle")` is fixed. Two further residual classes in the container corpus are worth their own look and are named in the doc comment: a list-item or lazy blockquote continuation is not followed, which is much the largest remaining class, and a multi-line link title whose continuation line begins with a backslash escape is mis-scanned in plain Markdown too.
