### PR TITLE
fix(ast): preserve SVG context and content in raw HTML reparsing

### DIFF
--- a/.sampo/changesets/raw-html-mdx-svg-context.md
+++ b/.sampo/changesets/raw-html-mdx-svg-context.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-ast: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed `rawHtml` losing the SVG attribute schema for raw HTML inside a JSX `<svg>` element, so `fill-rule` now maps to `fillRule` instead of passing through as an unknown property.

--- a/.sampo/changesets/valiant-shaman-ahti.md
+++ b/.sampo/changesets/valiant-shaman-ahti.md
@@ -1,0 +1,8 @@
+---
+cargo/satteri-ast: patch
+cargo/satteri-mdxjs: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed SVG script and style text being corrupted and elements with HTML void-element names losing children or absorbing siblings during HTML serialization and rawHtml reparsing. HTML content inside SVG integration points keeps its normal serialization rules, including with optimizeStatic.

--- a/crates/satteri-ast/README.md
+++ b/crates/satteri-ast/README.md
@@ -2,6 +2,8 @@
 
 MDAST and HAST node types, codecs, tree operations, and conversion for Sätteri, a high-performance Markdown and MDX processor.
 
+For subtree serialization, `hast::render_node_with_options` accepts `RenderOptions` to track SVG attribute casing separately from the content namespace. Use `RenderOptions::for_children(tag)` when descending through elements; it preserves HTML text and void-element rules inside SVG `foreignObject`, `desc`, and `title` elements.
+
 ## Development
 
 Refer to [CONTRIBUTING.md](https://github.com/bruits/satteri/blob/main/CONTRIBUTING.md) for development setup and workflow details.

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -35,8 +35,9 @@ const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
 
 /// SVG elements whose content is parsed as HTML (the spec's HTML integration
-/// points), so SVG content stops at them. MathML's integration points never
-/// arise: MathML is parsed in the HTML context here.
+/// points), so SVG content stops at them. MathML's integration points do not
+/// matter here: the context only tracks SVG content, which html5ever's
+/// MathML-namespace elements never enter.
 fn is_html_integration_point(local: &str) -> bool {
     matches!(local, "foreignObject" | "desc" | "title")
 }

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -1276,10 +1276,7 @@ mod tests {
         b.open_node_raw(HastNodeType::Root as u8);
 
         add_raw_node(&mut b, r#"<div class="n">"#);
-        let tag = b.alloc_string("p");
-        let el = b.open_node_raw(HastNodeType::Element as u8);
-        let data = encode_element_data(tag, &[]);
-        b.arena_mut().set_type_data(el, &data);
+        open_element(&mut b, "p", &[]);
         let t = b.alloc_string("hi");
         let text = b.add_leaf_raw(HastNodeType::Text as u8);
         b.arena_mut().set_type_data(text, &t.as_bytes());
@@ -1394,16 +1391,8 @@ mod tests {
         let mut b = ArenaBuilder::<Hast>::new(String::new());
         b.open_node_raw(HastNodeType::Root as u8);
 
-        // <Note> containing a single raw node `<em>hi</em>`.
-        let name = b.alloc_string("Note");
-        let mdx = b.open_node_raw(HastNodeType::MdxJsxElement as u8);
-        let data = encode_mdx_jsx_element_data(name, &[], true);
-        b.arena_mut().set_type_data(mdx, &data);
-
-        let raw = b.alloc_string("<em>hi</em>");
-        let leaf = b.add_leaf_raw(HastNodeType::Raw as u8);
-        b.arena_mut().set_type_data(leaf, &raw.as_bytes());
-
+        open_mdx_element(&mut b, "Note");
+        add_raw_node(&mut b, "<em>hi</em>");
         b.close_node(); // </Note>
         b.close_node(); // </root>
         let arena = b.finish();
@@ -1440,6 +1429,18 @@ mod tests {
         let r = b.alloc_string(html);
         let leaf = b.add_leaf_raw(HastNodeType::Raw as u8);
         b.arena_mut().set_type_data(leaf, &r.as_bytes());
+    }
+
+    /// Open a hast element with `(name, kind, value)` props; the caller closes it.
+    fn open_element(b: &mut ArenaBuilder<Hast>, tag: &str, props: &[(&str, u8, &str)]) {
+        let tag = b.alloc_string(tag);
+        let props: Vec<(StringRef, u8, StringRef)> = props
+            .iter()
+            .map(|&(name, kind, value)| (b.alloc_string(name), kind, b.alloc_string(value)))
+            .collect();
+        let el = b.open_node_raw(HastNodeType::Element as u8);
+        let data = encode_element_data(tag, &props);
+        b.arena_mut().set_type_data(el, &data);
     }
 
     #[cfg(feature = "mdx")]
@@ -1527,12 +1528,7 @@ mod tests {
         let mut b = ArenaBuilder::<Hast>::new(String::new());
         b.open_node_raw(HastNodeType::Root as u8);
         open_mdx_element(&mut b, "svg");
-        let tag = b.alloc_string("path");
-        let name = b.alloc_string("fillRule");
-        let value = b.alloc_string("evenodd");
-        let el = b.open_node_raw(HastNodeType::Element as u8);
-        let data = encode_element_data(tag, &[(name, PROP_STRING, value)]);
-        b.arena_mut().set_type_data(el, &data);
+        open_element(&mut b, "path", &[("fillRule", PROP_STRING, "evenodd")]);
         b.close_node(); // </path>
         b.close_node(); // </svg>
         b.close_node(); // </root>

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -42,7 +42,8 @@ fn is_html_integration_point(local: &str) -> bool {
     matches!(local, "foreignObject" | "desc" | "title")
 }
 
-/// The namespace a fragment's own top-level content is parsed in.
+/// The namespace HTML content is parsed in; for a fragment, that of its own
+/// top-level content.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum HtmlSpace {
     #[default]
@@ -51,6 +52,31 @@ pub enum HtmlSpace {
 }
 
 impl HtmlSpace {
+    fn is_svg(self) -> bool {
+        self == HtmlSpace::Svg
+    }
+
+    /// The space of an arena element named `tag` whose parent sits in `self`.
+    /// The arena records no namespace, so, as in the serializer, the name
+    /// `svg` is what opens SVG content.
+    fn of_arena_element(self, tag: &str) -> HtmlSpace {
+        if self.is_svg() || tag == "svg" {
+            HtmlSpace::Svg
+        } else {
+            HtmlSpace::Html
+        }
+    }
+
+    /// The space for the content of an element named `tag` that itself sits
+    /// in `self`: an HTML integration point parses its content as HTML.
+    fn inside(self, tag: &str) -> HtmlSpace {
+        if self.is_svg() && !is_html_integration_point(tag) {
+            HtmlSpace::Svg
+        } else {
+            HtmlSpace::Html
+        }
+    }
+
     /// `<template>` is the most permissive insertion mode, so table parts survive outside a table.
     fn context_element(self) -> QualName {
         match self {
@@ -386,15 +412,24 @@ impl TreeSink for HtmlSink {
 /// A unit of work for the iterative emitter: emit a sink node, copy a
 /// preserved node from the source arena, or close the open element.
 ///
-/// The `bool` is whether the node sits in SVG content. A parsed element
-/// carries its own namespace, so among sink nodes only a [`NodeData::Stitch`]
-/// reads it: the preserved MDX node has no namespace of its own and inherits
-/// its parent's. A copied arena node reads it to pick the schema for any raw
-/// HTML reparsed beneath it.
+/// The [`HtmlSpace`] is the context the node sits in. A parsed element has a
+/// namespace of its own and ignores it; a stitched MDX node has none and
+/// inherits it, and a copied arena node uses it for any raw HTML reparsed
+/// below.
 enum EmitTask {
-    Emit(usize, bool),
-    EmitArena(u32, bool),
+    Emit(usize, HtmlSpace),
+    EmitArena(u32, HtmlSpace),
     Close,
+}
+
+/// What a raw-HTML reparse stitches back into the parsed fragment: the arena
+/// the preserved MDX subtrees live in, their ids in placeholder order, and the
+/// markers that leaked into text instead of becoming stitch nodes.
+#[derive(Clone, Copy)]
+struct Stitching<'a> {
+    src: &'a Arena<Hast>,
+    stitches: &'a [u32],
+    leaked: &'a [String],
 }
 
 /// Emit `roots` into the HAST builder in document order.
@@ -402,49 +437,43 @@ enum EmitTask {
 /// Walks with an explicit stack: HTML nesting is unbounded, so recursion
 /// would overflow the native stack on adversarially deep input.
 ///
-/// A [`NodeData::Stitch`] node is replaced by the preserved subtree
-/// `stitches[N]` from `src` (`None` for [`html_to_hast_arena`], which never
-/// stitches). `leaked` markers are scrubbed from emitted text, comments, and
-/// attributes. `in_svg` is the namespace context of `roots` themselves.
+/// With `stitching`, a [`NodeData::Stitch`] node is replaced by the preserved
+/// subtree `stitches[N]` and leaked markers are scrubbed from emitted text,
+/// comments, and attributes; the plain HTML entry points pass `None`. `space`
+/// is the namespace context of `roots` themselves.
 fn emit(
     nodes: &[Node],
     roots: &[usize],
     builder: &mut ArenaBuilder<Hast>,
-    src: Option<&Arena<Hast>>,
-    stitches: &[u32],
-    leaked: &[String],
-    in_svg: bool,
+    stitching: Option<Stitching<'_>>,
+    space: HtmlSpace,
 ) {
+    let leaked = stitching.map_or(&[][..], |s| s.leaked);
     // Seed with the roots reversed, so they pop in document order.
     let mut stack: Vec<EmitTask> = roots
         .iter()
         .rev()
-        .map(|&id| EmitTask::Emit(id, in_svg))
+        .map(|&id| EmitTask::Emit(id, space))
         .collect();
 
     while let Some(task) = stack.pop() {
-        let (id, in_svg) = match task {
+        let (id, space) = match task {
             EmitTask::Close => {
                 builder.close_node();
                 continue;
             }
-            EmitTask::EmitArena(aid, in_svg) => {
-                emit_arena_node(
-                    src.expect("EmitArena without a source arena"),
-                    aid,
-                    builder,
-                    &mut stack,
-                    in_svg,
-                );
+            EmitTask::EmitArena(aid, space) => {
+                let src = stitching.expect("EmitArena without stitching").src;
+                emit_arena_node(src, aid, builder, &mut stack, space);
                 continue;
             }
-            EmitTask::Emit(id, in_svg) => (id, in_svg),
+            EmitTask::Emit(id, space) => (id, space),
         };
 
         match &nodes[id].data {
             NodeData::Document => {
                 for &child in nodes[id].children.iter().rev() {
-                    stack.push(EmitTask::Emit(child, in_svg));
+                    stack.push(EmitTask::Emit(child, space));
                 }
             }
             NodeData::Doctype => {
@@ -467,7 +496,8 @@ fn emit(
                     .set_type_data(leaf, &text_ref.as_bytes());
             }
             NodeData::Stitch(index) => {
-                stack.push(EmitTask::EmitArena(stitches[*index], in_svg));
+                let stitches = stitching.expect("Stitch node without stitching").stitches;
+                stack.push(EmitTask::EmitArena(stitches[*index], space));
             }
             // HAST has no processing-instruction node; HTML parsing turns `<?...>`
             // into a comment anyway, so this is effectively unreachable.
@@ -478,30 +508,14 @@ fn emit(
                 template_contents,
             } => {
                 let tag_ref = builder.alloc_string(&scrub_markers(&name.local, leaked));
-                // The SVG property schema keeps attribute casing (`viewBox`);
-                // the HTML schema normalises it.
-                let in_svg = &*name.ns == SVG_NAMESPACE;
-                // Children scheduled below inherit this element's namespace as
-                // their context, except under an HTML integration point.
-                let child_in_svg = in_svg && !is_html_integration_point(&name.local);
-                let props: Vec<(StringRef, u8, StringRef)> = attrs
-                    .iter()
-                    // An attribute name containing a leaked marker is junk the
-                    // tokenizer minted from marker text; drop it.
-                    .filter(|attr| {
-                        leaked.is_empty()
-                            || !leaked.iter().any(|m| attr.name.local.contains(m.as_str()))
-                    })
-                    .map(|attr| {
-                        let attr_name = qualified_attr_name(&attr.name);
-                        let (property, prop_kind) = find_property(&attr_name, in_svg);
-                        let name_ref = builder.alloc_string(&property);
-                        let value = scrub_markers(&attr.value, leaked);
-                        let (kind, value_ref) =
-                            coerce_value(builder, prop_kind, &attr_name, &value);
-                        (name_ref, kind, value_ref)
-                    })
-                    .collect();
+                // A parsed element has its own namespace, so the inherited
+                // context does not apply to it; its children take theirs from it.
+                let element_space = match &*name.ns {
+                    SVG_NAMESPACE => HtmlSpace::Svg,
+                    _ => HtmlSpace::Html,
+                };
+                let child_space = element_space.inside(&name.local);
+                let props = parsed_props(builder, attrs, leaked, element_space);
                 let element = builder.open_node_raw(HastNodeType::Element as u8);
                 let data = encode_element_data(tag_ref, &props);
                 builder.arena_mut().set_type_data(element, &data);
@@ -512,15 +526,41 @@ fn emit(
                 // so emit it as the template's children rather than dropping it.
                 if let Some(contents) = template_contents {
                     for &child in nodes[*contents].children.iter().rev() {
-                        stack.push(EmitTask::Emit(child, child_in_svg));
+                        stack.push(EmitTask::Emit(child, child_space));
                     }
                 }
                 for &child in nodes[id].children.iter().rev() {
-                    stack.push(EmitTask::Emit(child, child_in_svg));
+                    stack.push(EmitTask::Emit(child, child_space));
                 }
             }
         }
     }
+}
+
+/// Convert a parsed element's attributes into hast props under the schema of
+/// `space`: SVG keeps attribute casing (`viewBox`), HTML normalises it. An
+/// attribute whose name contains a leaked marker is junk the tokenizer minted
+/// from marker text, and is dropped.
+fn parsed_props(
+    builder: &mut ArenaBuilder<Hast>,
+    attrs: &[Attribute],
+    leaked: &[String],
+    space: HtmlSpace,
+) -> Vec<(StringRef, u8, StringRef)> {
+    attrs
+        .iter()
+        .filter(|attr| {
+            leaked.is_empty() || !leaked.iter().any(|m| attr.name.local.contains(m.as_str()))
+        })
+        .map(|attr| {
+            let attr_name = qualified_attr_name(&attr.name);
+            let (property, prop_kind) = find_property(&attr_name, space.is_svg());
+            let name_ref = builder.alloc_string(&property);
+            let value = scrub_markers(&attr.value, leaked);
+            let (kind, value_ref) = coerce_value(builder, prop_kind, &attr_name, &value);
+            (name_ref, kind, value_ref)
+        })
+        .collect()
 }
 
 /// html5ever splits foreign attrs into prefix + local; the tables key `prefix:local`.
@@ -549,14 +589,14 @@ fn scrub_markers<'a>(text: &'a str, leaked: &[String]) -> std::borrow::Cow<'a, s
 
 /// Copy the source-arena subtree rooted at `aid` into `builder`, scheduling
 /// its children on `stack`. Strings are re-allocated because `src` and the
-/// builder have separate pools. `in_svg` is the namespace context the node
-/// was stitched into; it decides the schema for any raw HTML reparsed below.
+/// builder have separate pools. `space` is the namespace context the node was
+/// stitched into; it decides the schema for any raw HTML reparsed below.
 fn emit_arena_node(
     src: &Arena<Hast>,
     aid: u32,
     builder: &mut ArenaBuilder<Hast>,
     stack: &mut Vec<EmitTask>,
-    in_svg: bool,
+    space: HtmlSpace,
 ) {
     let node_type = src.get_node(aid).node_type;
     let data = src.get_type_data(aid);
@@ -564,7 +604,7 @@ fn emit_arena_node(
     match HastNodeType::from_u8(node_type) {
         Some(HastNodeType::Root) => {
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child, in_svg));
+                stack.push(EmitTask::EmitArena(child, space));
             }
         }
         Some(HastNodeType::Doctype) => {
@@ -579,7 +619,7 @@ fn emit_arena_node(
         }
         Some(HastNodeType::Element) if data.len() >= 16 => {
             let tag = src.get_str(decode_element_tag(data));
-            let child_in_svg = (in_svg || tag == "svg") && !is_html_integration_point(tag);
+            let child_space = space.of_arena_element(tag).inside(tag);
             let tag_ref = builder.alloc_string(tag);
             let props: Vec<(StringRef, u8, StringRef)> = (0..decode_element_prop_count(data))
                 .map(|i| {
@@ -596,16 +636,13 @@ fn emit_arena_node(
             builder.arena_mut().set_type_data(element, &encoded);
             stack.push(EmitTask::Close);
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child, child_in_svg));
+                stack.push(EmitTask::EmitArena(child, child_space));
             }
         }
         #[cfg(feature = "mdx")]
         Some(HastNodeType::MdxJsxElement | HastNodeType::MdxJsxTextElement) if data.len() >= 16 => {
             let name = src.get_str(decode_mdx_jsx_element_name(data));
-            // Like the serializer's schema switch, an MDX element named `svg`
-            // puts its children in SVG content; unlike it, an HTML integration
-            // point takes them back out, as the parser would.
-            let child_in_svg = (in_svg || name == "svg") && !is_html_integration_point(name);
+            let child_space = space.of_arena_element(name).inside(name);
             let name_ref = builder.alloc_string(name);
             let explicit = decode_mdx_jsx_explicit(data);
             let attrs: Vec<(u8, StringRef, StringRef)> = (0..decode_mdx_jsx_attr_count(data))
@@ -623,7 +660,7 @@ fn emit_arena_node(
             builder.arena_mut().set_type_data(element, &encoded);
             // Reparse rather than copy, so raw HTML nested inside the MDX
             // element is resolved too.
-            reparse_children_into(src, aid, builder, child_in_svg);
+            reparse_children_into(src, aid, builder, child_space);
             builder.close_node();
         }
         #[cfg(feature = "mdx")]
@@ -642,7 +679,7 @@ fn emit_arena_node(
         // silently swallows a whole subtree.
         _ => {
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child, in_svg));
+                stack.push(EmitTask::EmitArena(child, space));
             }
         }
     }
@@ -655,18 +692,18 @@ fn emit_arena_node(
 /// text (e.g. inside an unclosed raw `<script>`, in HTML content) is dropped
 /// and its marker scrubbed from the output.
 ///
-/// `in_svg` selects the SVG schema for both directions: the children are
-/// serialized with it and the fragment is parsed in an `<svg>` context, so
-/// SVG-only attributes resolve to their canonical property names.
+/// Serialising and parsing must share `space`, or an SVG-cased attribute
+/// would not survive the round trip.
 fn reparse_children_into(
     src: &Arena<Hast>,
     parent: u32,
     builder: &mut ArenaBuilder<Hast>,
-    in_svg: bool,
+    space: HtmlSpace,
 ) {
     let prefix = stitch_prefix();
     let mut html = String::new();
     let mut stitches: Vec<u32> = Vec::new();
+    let in_svg = space.is_svg();
     {
         let mut on_mdx = |out: &mut String, node_id: u32| {
             out.push_str("<!--");
@@ -680,21 +717,13 @@ fn reparse_children_into(
         }
     }
     let recognizer = StitchRecognizer::new(prefix, stitches.len());
-    let space = if in_svg {
-        HtmlSpace::Svg
-    } else {
-        HtmlSpace::Html
-    };
     let (nodes, roots, leaked) = parse_fragment_nodes(&html, Some(recognizer), space);
-    emit(
-        &nodes,
-        &roots,
-        builder,
-        Some(src),
-        &stitches,
-        &leaked,
-        in_svg,
-    );
+    let stitching = Stitching {
+        src,
+        stitches: &stitches,
+        leaked: &leaked,
+    };
+    emit(&nodes, &roots, builder, Some(stitching), space);
 }
 
 /// Coerce an attribute string into its typed wire `(kind, value)` pair.
@@ -810,9 +839,7 @@ pub fn html_to_hast_arena(html: &str) -> Arena<Hast> {
         &nodes[0].children,
         &mut builder,
         None,
-        &[],
-        &[],
-        false,
+        HtmlSpace::Html,
     );
     builder.close_node();
     builder.finish()
@@ -826,8 +853,7 @@ pub fn html_fragment_to_hast_arena(html: &str, space: HtmlSpace) -> Arena<Hast> 
 
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
     builder.open_node_raw(HastNodeType::Root as u8);
-    let in_svg = space == HtmlSpace::Svg;
-    emit(&nodes, &roots, &mut builder, None, &[], &[], in_svg);
+    emit(&nodes, &roots, &mut builder, None, space);
     builder.close_node();
     builder.finish()
 }
@@ -858,7 +884,7 @@ pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
         return Err("must parse to exactly one element".to_string());
     };
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
-    emit(&nodes, &[wrapper], &mut builder, None, &[], &[], false);
+    emit(&nodes, &[wrapper], &mut builder, None, HtmlSpace::Html);
     Ok(builder.finish())
 }
 
@@ -875,7 +901,7 @@ pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
 pub fn raw_to_hast_arena(arena: &Arena<Hast>) -> Arena<Hast> {
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
     builder.open_node_raw(HastNodeType::Root as u8);
-    reparse_children_into(arena, 0, &mut builder, false);
+    reparse_children_into(arena, 0, &mut builder, HtmlSpace::Html);
     builder.close_node();
     builder.finish()
 }

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -377,9 +377,15 @@ impl TreeSink for HtmlSink {
 
 /// A unit of work for the iterative emitter: emit a sink node, copy a
 /// preserved node from the source arena, or close the open element.
+///
+/// The `bool` is whether the node sits in SVG content. A parsed element
+/// carries its own namespace, so among sink nodes only a [`NodeData::Stitch`]
+/// reads it: the preserved MDX node has no namespace of its own and inherits
+/// its parent's. A copied arena node reads it to pick the schema for any raw
+/// HTML reparsed beneath it.
 enum EmitTask {
-    Emit(usize),
-    EmitArena(u32),
+    Emit(usize, bool),
+    EmitArena(u32, bool),
     Close,
 }
 
@@ -391,7 +397,7 @@ enum EmitTask {
 /// A [`NodeData::Stitch`] node is replaced by the preserved subtree
 /// `stitches[N]` from `src` (`None` for [`html_to_hast_arena`], which never
 /// stitches). `leaked` markers are scrubbed from emitted text, comments, and
-/// attributes.
+/// attributes. `in_svg` is the namespace context of `roots` themselves.
 fn emit(
     nodes: &[Node],
     roots: &[usize],
@@ -399,32 +405,38 @@ fn emit(
     src: Option<&Arena<Hast>>,
     stitches: &[u32],
     leaked: &[String],
+    in_svg: bool,
 ) {
     // Seed with the roots reversed, so they pop in document order.
-    let mut stack: Vec<EmitTask> = roots.iter().rev().map(|&id| EmitTask::Emit(id)).collect();
+    let mut stack: Vec<EmitTask> = roots
+        .iter()
+        .rev()
+        .map(|&id| EmitTask::Emit(id, in_svg))
+        .collect();
 
     while let Some(task) = stack.pop() {
-        let id = match task {
+        let (id, in_svg) = match task {
             EmitTask::Close => {
                 builder.close_node();
                 continue;
             }
-            EmitTask::EmitArena(aid) => {
+            EmitTask::EmitArena(aid, in_svg) => {
                 emit_arena_node(
                     src.expect("EmitArena without a source arena"),
                     aid,
                     builder,
                     &mut stack,
+                    in_svg,
                 );
                 continue;
             }
-            EmitTask::Emit(id) => id,
+            EmitTask::Emit(id, in_svg) => (id, in_svg),
         };
 
         match &nodes[id].data {
             NodeData::Document => {
                 for &child in nodes[id].children.iter().rev() {
-                    stack.push(EmitTask::Emit(child));
+                    stack.push(EmitTask::Emit(child, in_svg));
                 }
             }
             NodeData::Doctype => {
@@ -447,7 +459,7 @@ fn emit(
                     .set_type_data(leaf, &text_ref.as_bytes());
             }
             NodeData::Stitch(index) => {
-                stack.push(EmitTask::EmitArena(stitches[*index]));
+                stack.push(EmitTask::EmitArena(stitches[*index], in_svg));
             }
             // HAST has no processing-instruction node; HTML parsing turns `<?...>`
             // into a comment anyway, so this is effectively unreachable.
@@ -459,7 +471,8 @@ fn emit(
             } => {
                 let tag_ref = builder.alloc_string(&scrub_markers(&name.local, leaked));
                 // The SVG property schema keeps attribute casing (`viewBox`);
-                // the HTML schema normalises it.
+                // the HTML schema normalises it. Children scheduled below
+                // inherit this element's namespace as their context.
                 let in_svg = &*name.ns == SVG_NAMESPACE;
                 let props: Vec<(StringRef, u8, StringRef)> = attrs
                     .iter()
@@ -489,11 +502,11 @@ fn emit(
                 // so emit it as the template's children rather than dropping it.
                 if let Some(contents) = template_contents {
                     for &child in nodes[*contents].children.iter().rev() {
-                        stack.push(EmitTask::Emit(child));
+                        stack.push(EmitTask::Emit(child, in_svg));
                     }
                 }
                 for &child in nodes[id].children.iter().rev() {
-                    stack.push(EmitTask::Emit(child));
+                    stack.push(EmitTask::Emit(child, in_svg));
                 }
             }
         }
@@ -526,12 +539,14 @@ fn scrub_markers<'a>(text: &'a str, leaked: &[String]) -> std::borrow::Cow<'a, s
 
 /// Copy the source-arena subtree rooted at `aid` into `builder`, scheduling
 /// its children on `stack`. Strings are re-allocated because `src` and the
-/// builder have separate pools.
+/// builder have separate pools. `in_svg` is the namespace context the node
+/// was stitched into; it decides the schema for any raw HTML reparsed below.
 fn emit_arena_node(
     src: &Arena<Hast>,
     aid: u32,
     builder: &mut ArenaBuilder<Hast>,
     stack: &mut Vec<EmitTask>,
+    in_svg: bool,
 ) {
     let node_type = src.get_node(aid).node_type;
     let data = src.get_type_data(aid);
@@ -539,7 +554,7 @@ fn emit_arena_node(
     match HastNodeType::from_u8(node_type) {
         Some(HastNodeType::Root) => {
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child));
+                stack.push(EmitTask::EmitArena(child, in_svg));
             }
         }
         Some(HastNodeType::Doctype) => {
@@ -553,7 +568,9 @@ fn emit_arena_node(
                 .set_type_data(leaf, &value_ref.as_bytes());
         }
         Some(HastNodeType::Element) if data.len() >= 16 => {
-            let tag_ref = builder.alloc_string(src.get_str(decode_element_tag(data)));
+            let tag = src.get_str(decode_element_tag(data));
+            let child_in_svg = in_svg || tag == "svg";
+            let tag_ref = builder.alloc_string(tag);
             let props: Vec<(StringRef, u8, StringRef)> = (0..decode_element_prop_count(data))
                 .map(|i| {
                     let (name, kind, value) = decode_element_prop(data, i);
@@ -569,12 +586,16 @@ fn emit_arena_node(
             builder.arena_mut().set_type_data(element, &encoded);
             stack.push(EmitTask::Close);
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child));
+                stack.push(EmitTask::EmitArena(child, child_in_svg));
             }
         }
         #[cfg(feature = "mdx")]
         Some(HastNodeType::MdxJsxElement | HastNodeType::MdxJsxTextElement) if data.len() >= 16 => {
-            let name_ref = builder.alloc_string(src.get_str(decode_mdx_jsx_element_name(data)));
+            let name = src.get_str(decode_mdx_jsx_element_name(data));
+            // Like the serializer's schema switch, an MDX element named `svg`
+            // puts its children in SVG content.
+            let child_in_svg = in_svg || name == "svg";
+            let name_ref = builder.alloc_string(name);
             let explicit = decode_mdx_jsx_explicit(data);
             let attrs: Vec<(u8, StringRef, StringRef)> = (0..decode_mdx_jsx_attr_count(data))
                 .map(|i| {
@@ -591,7 +612,7 @@ fn emit_arena_node(
             builder.arena_mut().set_type_data(element, &encoded);
             // Reparse rather than copy, so raw HTML nested inside the MDX
             // element is resolved too.
-            reparse_children_into(src, aid, builder);
+            reparse_children_into(src, aid, builder, child_in_svg);
             builder.close_node();
         }
         #[cfg(feature = "mdx")]
@@ -610,7 +631,7 @@ fn emit_arena_node(
         // silently swallows a whole subtree.
         _ => {
             for &child in src.get_children(aid).iter().rev() {
-                stack.push(EmitTask::EmitArena(child));
+                stack.push(EmitTask::EmitArena(child, in_svg));
             }
         }
     }
@@ -620,9 +641,18 @@ fn emit_arena_node(
 /// comments), reparse that as a fragment, and emit the result into the
 /// currently open node. Recurses once per nested MDX level via
 /// [`emit_arena_node`]. An MDX node whose placeholder the parser swallowed as
-/// text (e.g. inside an unclosed raw `<script>`) is dropped and its marker
-/// scrubbed from the output.
-fn reparse_children_into(src: &Arena<Hast>, parent: u32, builder: &mut ArenaBuilder<Hast>) {
+/// text (e.g. inside an unclosed raw `<script>`, in HTML content) is dropped
+/// and its marker scrubbed from the output.
+///
+/// `in_svg` selects the SVG schema for both directions: the children are
+/// serialized with it and the fragment is parsed in an `<svg>` context, so
+/// SVG-only attributes resolve to their canonical property names.
+fn reparse_children_into(
+    src: &Arena<Hast>,
+    parent: u32,
+    builder: &mut ArenaBuilder<Hast>,
+    in_svg: bool,
+) {
     let prefix = stitch_prefix();
     let mut html = String::new();
     let mut stitches: Vec<u32> = Vec::new();
@@ -635,12 +665,25 @@ fn reparse_children_into(src: &Arena<Hast>, parent: u32, builder: &mut ArenaBuil
             stitches.push(node_id);
         };
         for &child in src.get_children(parent) {
-            render_node_inner(child, src, &mut html, false, false, Some(&mut on_mdx), 0);
+            render_node_inner(child, src, &mut html, false, in_svg, Some(&mut on_mdx), 0);
         }
     }
     let recognizer = StitchRecognizer::new(prefix, stitches.len());
-    let (nodes, roots, leaked) = parse_fragment_nodes(&html, Some(recognizer), HtmlSpace::Html);
-    emit(&nodes, &roots, builder, Some(src), &stitches, &leaked);
+    let space = if in_svg {
+        HtmlSpace::Svg
+    } else {
+        HtmlSpace::Html
+    };
+    let (nodes, roots, leaked) = parse_fragment_nodes(&html, Some(recognizer), space);
+    emit(
+        &nodes,
+        &roots,
+        builder,
+        Some(src),
+        &stitches,
+        &leaked,
+        in_svg,
+    );
 }
 
 /// Coerce an attribute string into its typed wire `(kind, value)` pair.
@@ -751,7 +794,15 @@ pub fn html_to_hast_arena(html: &str) -> Arena<Hast> {
 
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
     builder.open_node_raw(HastNodeType::Root as u8);
-    emit(&nodes, &nodes[0].children, &mut builder, None, &[], &[]);
+    emit(
+        &nodes,
+        &nodes[0].children,
+        &mut builder,
+        None,
+        &[],
+        &[],
+        false,
+    );
     builder.close_node();
     builder.finish()
 }
@@ -764,7 +815,8 @@ pub fn html_fragment_to_hast_arena(html: &str, space: HtmlSpace) -> Arena<Hast> 
 
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
     builder.open_node_raw(HastNodeType::Root as u8);
-    emit(&nodes, &roots, &mut builder, None, &[], &[]);
+    let in_svg = space == HtmlSpace::Svg;
+    emit(&nodes, &roots, &mut builder, None, &[], &[], in_svg);
     builder.close_node();
     builder.finish()
 }
@@ -795,7 +847,7 @@ pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
         return Err("must parse to exactly one element".to_string());
     };
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
-    emit(&nodes, &[wrapper], &mut builder, None, &[], &[]);
+    emit(&nodes, &[wrapper], &mut builder, None, &[], &[], false);
     Ok(builder.finish())
 }
 
@@ -812,7 +864,7 @@ pub fn html_fragment_to_wrap_arena(html: &str) -> Result<Arena<Hast>, String> {
 pub fn raw_to_hast_arena(arena: &Arena<Hast>) -> Arena<Hast> {
     let mut builder = ArenaBuilder::<Hast>::new(String::new());
     builder.open_node_raw(HastNodeType::Root as u8);
-    reparse_children_into(arena, 0, &mut builder);
+    reparse_children_into(arena, 0, &mut builder, false);
     builder.close_node();
     builder.finish()
 }
@@ -1355,11 +1407,147 @@ mod tests {
 
     #[cfg(feature = "mdx")]
     fn add_mdx_foo(b: &mut ArenaBuilder<Hast>) {
-        let name = b.alloc_string("Foo");
+        open_mdx_element(b, "Foo");
+        b.close_node();
+    }
+
+    /// Open an attribute-less MDX JSX element; the caller closes it.
+    #[cfg(feature = "mdx")]
+    fn open_mdx_element(b: &mut ArenaBuilder<Hast>, name: &str) {
+        let name = b.alloc_string(name);
         let mdx = b.open_node_raw(HastNodeType::MdxJsxElement as u8);
         let data = encode_mdx_jsx_element_data(name, &[], true);
         b.arena_mut().set_type_data(mdx, &data);
-        b.close_node();
+    }
+
+    /// Raw HTML inside an MDX `<svg>` element reparses with the SVG schema,
+    /// like raw HTML inside a real `<svg>` (#249).
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_keeps_svg_schema_inside_mdx_svg_element() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "svg");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd" stroke-width="2"/>"#);
+        b.close_node(); // </svg>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [
+                ("fillRule".into(), PROP_STRING, "evenodd".into()),
+                ("strokeWidth".into(), PROP_STRING, "2".into()),
+            ]
+        );
+    }
+
+    /// Raw HTML inside an MDX element that is not `<svg>` keeps the HTML
+    /// schema: an SVG-only attribute passes through unknown rather than being
+    /// camel-cased.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_keeps_html_schema_inside_non_svg_mdx_element() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "Foo");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd"/>"#);
+        b.close_node(); // </Foo>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fill-rule".into(), PROP_STRING, "evenodd".into())]
+        );
+    }
+
+    /// Ordinary HTML inside an MDX `<svg>` element still parses as HTML: the
+    /// element breaks out of the foreign content and keeps the HTML schema.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_keeps_html_elements_inside_mdx_svg_element() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "svg");
+        add_raw_node(&mut b, r#"<p class="a">x</p>"#);
+        b.close_node(); // </svg>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(tags(&reparsed), ["p"]);
+        assert_eq!(
+            props_of(&reparsed, "p"),
+            [("className".into(), PROP_SPACE_SEP, "a".into())]
+        );
+    }
+
+    /// A hast element's SVG-cased property inside an MDX `<svg>` element is
+    /// serialized with the SVG schema, so the reparse reads it back intact.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_serializes_svg_properties_inside_mdx_svg_element() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "svg");
+        let tag = b.alloc_string("path");
+        let name = b.alloc_string("fillRule");
+        let value = b.alloc_string("evenodd");
+        let el = b.open_node_raw(HastNodeType::Element as u8);
+        let data = encode_element_data(tag, &[(name, PROP_STRING, value)]);
+        b.arena_mut().set_type_data(el, &data);
+        b.close_node(); // </path>
+        b.close_node(); // </svg>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fillRule".into(), PROP_STRING, "evenodd".into())]
+        );
+    }
+
+    /// The SVG context is sticky through an MDX element nested inside an MDX
+    /// `<svg>` element, as it is for descendants of a real `<svg>`.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_keeps_svg_schema_across_nested_mdx_elements() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "svg");
+        open_mdx_element(&mut b, "Foo");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd"/>"#);
+        b.close_node(); // </Foo>
+        b.close_node(); // </svg>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fillRule".into(), PROP_STRING, "evenodd".into())]
+        );
+    }
+
+    /// An MDX element stitched back under a raw `<svg>` inherits that
+    /// element's namespace for its own raw children.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_keeps_svg_schema_for_mdx_element_inside_raw_svg() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        add_raw_node(&mut b, "<svg>");
+        open_mdx_element(&mut b, "Foo");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd"/>"#);
+        b.close_node(); // </Foo>
+        add_raw_node(&mut b, "</svg>");
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(tags(&reparsed), ["svg", "path"]);
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fillRule".into(), PROP_STRING, "evenodd".into())]
+        );
     }
 
     /// A stitch-like comment authored in raw HTML must survive as an ordinary

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -34,6 +34,13 @@ use crate::shared::{
 const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
 
+/// SVG elements whose content is parsed as HTML (the spec's HTML integration
+/// points), so SVG content stops at them. MathML's integration points never
+/// arise: MathML is parsed in the HTML context here.
+fn is_html_integration_point(local: &str) -> bool {
+    matches!(local, "foreignObject" | "desc" | "title")
+}
+
 /// The namespace a fragment's own top-level content is parsed in.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum HtmlSpace {
@@ -471,9 +478,11 @@ fn emit(
             } => {
                 let tag_ref = builder.alloc_string(&scrub_markers(&name.local, leaked));
                 // The SVG property schema keeps attribute casing (`viewBox`);
-                // the HTML schema normalises it. Children scheduled below
-                // inherit this element's namespace as their context.
+                // the HTML schema normalises it.
                 let in_svg = &*name.ns == SVG_NAMESPACE;
+                // Children scheduled below inherit this element's namespace as
+                // their context, except under an HTML integration point.
+                let child_in_svg = in_svg && !is_html_integration_point(&name.local);
                 let props: Vec<(StringRef, u8, StringRef)> = attrs
                     .iter()
                     // An attribute name containing a leaked marker is junk the
@@ -502,11 +511,11 @@ fn emit(
                 // so emit it as the template's children rather than dropping it.
                 if let Some(contents) = template_contents {
                     for &child in nodes[*contents].children.iter().rev() {
-                        stack.push(EmitTask::Emit(child, in_svg));
+                        stack.push(EmitTask::Emit(child, child_in_svg));
                     }
                 }
                 for &child in nodes[id].children.iter().rev() {
-                    stack.push(EmitTask::Emit(child, in_svg));
+                    stack.push(EmitTask::Emit(child, child_in_svg));
                 }
             }
         }
@@ -569,7 +578,7 @@ fn emit_arena_node(
         }
         Some(HastNodeType::Element) if data.len() >= 16 => {
             let tag = src.get_str(decode_element_tag(data));
-            let child_in_svg = in_svg || tag == "svg";
+            let child_in_svg = (in_svg || tag == "svg") && !is_html_integration_point(tag);
             let tag_ref = builder.alloc_string(tag);
             let props: Vec<(StringRef, u8, StringRef)> = (0..decode_element_prop_count(data))
                 .map(|i| {
@@ -593,8 +602,9 @@ fn emit_arena_node(
         Some(HastNodeType::MdxJsxElement | HastNodeType::MdxJsxTextElement) if data.len() >= 16 => {
             let name = src.get_str(decode_mdx_jsx_element_name(data));
             // Like the serializer's schema switch, an MDX element named `svg`
-            // puts its children in SVG content.
-            let child_in_svg = in_svg || name == "svg";
+            // puts its children in SVG content; unlike it, an HTML integration
+            // point takes them back out, as the parser would.
+            let child_in_svg = (in_svg || name == "svg") && !is_html_integration_point(name);
             let name_ref = builder.alloc_string(name);
             let explicit = decode_mdx_jsx_explicit(data);
             let attrs: Vec<(u8, StringRef, StringRef)> = (0..decode_mdx_jsx_attr_count(data))
@@ -1547,6 +1557,50 @@ mod tests {
         assert_eq!(
             props_of(&reparsed, "path"),
             [("fillRule".into(), PROP_STRING, "evenodd".into())]
+        );
+    }
+
+    /// A raw `<foreignObject>` is an HTML integration point: an MDX element
+    /// stitched back under it parses its own raw children as HTML, just as
+    /// the parser treats the element's direct children.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_exits_svg_schema_for_mdx_element_inside_raw_foreign_object() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        add_raw_node(&mut b, "<svg><foreignObject>");
+        open_mdx_element(&mut b, "Foo");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd"/>"#);
+        b.close_node(); // </Foo>
+        add_raw_node(&mut b, "</foreignObject></svg>");
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(tags(&reparsed), ["svg", "foreignObject", "path"]);
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fill-rule".into(), PROP_STRING, "evenodd".into())]
+        );
+    }
+
+    /// An MDX `<foreignObject>` inside an MDX `<svg>` likewise switches its
+    /// raw children back to the HTML schema.
+    #[cfg(feature = "mdx")]
+    #[test]
+    fn raw_reparse_exits_svg_schema_inside_mdx_foreign_object() {
+        let mut b = ArenaBuilder::<Hast>::new(String::new());
+        b.open_node_raw(HastNodeType::Root as u8);
+        open_mdx_element(&mut b, "svg");
+        open_mdx_element(&mut b, "foreignObject");
+        add_raw_node(&mut b, r#"<path fill-rule="evenodd"/>"#);
+        b.close_node(); // </foreignObject>
+        b.close_node(); // </svg>
+        b.close_node(); // </root>
+
+        let reparsed = raw_to_hast_arena(&b.finish());
+        assert_eq!(
+            props_of(&reparsed, "path"),
+            [("fill-rule".into(), PROP_STRING, "evenodd".into())]
         );
     }
 

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -16,12 +16,12 @@ use html5ever::{
 use satteri_arena::{Arena, ArenaBuilder, Hast, StringRef};
 use satteri_property_info::{PropKind, find_property};
 
-use crate::hast::HastNodeType;
 use crate::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
     encode_element_data,
 };
-use crate::hast::render::{is_void_element, render_node_inner};
+use crate::hast::render::{RenderOptions, is_void_element, render_node_inner};
+use crate::hast::{HastNodeType, is_svg_html_integration_point};
 #[cfg(feature = "mdx")]
 use crate::mdast::codec::{
     decode_mdx_jsx_attr, decode_mdx_jsx_attr_count, decode_mdx_jsx_element_name,
@@ -33,14 +33,6 @@ use crate::shared::{
 
 const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
-
-/// SVG elements whose content is parsed as HTML (the spec's HTML integration
-/// points), so SVG content stops at them. MathML's integration points do not
-/// matter here: the context only tracks SVG content, which html5ever's
-/// MathML-namespace elements never enter.
-fn is_html_integration_point(local: &str) -> bool {
-    matches!(local, "foreignObject" | "desc" | "title")
-}
 
 /// The namespace HTML content is parsed in; for a fragment, that of its own
 /// top-level content.
@@ -70,7 +62,7 @@ impl HtmlSpace {
     /// The space for the content of an element named `tag` that itself sits
     /// in `self`: an HTML integration point parses its content as HTML.
     fn inside(self, tag: &str) -> HtmlSpace {
-        if self.is_svg() && !is_html_integration_point(tag) {
+        if self.is_svg() && !is_svg_html_integration_point(tag) {
             HtmlSpace::Svg
         } else {
             HtmlSpace::Html
@@ -703,7 +695,7 @@ fn reparse_children_into(
     let prefix = stitch_prefix();
     let mut html = String::new();
     let mut stitches: Vec<u32> = Vec::new();
-    let in_svg = space.is_svg();
+    let context = RenderOptions::new(false, space.is_svg());
     {
         let mut on_mdx = |out: &mut String, node_id: u32| {
             out.push_str("<!--");
@@ -713,7 +705,7 @@ fn reparse_children_into(
             stitches.push(node_id);
         };
         for &child in src.get_children(parent) {
-            render_node_inner(child, src, &mut html, false, in_svg, Some(&mut on_mdx), 0);
+            render_node_inner(child, src, &mut html, context, Some(&mut on_mdx), 0);
         }
     }
     let recognizer = StitchRecognizer::new(prefix, stitches.len());
@@ -977,6 +969,49 @@ mod tests {
         let arena = html_fragment_to_hast_arena("<p>hi</p>", HtmlSpace::Html);
         assert_eq!(arena.get_node(0).node_type, HastNodeType::Root as u8);
         assert_eq!(tags(&arena), ["p"]);
+    }
+
+    #[test]
+    fn svg_serialization_preserves_script_and_style_text() {
+        for tag in ["script", "style"] {
+            let html = format!("<svg><{tag}>a&lt;b &amp; &amp;copy;</{tag}></svg>");
+            let arena = html_fragment_to_hast_arena(&html, HtmlSpace::Html);
+            assert_eq!(hast_arena_to_html(&arena), format!("{html}\n"));
+            let reparsed = raw_to_hast_arena(&arena);
+            assert_eq!(tags(&reparsed), ["svg", tag]);
+            assert_eq!(crate::hast::text_content(&reparsed, 0), "a<b & &copy;");
+        }
+    }
+
+    #[test]
+    fn svg_serialization_preserves_void_named_elements_children_and_siblings() {
+        let html = "<svg><input><path></path></input><path></path></svg>";
+        let arena = html_fragment_to_hast_arena(html, HtmlSpace::Html);
+        assert_eq!(hast_arena_to_html(&arena), format!("{html}\n"));
+        let reparsed = raw_to_hast_arena(&arena);
+        let svg = reparsed.get_children(0)[0];
+        let children = reparsed.get_children(svg);
+        assert_eq!(children.len(), 2);
+        assert_eq!(reparsed.get_children(children[0]).len(), 1);
+        assert!(reparsed.get_children(children[1]).is_empty());
+        assert_eq!(tags(&reparsed), ["svg", "input", "path", "path"]);
+    }
+
+    #[test]
+    fn svg_serialization_uses_html_rules_inside_integration_points() {
+        for tag in ["foreignObject", "desc", "title"] {
+            let html = format!(
+                "<svg><{tag}><input><script>a<b & &copy;</script>\
+                 <svg><input></input><style>a&lt;b &amp; &amp;copy;</style></svg>\
+                 </{tag}></svg>"
+            );
+            let arena = html_fragment_to_hast_arena(&html, HtmlSpace::Html);
+            assert_eq!(hast_arena_to_html(&arena), format!("{html}\n"));
+            assert_eq!(
+                hast_arena_to_html(&raw_to_hast_arena(&arena)),
+                format!("{html}\n")
+            );
+        }
     }
 
     #[test]

--- a/crates/satteri-ast/src/hast/mod.rs
+++ b/crates/satteri-ast/src/hast/mod.rs
@@ -19,7 +19,14 @@ pub use from_html::{
     raw_to_hast_arena,
 };
 pub use node::HastNodeType;
-pub use render::{hast_arena_to_html, is_void_element, render_node};
+pub use render::{
+    RenderOptions, hast_arena_to_html, is_void_element, render_node, render_node_with_options,
+};
+
+/// SVG elements whose children are parsed as HTML.
+pub(crate) fn is_svg_html_integration_point(tag: &str) -> bool {
+    matches!(tag, "foreignObject" | "desc" | "title")
+}
 
 /// Collect concatenated text content from a HAST arena.
 ///

--- a/crates/satteri-ast/src/hast/render.rs
+++ b/crates/satteri-ast/src/hast/render.rs
@@ -2,12 +2,12 @@
 
 use satteri_arena::{Arena, Hast};
 
-use crate::hast::HastNodeType;
 use crate::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
 };
 use crate::hast::escape::{escape_html_attr_value, escape_html_body_text};
 use crate::hast::properties::property_to_attribute;
+use crate::hast::{HastNodeType, is_svg_html_integration_point};
 use crate::shared::{
     PROP_BOOL_FALSE, PROP_BOOL_TRUE, PROP_COMMA_SEP, PROP_COMMA_SEP_NUM, PROP_INT, PROP_SPACE_SEP,
     PROP_STRING,
@@ -26,12 +26,13 @@ pub fn hast_arena_to_html(arena: &Arena<Hast>) -> String {
 /// Render a HAST node subtree to HTML.
 ///
 /// `in_raw_text` indicates the node is being rendered inside a raw-text element
-/// (`<script>` / `<style>`). Per the HTML spec, descendant text of these elements
-/// is not entity-escaped.
+/// (HTML `<script>` / `<style>`). Descendant text of these elements is not
+/// entity-escaped; SVG script/style text is escaped.
 ///
 /// `in_svg` selects the SVG attribute schema. Set on entry to `<svg>` and
 /// sticky for all descendants — `<foreignObject>` does NOT switch back, matching
-/// `hast-util-to-html`.
+/// `hast-util-to-html`. It also sets the initial content namespace, which does
+/// switch back to HTML at SVG integration points for text and void-element rules.
 pub fn render_node(
     node_id: u32,
     view: &Arena<Hast>,
@@ -39,7 +40,49 @@ pub fn render_node(
     in_raw_text: bool,
     in_svg: bool,
 ) {
-    render_node_inner(node_id, view, out, in_raw_text, in_svg, None, 0);
+    render_node_with_options(node_id, view, out, RenderOptions::new(in_raw_text, in_svg));
+}
+
+/// Attribute casing stays in the SVG schema through integration points, but
+/// text escaping and void tags follow the content namespace instead.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RenderOptions {
+    /// Whether text is inside an HTML raw-text element and must remain unescaped.
+    pub in_raw_text: bool,
+    /// Whether attributes use the SVG schema, including below integration points.
+    pub svg_schema: bool,
+    /// Whether elements are in SVG content, controlling escaping and void tags.
+    pub svg_content: bool,
+}
+
+impl RenderOptions {
+    pub(crate) fn new(in_raw_text: bool, in_svg: bool) -> Self {
+        Self {
+            in_raw_text,
+            svg_schema: in_svg,
+            svg_content: in_svg,
+        }
+    }
+
+    /// Derive the rendering options for the children of an element named `tag`.
+    pub fn for_children(self, tag: &str) -> Self {
+        let element_in_svg = self.svg_content || tag == "svg";
+        Self {
+            in_raw_text: self.in_raw_text || (!element_in_svg && is_raw_text_element(tag)),
+            svg_schema: self.svg_schema || tag == "svg",
+            svg_content: element_in_svg && !is_svg_html_integration_point(tag),
+        }
+    }
+}
+
+/// Render a subtree with separate attribute-schema and content-namespace options.
+pub fn render_node_with_options(
+    node_id: u32,
+    view: &Arena<Hast>,
+    out: &mut String,
+    options: RenderOptions,
+) {
+    render_node_inner(node_id, view, out, options, None, 0);
 }
 
 /// Raw-HTML reparse hook: receives the output buffer and the MDX node's id.
@@ -51,13 +94,12 @@ pub(crate) fn render_node_inner<'cb>(
     node_id: u32,
     view: &Arena<Hast>,
     out: &mut String,
-    in_raw_text: bool,
-    in_svg: bool,
+    context: RenderOptions,
     on_mdx: Option<&mut OnMdx<'cb>>,
     depth: u32,
 ) {
     crate::stack::with_headroom(depth, || {
-        render_node_at(node_id, view, out, in_raw_text, in_svg, on_mdx, depth);
+        render_node_at(node_id, view, out, context, on_mdx, depth);
     });
 }
 
@@ -65,8 +107,7 @@ fn render_node_at<'cb>(
     node_id: u32,
     view: &Arena<Hast>,
     out: &mut String,
-    in_raw_text: bool,
-    in_svg: bool,
+    context: RenderOptions,
     mut on_mdx: Option<&mut OnMdx<'cb>>,
     depth: u32,
 ) {
@@ -78,8 +119,7 @@ fn render_node_at<'cb>(
                 child_id,
                 view,
                 out,
-                in_raw_text,
-                in_svg,
+                context,
                 on_mdx.as_deref_mut(),
                 depth + 1,
             );
@@ -94,8 +134,7 @@ fn render_node_at<'cb>(
                     child_id,
                     view,
                     out,
-                    in_raw_text,
-                    in_svg,
+                    context,
                     on_mdx.as_deref_mut(),
                     depth + 1,
                 );
@@ -112,7 +151,8 @@ fn render_node_at<'cb>(
 
             // The schema switch covers the <svg> element's own attributes too,
             // not just its descendants.
-            let element_in_svg = in_svg || tag == "svg";
+            let svg_schema = context.svg_schema || tag == "svg";
+            let element_in_svg = context.svg_content || tag == "svg";
 
             out.push('<');
             out.push_str(tag);
@@ -121,7 +161,7 @@ fn render_node_at<'cb>(
             for i in 0..prop_count {
                 let (name_ref, value_kind, value_ref) = decode_element_prop(data, i);
                 let name = view.get_str(name_ref);
-                let attr_name = property_to_attribute(name, element_in_svg);
+                let attr_name = property_to_attribute(name, svg_schema);
                 match value_kind {
                     PROP_BOOL_TRUE => {
                         out.push(' ');
@@ -141,18 +181,17 @@ fn render_node_at<'cb>(
                 }
             }
 
-            if is_void_element(tag) {
+            if !element_in_svg && is_void_element(tag) {
                 out.push('>');
             } else {
                 out.push('>');
-                let child_in_raw_text = in_raw_text || is_raw_text_element(tag);
+                let child_context = context.for_children(tag);
                 for &child_id in view.get_children(node_id) {
                     render_node_inner(
                         child_id,
                         view,
                         out,
-                        child_in_raw_text,
-                        element_in_svg,
+                        child_context,
                         on_mdx.as_deref_mut(),
                         depth + 1,
                     );
@@ -168,7 +207,7 @@ fn render_node_at<'cb>(
             if data.len() >= 8 {
                 let sr = decode_text_data(data);
                 let text = view.get_str(sr);
-                if in_raw_text {
+                if context.in_raw_text {
                     out.push_str(text);
                 } else {
                     escape_html_body_text(out, text);

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -27,10 +27,10 @@ use oxc_syntax::node::NodeId;
 use rustc_hash::FxHashMap;
 use satteri_arena::mdx_types::{self as message, Location, MdxExpressionKind, Stop};
 use satteri_arena::{Arena, Hast};
-use satteri_ast::hast::HastNodeType;
 use satteri_ast::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
 };
+use satteri_ast::hast::{HastNodeType, RenderOptions};
 use satteri_ast::mdast::codec::{
     decode_mdx_jsx_attr, decode_mdx_jsx_attr_count, decode_mdx_jsx_element_name,
     decode_mdx_jsx_explicit,
@@ -102,16 +102,9 @@ impl MdxProgram<'_> {
     }
 }
 
-/// Whether we're in HTML or SVG.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Space {
-    Html,
-    Svg,
-}
-
 /// Context used to compile hast into OXC's ES AST.
 struct Context<'a> {
-    space: Space,
+    render_options: RenderOptions,
     comments: Vec<MdxComment>,
     esm: Vec<Statement<'a>>,
     location: Option<&'a Location<'a>>,
@@ -143,7 +136,7 @@ pub fn hast_util_to_oxc<'a>(
         prepare_component_overrides(view, allocator, location, optimize_static)?;
 
     let mut context = Context {
-        space: Space::Html,
+        render_options: RenderOptions::default(),
         comments: vec![],
         esm: vec![],
         location,
@@ -407,9 +400,14 @@ fn is_text_node(view: &Arena<Hast>, node_id: u32) -> bool {
     )
 }
 
-fn render_static_group(view: &Arena<Hast>, node_ids: &[u32], out: &mut String, space: Space) {
+fn render_static_group(
+    view: &Arena<Hast>,
+    node_ids: &[u32],
+    out: &mut String,
+    options: RenderOptions,
+) {
     for &node_id in node_ids {
-        satteri_ast::hast::render_node(node_id, view, out, false, space == Space::Svg);
+        satteri_ast::hast::render_node_with_options(node_id, view, out, options);
     }
 }
 
@@ -523,7 +521,7 @@ fn all<'a>(
                         context.view,
                         &context.view.get_children(parent_id)[group_start..i],
                         &mut html_buf,
-                        context.space,
+                        context.render_options,
                     );
                     if !html_buf.is_empty() {
                         result.push(create_raw_html_jsx(context.allocator, &html_buf, config));
@@ -593,13 +591,11 @@ fn transform_element<'a>(
     let tag_ref = decode_element_tag(data);
     let tag_name = context.view.get_str(tag_ref);
 
-    let space = context.space;
-    if space == Space::Html && tag_name == "svg" {
-        context.space = Space::Svg;
-    }
+    let render_options = context.render_options;
+    context.render_options = render_options.for_children(tag_name);
 
     let children = all(context, node_id, explicit_jsxs)?;
-    context.space = space;
+    context.render_options = render_options;
 
     let alloc = context.allocator;
     let prop_count = decode_element_prop_count(data);
@@ -607,7 +603,7 @@ fn transform_element<'a>(
 
     // The schema switch covers the <svg> element's own attributes too, not
     // just its descendants (mirrors the HTML serializer in hast/render.rs).
-    let in_svg = space == Space::Svg || tag_name == "svg";
+    let in_svg = render_options.svg_schema || tag_name == "svg";
     let attr_case = context.element_attribute_name_case;
     let style_case = context.style_property_name_case;
     for i in 0..prop_count {
@@ -702,16 +698,13 @@ fn transform_mdx_jsx_element<'a>(
         Some(name_str)
     };
 
-    let space = context.space;
-    if let Some(n) = name
-        && space == Space::Html
-        && n == "svg"
-    {
-        context.space = Space::Svg;
+    let render_options = context.render_options;
+    if let Some(name) = name {
+        context.render_options = render_options.for_children(name);
     }
 
     let children = all(context, node_id, explicit_jsxs)?;
-    context.space = space;
+    context.render_options = render_options;
 
     let alloc = context.allocator;
     let attr_count = decode_mdx_jsx_attr_count(data);

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -1368,6 +1368,29 @@ describe("mdxToJs", () => {
     expect(js).toContain('strokeWidth: "1"');
   });
 
+  test("rawHtml keeps the SVG schema for raw HTML inside a JSX <svg> (#249)", () => {
+    // An `html` node is the only way raw HTML reaches the MDX path: `{ raw }`
+    // is parsed as MDX, where `<path .../>` would already be JSX.
+    const inject = defineMdastPlugin({
+      name: "inject-html-path",
+      paragraph() {
+        return {
+          type: "html" as const,
+          value: '<path fill-rule="evenodd" stroke-width="2"/>',
+        } as MdastNode;
+      },
+    });
+    const { code: js } = mdxToJs('<svg viewBox="0 0 10 10">\n\ntext\n\n</svg>\n', {
+      mdastPlugins: [inject],
+      features: { rawHtml: true },
+    });
+    // The raw <path> reparses in the SVG namespace, so its attributes map to
+    // the canonical SVG property names instead of passing through unknown.
+    expect(js).toContain('fillRule: "evenodd"');
+    expect(js).toContain('strokeWidth: "2"');
+    expect(js).not.toContain("fill-rule");
+  });
+
   test("style attribute parses into an object by default (DOM casing)", () => {
     const { code: js } = mdxToJs("| a | b |\n|:--|--:|\n| c | d |\n", {
       features: { gfm: true },

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/index.js";
 import type { MarkdownToJsOptions } from "../src/index.js";
 import type { HastNode } from "../src/hast/hast-materializer.js";
-import type { MdastNode } from "../src/types.js";
+import type { Custom, MdastNode } from "../src/types.js";
 import type { Element } from "hast";
 import type { MdxJsxFlowElement, MdxJsxFlowElementData } from "../src/mdx-types.js";
 
@@ -1390,6 +1390,128 @@ describe("mdxToJs", () => {
     expect(js).toContain('strokeWidth: "2"');
     expect(js).not.toContain("fill-rule");
   });
+
+  test.each([
+    ["script", 'if (a<b && c) { const label = "&copy;"; }'],
+    ["style", 'a::before { content: "<b>&copy;"; }'],
+  ])("rawHtml preserves plugin-created %s text inside JSX svg", (tag, value) => {
+    const inject = defineMdastPlugin({
+      name: "inject-svg-text",
+      paragraph(): MdastNode {
+        return {
+          type: "paragraph",
+          data: { hName: tag },
+          children: [{ type: "text", value }],
+        };
+      },
+    });
+    const tree = mdxToHast("<svg>\n\ntext\n\n</svg>", {
+      mdastPlugins: [inject],
+      features: { rawHtml: true },
+      position: false,
+    });
+    expect(tree.type).toBe("root");
+    if (tree.type !== "root") throw new Error("expected a root");
+    expect(tree.children).toEqual([
+      expect.objectContaining({
+        type: "mdxJsxFlowElement",
+        name: "svg",
+        children: [
+          {
+            type: "element",
+            tagName: tag,
+            properties: {},
+            children: [{ type: "text", value }],
+          },
+        ],
+      }),
+    ]);
+  });
+
+  test("rawHtml preserves children and siblings of a plugin-created SVG input", () => {
+    const path: Custom = {
+      type: "custom",
+      data: { hName: "path", hProperties: { fillRule: "evenodd" } },
+      children: [],
+    };
+    const inject = defineMdastPlugin({
+      name: "inject-svg-input",
+      paragraph(node, ctx) {
+        ctx.replaceNode(node, {
+          type: "custom",
+          data: { hName: "g" },
+          children: [{ type: "custom", data: { hName: "input" }, children: [path] }, path],
+        });
+      },
+    });
+    const tree = mdxToHast("<svg>\n\ntext\n\n</svg>", {
+      mdastPlugins: [inject],
+      features: { rawHtml: true },
+      position: false,
+    });
+    const expectedPath = {
+      type: "element",
+      tagName: "path",
+      properties: { fillRule: "evenodd" },
+      children: [],
+    };
+    expect(tree.type).toBe("root");
+    if (tree.type !== "root") throw new Error("expected a root");
+    expect(tree.children).toEqual([
+      expect.objectContaining({
+        type: "mdxJsxFlowElement",
+        name: "svg",
+        children: [
+          {
+            type: "element",
+            tagName: "g",
+            properties: {},
+            children: [
+              { type: "element", tagName: "input", properties: {}, children: [expectedPath] },
+              expectedPath,
+            ],
+          },
+        ],
+      }),
+    ]);
+  });
+
+  test.each(["svg", "foreignObject", "desc", "title"])(
+    "optimizeStatic preserves the content namespace below a dynamic %s",
+    (tag) => {
+      const inject = defineMdastPlugin({
+        name: "inject-html-in-svg",
+        paragraph(node, ctx) {
+          ctx.replaceNode(node, {
+            type: "custom",
+            data: { hName: "g" },
+            children: [
+              { type: "custom", data: { hName: "input" }, children: [] },
+              {
+                type: "custom",
+                data: { hName: "script" },
+                children: [{ type: "text", value: "a<b & &copy;" }],
+              },
+            ],
+          });
+        },
+      });
+      const source =
+        tag === "svg"
+          ? "<svg>{value}\n\ntext\n\n</svg>"
+          : `<svg><${tag}>{value}\n\ntext\n\n</${tag}></svg>`;
+      const { code } = mdxToJs(source, {
+        mdastPlugins: [inject],
+        features: { rawHtml: true },
+        optimizeStatic: { component: "Fragment", prop: "set:html" },
+      });
+      expect(code).toContain(
+        tag === "svg"
+          ? '"set:html": "<g><input></input><script>a&lt;b &amp; &amp;copy;'
+          : '"set:html": "<g><input><script>a<b & &copy;',
+      );
+    },
+  );
 
   test("style attribute parses into an object by default (DOM casing)", () => {
     const { code: js } = mdxToJs("| a | b |\n|:--|--:|\n| c | d |\n", {


### PR DESCRIPTION
Fixes #249. Refs #284.

## Problem

With `rawHtml`, raw HTML inside a JSX `<svg>` was serialized and reparsed in an HTML fragment context. SVG attributes such as `fill-rule` consequently failed to become canonical HAST properties such as `fillRule`.

Switching only the parser to SVG also exposed serializer bugs: plugin-created SVG script/style text containing `<` or character-reference-like text was corrupted, and elements with HTML void-element names could lose children or absorb following siblings.

## Changes

- Carry `HtmlSpace` through the emitter and preserved JSX subtrees so raw children inherit the correct parsing context. Exit SVG content at `foreignObject`, `desc`, and `title`, and re-enter it at nested `svg` elements.
- Track the attribute schema separately from the content namespace during serialization. SVG script/style text is escaped, and SVG elements receive closing tags even when their names match HTML void elements. HTML content inside integration points retains its ordinary serialization rules.
- Share `RenderOptions` with static MDX compilation so static subtrees below dynamic elements receive the same context. Existing `render_node` callers remain supported; `render_node_with_options` accepts the explicit context.
- Include Sampo changesets and regression tests for attribute casing, text preservation, child/sibling structure, integration points, and static serialization.

Raw MathML inside JSX `<math>` remains a separate issue tracked in #285.

## Validation

- `cargo test --all`
- `SKIP_FUZZ=1 pnpm --dir packages/satteri test`
- `pnpm --dir packages/satteri typecheck`
- `pnpm lint` and `cargo clippy --all --all-targets`
- `cargo check -p satteri-ast --no-default-features`
- Rust formatting, changed-file TypeScript/Markdown formatting, and `git diff --check`
- 31 additional focused review cases covering namespace transitions, generated-JavaScript execution, and the reproduced regressions

The text and structure regressions were reproduced before the fix. All 31 focused review cases pass after it. Clock-seeded fuzz tests were excluded, matching CI.
