### PR TITLE
fix(mdx): key explicit JSX by node identity instead of span

### DIFF
--- a/.sampo/changesets/quiet-tagsmith-ilmatar.md
+++ b/.sampo/changesets/quiet-tagsmith-ilmatar.md
@@ -1,0 +1,6 @@
+---
+cargo/satteri-mdxjs: patch
+npm/satteri: patch
+---
+
+Fixed plugin-inserted elements being emitted as literal JSX tags, instead of going through `_components`, when another plugin-inserted node was marked as explicit JSX.

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -5,8 +5,9 @@
 use crate::configuration::{ElementAttributeNameCase, OptimizeStaticConfig, StylePropertyNameCase};
 use crate::oxc::{parse_esm_to_tree, parse_expression_to_tree, serialize};
 use crate::oxc_utils::{
-    create_jsx_attr_name_from_str, create_jsx_name_from_str, create_object_expression,
-    create_prop_name, create_string_literal, inter_element_whitespace, is_literal_name,
+    ExplicitJsxs, create_jsx_attr_name_from_str, create_jsx_name_from_str,
+    create_object_expression, create_prop_name, create_string_literal, explicit_jsx_key,
+    inter_element_whitespace, is_literal_name,
 };
 use core::str;
 use std::borrow::Cow;
@@ -23,7 +24,7 @@ use oxc_ast::ast::{
 };
 use oxc_span::{Atom, SPAN, Span};
 use oxc_syntax::node::NodeId;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use satteri_arena::mdx_types::{self as message, Location, MdxExpressionKind, Stop};
 use satteri_arena::{Arena, Hast};
 use satteri_ast::hast::HastNodeType;
@@ -132,7 +133,7 @@ pub fn hast_util_to_oxc<'a>(
     view: &'a Arena<Hast>,
     path: Option<String>,
     location: Option<&'a Location<'a>>,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
     allocator: &'a Allocator,
     optimize_static: Option<&OptimizeStaticConfig>,
     element_attribute_name_case: ElementAttributeNameCase,
@@ -315,7 +316,7 @@ fn extract_component_override_keys(program: &Program<'_>, keys: &mut Vec<String>
 fn one<'a>(
     context: &mut Context<'a>,
     node_id: u32,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
 ) -> Result<Option<JSXChild<'a>>, message::Message> {
     let node = context.view.get_node(node_id);
     let raw_type = node.node_type;
@@ -483,7 +484,7 @@ fn create_raw_html_jsx<'a>(
 fn all<'a>(
     context: &mut Context<'a>,
     parent_id: u32,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
 ) -> Result<OxcVec<'a, JSXChild<'a>>, message::Message> {
     let child_count = context.view.get_children(parent_id).len();
     let mut result = OxcVec::with_capacity_in(child_count, context.allocator);
@@ -582,7 +583,7 @@ fn transform_comment<'a>(context: &mut Context<'a>, node_id: u32) -> JSXChild<'a
 fn transform_element<'a>(
     context: &mut Context<'a>,
     node_id: u32,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
 ) -> Result<Option<JSXChild<'a>>, message::Message> {
     let data = context.view.get_type_data(node_id);
     if data.len() < 16 {
@@ -674,15 +675,7 @@ fn transform_element<'a>(
         )));
     }
 
-    // The span feeds development `__source`. `explicit_jsxs` is keyed by span,
-    // so an MDX descendant covering the identical range would make this element
-    // read as author-written JSX; children are already transformed by here.
     let span = node_span(context.view, node_id);
