### PR TITLE
fix(mdx): keep SVG `datatype` out of the React `data-*` kebab-casing

### DIFF
--- a/.sampo/changesets/react-casing-svg-datatype.md
+++ b/.sampo/changesets/react-casing-svg-datatype.md
@@ -1,0 +1,9 @@
+---
+cargo/satteri-property-info: patch
+cargo/satteri-ast: patch
+cargo/satteri-mdxjs: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed the default `elementAttributeNameCase: "react"` compiling the SVG `datatype` attribute to `data-type`. It now emits `datatype`, while custom `data-*` attributes on SVG and HTML elements are still kebab-cased.

--- a/crates/satteri-ast/src/hast/properties.rs
+++ b/crates/satteri-ast/src/hast/properties.rs
@@ -1,7 +1,7 @@
 //! HAST property name → HTML/SVG attribute name mapping, re-exported from
 //! [`satteri_property_info`].
 
-pub use satteri_property_info::property_to_attribute;
+pub use satteri_property_info::{is_known_property, property_to_attribute};
 
 /// ECMAScript includes BOM but excludes NEL from its whitespace set.
 pub(crate) fn trim_js_whitespace(value: &str) -> &str {

--- a/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
+++ b/crates/satteri-mdxjs-rs/src/hast_util_to_oxc.rs
@@ -30,6 +30,7 @@ use satteri_arena::{Arena, Hast};
 use satteri_ast::hast::codec::{
     decode_element_prop, decode_element_prop_count, decode_element_tag, decode_text_data,
 };
+use satteri_ast::hast::properties::{is_known_property, property_to_attribute};
 use satteri_ast::hast::{HastNodeType, RenderOptions};
 use satteri_ast::mdast::codec::{
     decode_mdx_jsx_attr, decode_mdx_jsx_attr_count, decode_mdx_jsx_element_name,
@@ -670,10 +671,8 @@ fn transform_element<'a>(
         // Keep the Cow borrowed where possible: create_jsx_attr_name_from_str
         // arena-copies from &str, so an intermediate String is pure waste.
         let attr_name = match attr_case {
-            ElementAttributeNameCase::React => Cow::Owned(prop_to_attr_name(name)),
-            ElementAttributeNameCase::Html => {
-                satteri_ast::hast::properties::property_to_attribute(name, in_svg)
-            }
+            ElementAttributeNameCase::React => Cow::Owned(prop_to_attr_name(name, in_svg)),
+            ElementAttributeNameCase::Html => property_to_attribute(name, in_svg),
         };
         attrs.push(JSXAttributeItem::Attribute(OxcBox::new_in(
             JSXAttribute {
@@ -1065,9 +1064,11 @@ fn create_fragment<'a>(
 }
 
 /// Turn a hast property into something that particularly React understands.
-fn prop_to_attr_name(prop: &str) -> String {
-    // Arbitrary data props, kebab case them.
-    if prop.len() > 4 && prop.starts_with("data") {
+fn prop_to_attr_name(prop: &str, in_svg: bool) -> String {
+    // Arbitrary data props, kebab case them. The schema wins first, as in
+    // `property_to_attribute`: `dataType` is a real SVG attribute whose React
+    // name is `datatype`, not a custom `data-type` (issue #250).
+    if prop.len() > 4 && prop.starts_with("data") && !is_known_property(prop, in_svg) {
         let mut result = String::with_capacity(prop.len() + 2);
         let bytes = prop.as_bytes();
         let mut index = 4;
@@ -1396,5 +1397,25 @@ mod tests {
                 ("color".to_string(), "red".to_string())
             ]
         );
+    }
+
+    #[test]
+    fn prop_to_attr_name_data_props_respect_the_schema() {
+        // Issue #250: `dataType` is a real SVG property whose React name is
+        // `datatype`; only outside SVG is it a custom `data-type` attribute.
+        assert_eq!(prop_to_attr_name("dataType", true), "datatype");
+        assert_eq!(prop_to_attr_name("dataType", false), "data-type");
+        assert_eq!(prop_to_attr_name("dataFooBar", true), "data-foo-bar");
+        assert_eq!(prop_to_attr_name("dataFooBar", false), "data-foo-bar");
+        // `<object data>` is a plain HTML attribute, not a `data-*` prefix.
+        assert_eq!(prop_to_attr_name("data", false), "data");
+    }
+
+    #[test]
+    fn prop_to_attr_name_react_map_and_aria() {
+        assert_eq!(prop_to_attr_name("strokeLineCap", true), "strokeLinecap");
+        assert_eq!(prop_to_attr_name("xLinkHref", true), "xlinkHref");
+        assert_eq!(prop_to_attr_name("className", false), "className");
+        assert_eq!(prop_to_attr_name("ariaHidden", false), "aria-hidden");
     }
 }

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -126,6 +126,12 @@ pub fn property_to_attribute(name: &str, in_svg: bool) -> Cow<'_, str> {
     Cow::Borrowed(name)
 }
 
+/// Whether `name` is a property of the HTML or SVG schema (case-insensitive).
+/// Custom `data-*` and unknown properties are not.
+pub fn is_known_property(name: &str, in_svg: bool) -> bool {
+    lookup(table(in_svg), normalize(name).as_ref()).is_some()
+}
+
 /// Reverse lookup: the attribute for a known hast property, or `None` for
 /// unknown / custom properties (which pass through unchanged).
 fn attribute_of(name: &str, in_svg: bool) -> Option<&'static str> {
@@ -204,7 +210,7 @@ fn format_data_attribute(suffix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{PropKind, find_property, property_to_attribute};
+    use super::{PropKind, find_property, is_known_property, property_to_attribute};
 
     fn html(name: &str) -> std::borrow::Cow<'_, str> {
         property_to_attribute(name, false)
@@ -306,6 +312,16 @@ mod tests {
     fn xmlns_special_cases() {
         assert_eq!(html("xmlnsXLink"), "xmlns:xlink");
         assert_eq!(svg("xmlnsXLink"), "xmlns:xlink");
+    }
+
+    #[test]
+    fn is_known_property_is_schema_and_case_aware() {
+        // `dataType` is an SVG-only property; on HTML it is a custom `data-type`.
+        assert!(is_known_property("dataType", true));
+        assert!(!is_known_property("dataType", false));
+        assert!(!is_known_property("dataFoo", true));
+        assert!(is_known_property("classname", false));
+        assert!(!is_known_property("customProp", false));
     }
 
     #[test]

--- a/crates/satteri-property-info/src/lib.rs
+++ b/crates/satteri-property-info/src/lib.rs
@@ -129,7 +129,7 @@ pub fn property_to_attribute(name: &str, in_svg: bool) -> Cow<'_, str> {
 /// Whether `name` is a property of the HTML or SVG schema (case-insensitive).
 /// Custom `data-*` and unknown properties are not.
 pub fn is_known_property(name: &str, in_svg: bool) -> bool {
-    lookup(table(in_svg), normalize(name).as_ref()).is_some()
+    attribute_of(name, in_svg).is_some()
 }
 
 /// Reverse lookup: the attribute for a known hast property, or `None` for

--- a/packages/satteri/test/compile.test.ts
+++ b/packages/satteri/test/compile.test.ts
@@ -1391,6 +1391,20 @@ describe("mdxToJs", () => {
     expect(js).not.toContain("fill-rule");
   });
 
+  test("elementAttributeNameCase: 'react' keeps SVG `datatype` apart from custom `data-*` (#250)", () => {
+    const { code: js } = markdownToJs(
+      '<svg datatype="rdf" data-foo="1"></svg>\n\n<div data-type="custom"></div>\n',
+      { features: { rawHtml: true } },
+    );
+    // `datatype` is a real SVG attribute (hast `dataType`), so React casing
+    // must not kebab-case it like a custom data property.
+    expect(js).toContain('datatype: "rdf"');
+    expect(js).toContain('"data-foo": "1"');
+    // On HTML elements `dataType` is only ever the custom `data-type`.
+    expect(js).toContain('"data-type": "custom"');
+    expect(js).not.toContain('"data-type": "rdf"');
+  });
+
   test.each([
     ["script", 'if (a<b && c) { const label = "&copy;"; }'],
     ["style", 'a::before { content: "<b>&copy;"; }'],


### PR DESCRIPTION
Closes #250

Under the default `elementAttributeNameCase: "react"`, `prop_to_attr_name` kebab-cased every `data*` property before consulting the React name map, so the SVG property `dataType` compiled to `data-type` instead of `datatype`, and the `("dataType", "datatype")` map entry was unreachable.

### Change

The issue proposed moving the React map lookup ahead of the `data-*` branch. That reorder is not schema-aware and would regress HTML: `<div data-type="x">` parses to the property `dataType` and would then compile to `datatype`. The reference implementation (hast-util-to-estree) calls `find(schema, prop)` with the element's own schema before its `data` fallback, and the Html branch here already does the same via `property_to_attribute`.

So the fix gates the `data-*` branch on the element's schema instead:

- `satteri-property-info`: new `is_known_property(name, in_svg)`, a case-insensitive table membership check, re-exported through `satteri_ast::hast::properties`.
- `satteri-mdxjs`: `prop_to_attr_name` takes `in_svg` (already computed by the caller) and skips kebab-casing when the schema knows the property. `dataType` is the only `data*` schema property, so nothing else changes.

Before and after, default React casing with `rawHtml`:

| Input | Before | After |
|---|---|---|
| `<svg datatype="rdf">` | `"data-type": "rdf"` | `datatype: "rdf"` |
| `<svg data-foo="1">` | `"data-foo": "1"` | `"data-foo": "1"` |
| `<div data-type="x">` | `"data-type": "x"` | `"data-type": "x"` |

### Tests

- Unit tests for `is_known_property` and for `prop_to_attr_name` in both schemas.
- End-to-end vitest case compiling the three inputs above.

Checked the open PRs (#291, #286, #271, #248, #246, #149): none touch `prop_to_attr_name` or this issue.

https://claude.ai/code/session_01N3XEw7WCtrUi6cRC4rhA8b
