### PR TITLE
fix(mdxjs): apply the SVG schema to a nested <svg> element's own attributes

### DIFF
--- a/.sampo/changesets/mdx-nested-svg-own-attributes.md
+++ b/.sampo/changesets/mdx-nested-svg-own-attributes.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-mdxjs: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed `elementAttributeNameCase: "html"` leaving a nested `<svg>` element's own React-cased attributes (like `strokeWidth`) unconverted on the MDX compile path; the SVG schema now covers the `<svg>` element itself, not just its descendants.

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -603,7 +603,9 @@ fn transform_element<'a>(
     let mut attrs = OxcVec::new_in(alloc);
 
     let prop_count = decode_element_prop_count(data);
-    let in_svg = context.space == Space::Svg;
+    // The schema switch covers the <svg> element's own attributes too, not
+    // just its descendants (mirrors the HTML serializer in hast/render.rs).
+    let in_svg = space == Space::Svg || tag_name == "svg";
     let attr_case = context.element_attribute_name_case;
     let style_case = context.style_property_name_case;
     for i in 0..prop_count {

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -9,6 +9,7 @@ use crate::oxc_utils::{
     create_prop_name, create_string_literal, inter_element_whitespace, is_literal_name,
 };
 use core::str;
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -654,10 +655,12 @@ fn transform_element<'a>(
             _ => continue,
         };
 
+        // Keep the Cow borrowed where possible: create_jsx_attr_name_from_str
+        // arena-copies from &str, so an intermediate String is pure waste.
         let attr_name = match attr_case {
-            ElementAttributeNameCase::React => prop_to_attr_name(name),
+            ElementAttributeNameCase::React => Cow::Owned(prop_to_attr_name(name)),
             ElementAttributeNameCase::Html => {
-                satteri_ast::hast::properties::property_to_attribute(name, in_svg).into_owned()
+                satteri_ast::hast::properties::property_to_attribute(name, in_svg)
             }
         };
         attrs.push(JSXAttributeItem::Attribute(OxcBox::new_in(

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -1180,6 +1180,46 @@ describe("mdxToJs", () => {
     expect(js).toContain('className: "x"');
   });
 
+  test("elementAttributeNameCase: 'html' converts a nested appended <svg>'s own attributes (#208)", () => {
+    const plugin = defineHastPlugin({
+      name: "svg-append",
+      element: {
+        filter: ["p"],
+        visit(node, ctx) {
+          ctx.appendChild(node, {
+            type: "element",
+            tagName: "span",
+            properties: {},
+            children: [
+              {
+                type: "element",
+                tagName: "svg",
+                properties: { strokeWidth: "1.2", strokeLinecap: "round" },
+                children: [
+                  {
+                    type: "element",
+                    tagName: "path",
+                    properties: { fillRule: "evenodd" },
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          });
+        },
+      },
+    });
+    const { code: js } = mdxToJs("hello", {
+      hastPlugins: [plugin],
+      elementAttributeNameCase: "html",
+    });
+    // The SVG schema covers the <svg> element's own attributes, not just descendants.
+    expect(js).toContain('"stroke-width": "1.2"');
+    expect(js).toContain('"stroke-linecap": "round"');
+    expect(js).not.toContain("strokeWidth");
+    expect(js).toContain('"fill-rule": "evenodd"');
+  });
+
   test("style attribute parses into an object by default (DOM casing)", () => {
     const { code: js } = mdxToJs("| a | b |\n|:--|--:|\n| c | d |\n", {
       features: { gfm: true },


### PR DESCRIPTION
Fixes #208.

## Problem

On the MDX compile path, `transform_element` switches `context.space` to `Svg` for the children of an `<svg>` element. It restores the space before it computes `in_svg` for the element's own attributes. As a result, with `elementAttributeNameCase: "html"`, a nested plugin-appended `<svg>` element keeps React-cased attribute names, for example `strokeWidth`. Its descendants convert correctly.

## Fix

`transform_element` now computes `in_svg` as `space == Space::Svg || tag_name == "svg"`. This matches the HTML serializer in `hast/render.rs`, where the schema switch covers the `<svg>` element and its descendants.

## Also in this PR

The same line called `.into_owned()` on the `Cow` from `property_to_attribute`. This allocated a temporary `String` for each attribute. `create_jsx_attr_name_from_str` copies from `&str` into the arena, so the `String` was not necessary. The code now keeps the `Cow`.

## Tests

A regression test compiles a plugin-appended `span > svg > path` subtree with `elementAttributeNameCase: "html"`. It asserts `stroke-width` and `stroke-linecap` on the `<svg>` element, and `fill-rule` on the `<path>` child. The test failed before the fix.

## Related

Review of this change found two pre-existing bugs in adjacent code: #249 and #250.
