### PR TITLE
fix(ast): preserve the MathML default namespace

### DIFF
--- a/.sampo/changesets/mathml-default-namespace.md
+++ b/.sampo/changesets/mathml-default-namespace.md
@@ -1,0 +1,7 @@
+---
+cargo/satteri-ast: patch
+cargo/satteri-napi: patch
+npm/satteri: patch
+---
+
+Fixed raw HTML MathML default namespace attributes being serialized as `:xmlns` instead of `xmlns`.

--- a/crates/satteri-ast/src/hast/from_html.rs
+++ b/crates/satteri-ast/src/hast/from_html.rs
@@ -559,8 +559,10 @@ fn parsed_props(
 /// html5ever splits foreign attrs into prefix + local; the tables key `prefix:local`.
 fn qualified_attr_name(name: &QualName) -> std::borrow::Cow<'_, str> {
     match &name.prefix {
-        Some(prefix) => std::borrow::Cow::Owned(format!("{prefix}:{}", name.local)),
-        None => std::borrow::Cow::Borrowed(&name.local),
+        Some(prefix) if !prefix.is_empty() => {
+            std::borrow::Cow::Owned(format!("{prefix}:{}", name.local))
+        }
+        _ => std::borrow::Cow::Borrowed(&name.local),
     }
 }
 
@@ -993,6 +995,15 @@ mod tests {
             assert_eq!(tags(&reparsed), ["svg", tag]);
             assert_eq!(crate::hast::text_content(&reparsed, 0), "a<b & &copy;");
         }
+    }
+
+    #[test]
+    fn mathml_default_namespace_round_trips() {
+        let html = r#"<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>"#;
+        assert_eq!(
+            hast_arena_to_html(&html_fragment_to_hast_arena(html, HtmlSpace::Html)),
+            format!("{html}\n")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Round-tripping `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>` through the HTML-to-HAST parser currently emits `:xmlns` instead of `xmlns`.

html5ever represents this default namespace attribute with an empty prefix. Only prepend `prefix:` when the prefix is nonempty; preserve the existing behavior for qualified attributes. Includes one MathML round-trip regression and the required changeset.

Validation: `pnpm lint`, `pnpm format`, `cargo fmt --all --check`, `cargo test --all`, the regression with `--features from-html`, and `packages/satteri`'s `pnpm test` all passed (3,201 JS tests passed; 23 expected failures and 1 skipped). The regression was also verified to fail before the fix and pass afterward. Unrelated existing formatter changes were excluded.
