### PR TITLE
feat: add Android ARM64 native binding target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
             target: aarch64-unknown-linux-gnu
             build: pnpm run build:binary:native --target aarch64-unknown-linux-gnu --use-napi-cross
 
+          # -- Android --
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            build: pnpm run build:binary:native --target aarch64-linux-android
+
           # -- Linux musl (Alpine) --
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/.sampo/changesets/forthright-prince-erika.md
+++ b/.sampo/changesets/forthright-prince-erika.md
@@ -1,0 +1,5 @@
+---
+npm/satteri: patch
+---
+
+Added Android ARM64 native binding support.

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -94,6 +94,7 @@
     "targets": [
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
+      "aarch64-linux-android",
       "x86_64-unknown-linux-musl",
       "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",


### PR DESCRIPTION
Closes #294

## Changes

- Add `aarch64-linux-android` to the Sätteri N-API targets.
- Add an Android ARM64 build to the release matrix.
- Enable generation and publishing of `@bruits/satteri-android-arm64` through the existing napi-rs packaging flow.

The existing runtime loader already supports Android ARM64, so no runtime-specific logic is added.

## Testing

Tested on native ARM64 Android using Termux.

- Built `satteri_napi.android-arm64.node` for `aarch64-linux-android`.
- Loaded the native binding directly with Node.
- Verified normal `import 'satteri'` loading through the existing package loader.
- Successfully executed `markdownToHtml()`.
- Verified the native binding in an Astro 7 project without `NAPI_RS_FORCE_WASI`.