-    let span = if explicit_jsxs.contains(&span) {
-        SPAN
-    } else {
-        span
-    };
 
     Ok(Some(JSXChild::Element(OxcBox::new_in(
         create_element(alloc, tag_name, attrs, children, span),
@@ -694,7 +687,7 @@ fn transform_element<'a>(
 fn transform_mdx_jsx_element<'a>(
     context: &mut Context<'a>,
     node_id: u32,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
 ) -> Result<Option<JSXChild<'a>>, message::Message> {
     let data = context.view.get_type_data(node_id);
     if data.len() < 16 {
@@ -828,13 +821,11 @@ fn transform_mdx_jsx_element<'a>(
     // Fast-path mirror of `node.data._mdxExplicitJsx`; see codec.rs.
     let explicit_jsx = decode_mdx_jsx_explicit(data);
     Ok(Some(if let Some(n) = name {
+        let elem = OxcBox::new_in(create_element(alloc, n, attrs, children, span), alloc);
         if explicit_jsx {
-            explicit_jsxs.insert(span);
+            explicit_jsxs.insert(explicit_jsx_key(&elem));
         }
-        JSXChild::Element(OxcBox::new_in(
-            create_element(alloc, n, attrs, children, span),
-            alloc,
-        ))
+        JSXChild::Element(elem)
     } else {
         JSXChild::Fragment(OxcBox::new_in(
             create_fragment(alloc, children, span),
@@ -929,7 +920,7 @@ fn transform_mdxjs_esm<'a>(
 fn transform_root<'a>(
     context: &mut Context<'a>,
     node_id: u32,
-    explicit_jsxs: &mut FxHashSet<Span>,
+    explicit_jsxs: &mut ExplicitJsxs,
 ) -> Result<Option<JSXChild<'a>>, message::Message> {
     let alloc = context.allocator;
     let children_vec = all(context, node_id, explicit_jsxs)?;

--- a/crates/satteri-mdxjs-rs/src/lib.rs
+++ b/crates/satteri-mdxjs-rs/src/lib.rs
@@ -25,8 +25,8 @@ use crate::{
     oxc::serialize,
     oxc_util_build_jsx::{Options as BuildOptions, oxc_util_build_jsx},
     oxc_utils::{
-        create_binding_ident, create_ident_expression, create_ident_name, create_num_expression,
-        create_object_expression, create_string_literal,
+        ExplicitJsxs, create_binding_ident, create_ident_expression, create_ident_name,
+        create_num_expression, create_object_expression, create_string_literal,
     },
 };
 use oxc_allocator::{Allocator, Box as OxcBox, Vec as OxcVec};
@@ -38,9 +38,8 @@ use oxc_ast::ast::{
 };
 use oxc_estree::{CompactJSSerializer, ESTree};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_span::{Atom, SPAN, SourceType, Span};
+use oxc_span::{Atom, SPAN, SourceType};
 use oxc_syntax::node::NodeId;
-use rustc_hash::FxHashSet;
 use satteri_arena::mdx_types::{self as message, Location};
 use std::cell::Cell;
 
@@ -174,7 +173,7 @@ pub fn compile_hast_arena(
 ) -> Result<String, message::Message> {
     let allocator = Allocator::default();
     let location = Location::new(arena.string_pool());
-    let mut explicit_jsxs = FxHashSet::default();
+    let mut explicit_jsxs = ExplicitJsxs::default();
     let mut program = hast_util_to_oxc(
         arena,
         options.filepath.clone(),
@@ -568,7 +567,7 @@ pub fn mdx_plugin_recma_jsx_rewrite<'a>(
     program: &mut MdxProgram<'a>,
     options: &Options,
     location: Option<&Location>,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) -> Result<(), message::Message> {
     let rewrite_options = RewriteOptions {

--- a/crates/satteri-mdxjs-rs/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/crates/satteri-mdxjs-rs/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -5,10 +5,10 @@
 
 use crate::hast_util_to_oxc::MdxProgram;
 use crate::oxc_utils::{
-    create_binding_ident, create_bool_expression, create_call_expression, create_ident_expression,
-    create_ident_name, create_member, create_object_expression, create_prop_name,
-    create_str_expression, create_string_literal, is_literal_name, jsx_member_to_parts,
-    span_to_position,
+    ExplicitJsxs, create_binding_ident, create_bool_expression, create_call_expression,
+    create_ident_expression, create_ident_name, create_member, create_object_expression,
+    create_prop_name, create_str_expression, create_string_literal, explicit_jsx_key,
+    is_literal_name, jsx_member_to_parts, span_to_position,
 };
 use satteri_arena::mdx_types::Location;
 
@@ -68,7 +68,7 @@ pub fn mdx_plugin_recma_jsx_rewrite<'a>(
     program: &mut MdxProgram<'a>,
     options: &Options,
     location: Option<&Location>,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
     let has_provider = options.provider_import_source.is_some();
@@ -327,7 +327,7 @@ fn get_function_body_mut<'a, 'b>(stmt: &'b mut Statement<'a>) -> Option<&'b mut 
 }
 
 /// Collect information about JSX references in a function body.
-fn collect_scope_info(body: &FunctionBody, explicit_jsxs: &FxHashSet<Span>) -> ScopeInfo {
+fn collect_scope_info(body: &FunctionBody, explicit_jsxs: &ExplicitJsxs) -> ScopeInfo {
     let mut info = ScopeInfo::default();
 
     // Collect defined names from declarations in the body
@@ -435,11 +435,7 @@ fn collect_binding_names(pattern: &BindingPattern, names: &mut FxHashSet<String>
 }
 
 /// Recursively collect JSX references in a statement.
-fn collect_jsx_refs_in_stmt(
-    stmt: &Statement,
-    explicit_jsxs: &FxHashSet<Span>,
-    info: &mut ScopeInfo,
-) {
+fn collect_jsx_refs_in_stmt(stmt: &Statement, explicit_jsxs: &ExplicitJsxs, info: &mut ScopeInfo) {
     match stmt {
         Statement::ReturnStatement(ret) => {
             if let Some(expr) = &ret.argument {
@@ -481,11 +477,7 @@ fn collect_jsx_refs_in_stmt(
 }
 
 /// Recursively collect JSX references in an expression.
-fn collect_jsx_refs_in_expr(
-    expr: &Expression,
-    explicit_jsxs: &FxHashSet<Span>,
-    info: &mut ScopeInfo,
-) {
+fn collect_jsx_refs_in_expr(expr: &Expression, explicit_jsxs: &ExplicitJsxs, info: &mut ScopeInfo) {
     match expr {
         Expression::JSXElement(elem) => {
             collect_jsx_refs_in_element(elem, explicit_jsxs, info);
@@ -595,10 +587,10 @@ fn record_literal_tag(literal_tags: &mut FxHashMap<String, bool>, name: &str, is
 /// Collect JSX refs from a JSX element.
 fn collect_jsx_refs_in_element(
     elem: &JSXElement,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     info: &mut ScopeInfo,
 ) {
-    let is_explicit = explicit_jsxs.contains(&elem.span);
+    let is_explicit = explicit_jsxs.contains(&explicit_jsx_key(elem));
 
     match &elem.opening_element.name {
         JSXElementName::Identifier(ident) => {
@@ -671,11 +663,7 @@ fn collect_jsx_refs_in_element(
 }
 
 /// Collect JSX refs from a JSX child.
-fn collect_jsx_refs_in_child(
-    child: &JSXChild,
-    explicit_jsxs: &FxHashSet<Span>,
-    info: &mut ScopeInfo,
-) {
+fn collect_jsx_refs_in_child(child: &JSXChild, explicit_jsxs: &ExplicitJsxs, info: &mut ScopeInfo) {
     match child {
         JSXChild::Element(elem) => {
             collect_jsx_refs_in_element(elem, explicit_jsxs, info);
@@ -702,7 +690,7 @@ fn collect_jsx_refs_in_child(
 fn rewrite_jsx_tags_in_body<'a>(
     body: &mut FunctionBody<'a>,
     scope: &ScopeInfo,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
     for stmt in &mut body.statements {
@@ -714,7 +702,7 @@ fn rewrite_jsx_tags_in_body<'a>(
 fn rewrite_jsx_tags_in_stmt<'a>(
     stmt: &mut Statement<'a>,
     scope: &ScopeInfo,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
     match stmt {
@@ -752,7 +740,7 @@ fn rewrite_jsx_tags_in_stmt<'a>(
 fn rewrite_jsx_tags_in_expr<'a>(
     expr: &mut Expression<'a>,
     scope: &ScopeInfo,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
     match expr {
@@ -846,10 +834,10 @@ fn rewrite_jsx_tags_in_expr<'a>(
 fn rewrite_jsx_element<'a>(
     elem: &mut OxcBox<'a, JSXElement<'a>>,
     scope: &ScopeInfo,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
-    let is_explicit = explicit_jsxs.contains(&elem.span);
+    let is_explicit = explicit_jsxs.contains(&explicit_jsx_key(elem));
 
     if !is_explicit {
         let tag_name = get_jsx_element_tag_name(&elem.opening_element.name);
@@ -907,7 +895,7 @@ fn rewrite_jsx_element<'a>(
 fn rewrite_jsx_child<'a>(
     child: &mut JSXChild<'a>,
     scope: &ScopeInfo,
-    explicit_jsxs: &FxHashSet<Span>,
+    explicit_jsxs: &ExplicitJsxs,
     allocator: &'a Allocator,
 ) {
     match child {

--- a/crates/satteri-mdxjs-rs/src/oxc_utils.rs
+++ b/crates/satteri-mdxjs-rs/src/oxc_utils.rs
@@ -9,13 +9,14 @@ use std::cell::Cell;
 use oxc_allocator::{Allocator, Box as OxcBox, Vec as OxcVec};
 use oxc_ast::ast::{
     Argument, BindingIdentifier, BooleanLiteral, CallExpression, ComputedMemberExpression,
-    Expression, IdentifierName, IdentifierReference, JSXAttributeName, JSXElementName,
+    Expression, IdentifierName, IdentifierReference, JSXAttributeName, JSXElement, JSXElementName,
     JSXIdentifier, JSXMemberExpression, JSXMemberExpressionObject, JSXNamespacedName,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, ObjectPropertyKind,
     PropertyKey, StaticMemberExpression, StringLiteral, ThisExpression,
 };
 use oxc_span::{Atom, SPAN, Span};
 use oxc_syntax::node::NodeId;
+use rustc_hash::FxHashSet;
 
 /// Turn an OXC span, of two byte positions, into a unist position.
 ///
@@ -485,6 +486,15 @@ pub fn create_prop_name<'a>(alloc: &'a Allocator, name: &str) -> PropertyKey<'a>
     } else {
         PropertyKey::StringLiteral(OxcBox::new_in(create_string_literal(alloc, name), alloc))
     }
+}
+
+/// Elements written as JSX in the source (`_mdxExplicitJsx`), by identity.
+pub type ExplicitJsxs = FxHashSet<usize>;
+
+/// Identify a JSX element by its address, stable for the allocator's lifetime.
+/// Spans alias: every plugin-inserted node carries the same dummy span.
+pub fn explicit_jsx_key(elem: &JSXElement) -> usize {
+    std::ptr::from_ref(elem) as usize
 }
 
 /// Check if a name is a literal tag name or an identifier to a component.

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -15,7 +15,11 @@ import type { HastNode } from "../src/hast/hast-materializer.js";
 import type { HastVisitorContext } from "../src/hast/hast-visitor.js";
 import type { MdastNode } from "../src/types.js";
 import type { Element } from "hast";
-import type { MdxJsxTextElementHast } from "../src/mdx-types.js";
+import type {
+  MdxJsxFlowElement,
+  MdxJsxFlowElementData,
+  MdxJsxTextElementHast,
+} from "../src/mdx-types.js";
 
 describe("frontmatter extraction", () => {
   test("returns null when there is no frontmatter", () => {
@@ -795,6 +799,12 @@ describe("markdownToHtml", () => {
 
 // mdxToJs
 
+// Declared locally because `_mdxExplicitJsx` is private to the Data interfaces.
+interface ExplicitJsxData extends MdxJsxFlowElementData {
+  _mdxExplicitJsx: true;
+}
+const explicitJsxData: ExplicitJsxData = { _mdxExplicitJsx: true };
+
 describe("mdxToJs", () => {
   test("basic MDX compilation", () => {
     const { code: js } = mdxToJs("# Hello\n\nWorld");
@@ -1072,6 +1082,72 @@ describe("mdxToJs", () => {
     const pluginInserted = mdxToJs("# hi\n", { hastPlugins: [insertAstroImage] }).code;
     expect(pluginInserted).toContain('"astro-image": "astro-image"');
     expect(pluginInserted).toContain('_components["astro-image"]');
+  });
+
+  test("explicit JSX from one plugin-inserted node doesn't leak to the others", () => {
+    const insertExplicit = defineMdastPlugin({
+      name: "insert-explicit",
+      paragraph(node, ctx) {
+        ctx.replaceNode(node, {
+          type: "mdxJsxFlowElement",
+          name: "Building",
+          attributes: [],
+          children: [],
+          data: explicitJsxData,
+        } satisfies MdxJsxFlowElement);
+      },
+    });
+    const highlight = defineHastPlugin({
+      name: "highlight",
+      element: {
+        filter: ["pre"],
+        visit(node, ctx) {
+          ctx.replaceNode(node, {
+            type: "element",
+            tagName: "pre",
+            properties: { className: ["shiki"] },
+            children: [{ type: "text", value: "highlighted" }],
+          } satisfies Element);
+        },
+      },
+    });
+
+    const { code } = mdxToJs("# Title\n\n```js\nconsole.log('hi');\n```\n\nSome paragraph.\n", {
+      mdastPlugins: [insertExplicit],
+      hastPlugins: [highlight],
+    });
+
+    expect(code).toContain('pre: "pre"');
+    expect(code).toContain("_components.pre");
+    expect(code).not.toContain('_jsx("pre"');
+  });
+
+  test("explicit JSX is honoured per node, not per span", () => {
+    const insertWidgets = defineMdastPlugin({
+      name: "insert-widgets",
+      paragraph(node, ctx) {
+        ctx.replaceNode(node, {
+          type: "mdxJsxFlowElement",
+          name: "my-widget",
+          attributes: [{ type: "mdxJsxAttribute", name: "foo", value: "bar" }],
+          children: [],
+          data: explicitJsxData,
+        } satisfies MdxJsxFlowElement);
+      },
+      heading(node, ctx) {
+        ctx.insertAfter(node, {
+          type: "mdxJsxFlowElement",
+          name: "other-widget",
+          attributes: [{ type: "mdxJsxAttribute", name: "foo", value: "bar" }],
+          children: [],
+        } satisfies MdxJsxFlowElement);
+      },
+    });
+
+    const { code } = mdxToJs("# hi\n\npara\n", { mdastPlugins: [insertWidgets] });
+
+    expect(code).toContain('_jsx("my-widget"');
+    expect(code).toContain('_components["other-widget"]');
   });
 
   test("HAST plugin setProperty on MDX JSX element preserves existing attributes", () => {

--- a/packages/satteri/test/conformance/helpers.ts
+++ b/packages/satteri/test/conformance/helpers.ts
@@ -707,6 +707,38 @@ export async function assertMdxConformance(
   expect(normalizeHtml(satHtml)).toBe(normalizeHtml(mdxHtml));
 }
 
+export interface MdxPluginConformanceOptions {
+  reference: Pick<MdxCompileOptions, "remarkPlugins" | "rehypePlugins">;
+  satteri: Pick<MarkdownToJsOptions, "mdastPlugins" | "hastPlugins">;
+  components?: Record<string, unknown>;
+}
+
+// Pass `components` overrides: a tag that skips `_components` ignores them.
+export async function assertMdxPluginConformance(
+  input: string,
+  options: MdxPluginConformanceOptions,
+): Promise<void> {
+  const { reference, satteri, components = {} } = options;
+
+  const { default: MdxComponent } = (await mdxEvaluate(input, {
+    ...mdxRuntime,
+    ...reference,
+  })) as { default: Function };
+  const mdxHtml = renderToStaticMarkup(
+    createElement(MdxComponent as React.FC<Record<string, unknown>>, { components }),
+  );
+
+  const { default: SatComponent } = await satteriEvaluate(input, {
+    ...satteriRuntime,
+    ...satteri,
+  });
+  const satHtml = renderToStaticMarkup(
+    createElement(SatComponent as React.FC<Record<string, unknown>>, { components }),
+  );
+
+  expect(normalizeHtml(satHtml)).toBe(normalizeHtml(mdxHtml));
+}
+
 // Reference is @mdx-js/mdx with `format: "md"`. Both sides evaluate to a
 // component and render through react-dom/server, so escaping is identical and
 // only structural differences survive.

--- a/packages/satteri/test/conformance/mdx.test.ts
+++ b/packages/satteri/test/conformance/mdx.test.ts
@@ -4,9 +4,12 @@ import {
   assertMdxConformance,
   assertMdxDevPositionConformance,
   assertMdxMathConformance,
+  assertMdxPluginConformance,
   assertBothReject,
 } from "./helpers.js";
-import { mdxToJs, mdxToMdast } from "../../src/index.js";
+import { mdxToJs, mdxToMdast, defineMdastPlugin, defineHastPlugin } from "../../src/index.js";
+import type { Element } from "hast";
+import type { MdxJsxFlowElement, MdxJsxFlowElementData } from "../../src/mdx-types.js";
 
 const Foo = (props: any) => createElement("div", null, `bar=${props.bar}`);
 const Bar = (props: any) => createElement("em", null, `baz=${props.baz}`);
@@ -1223,5 +1226,134 @@ describe("MDX conformance: development positions", () => {
 
   test("parse error column counts UTF-16 code units", () => {
     expect(() => mdxToJs("😀 <Foo>\n")).toThrow(/^1:4: Expected a closing tag for `<Foo>` \(1:4\)/);
+  });
+});
+
+// Declared locally because `_mdxExplicitJsx` is private to the Data interfaces.
+interface ExplicitJsxData extends MdxJsxFlowElementData {
+  _mdxExplicitJsx: true;
+}
+const explicitJsxData: ExplicitJsxData = { _mdxExplicitJsx: true };
+
+interface TreeNode {
+  type: string;
+  tagName?: string;
+  children?: unknown[];
+}
+
+function mapChildren(tree: TreeNode, fn: (node: TreeNode) => unknown): void {
+  if (!tree.children) return;
+  const next: unknown[] = [];
+  for (const child of tree.children as TreeNode[]) {
+    mapChildren(child, fn);
+    const replacement = fn(child);
+    if (Array.isArray(replacement)) next.push(...replacement);
+    else next.push(replacement ?? child);
+  }
+  tree.children = next;
+}
+
+const widget = (name: string, explicit: boolean) =>
+  ({
+    type: "mdxJsxFlowElement",
+    name,
+    attributes: [{ type: "mdxJsxAttribute", name: "foo", value: "bar" }],
+    children: [],
+    ...(explicit ? { data: explicitJsxData } : {}),
+  }) satisfies MdxJsxFlowElement;
+
+const insertedBuilding = {
+  type: "mdxJsxFlowElement",
+  name: "Building",
+  attributes: [],
+  children: [],
+  data: explicitJsxData,
+} satisfies MdxJsxFlowElement;
+
+const highlightedPre = () =>
+  ({
+    type: "element",
+    tagName: "pre",
+    properties: { className: ["shiki"] },
+    children: [{ type: "text", value: "highlighted" }],
+  }) satisfies Element;
+
+describe("MDX conformance: plugin-inserted explicit JSX", () => {
+  const Building = () => createElement("aside", null, "building");
+  const OverriddenPre = (props: any) =>
+    createElement("pre", { "data-from": "components" }, props.children);
+  const OverriddenWidget = () => createElement("span", null, "overridden");
+
+  test("one explicit inserted node doesn't stop the others reaching _components", async () => {
+    await assertMdxPluginConformance(
+      "# Title\n\n```js\nconsole.log('hi');\n```\n\nSome paragraph.\n",
+      {
+        reference: {
+          remarkPlugins: [
+            () => (tree: TreeNode) =>
+              mapChildren(tree, (node) =>
+                node.type === "paragraph" ? insertedBuilding : undefined,
+              ),
+          ],
+          rehypePlugins: [
+            () => (tree: TreeNode) =>
+              mapChildren(tree, (node) =>
+                node.type === "element" && node.tagName === "pre" ? highlightedPre() : undefined,
+              ),
+          ],
+        },
+        satteri: {
+          mdastPlugins: [
+            defineMdastPlugin({
+              name: "insert-explicit",
+              paragraph(node, ctx) {
+                ctx.replaceNode(node, insertedBuilding);
+              },
+            }),
+          ],
+          hastPlugins: [
+            defineHastPlugin({
+              name: "highlight",
+              element: {
+                filter: ["pre"],
+                visit(node, ctx) {
+                  ctx.replaceNode(node, highlightedPre());
+                },
+              },
+            }),
+          ],
+        },
+        components: { Building, pre: OverriddenPre },
+      },
+    );
+  });
+
+  test("explicit JSX is honoured per node, not per span", async () => {
+    await assertMdxPluginConformance("# hi\n\npara\n", {
+      reference: {
+        remarkPlugins: [
+          () => (tree: TreeNode) =>
+            mapChildren(tree, (node) => {
+              if (node.type === "paragraph") return widget("my-widget", true);
+              if (node.type === "heading") return [node, widget("other-widget", false)];
+              return undefined;
+            }),
+        ],
+      },
+      satteri: {
+        mdastPlugins: [
+          defineMdastPlugin({
+            name: "insert-widgets",
+            paragraph(node, ctx) {
+              ctx.replaceNode(node, widget("my-widget", true));
+            },
+            heading(node, ctx) {
+              ctx.insertAfter(node, widget("other-widget", false));
+            },
+          }),
+        ],
+      },
+      components: { "my-widget": OverriddenWidget, "other-widget": OverriddenWidget },
+    });
   });
 });


### PR DESCRIPTION
Fixes #270