### PR TITLE
docs: add heading anchor links

### DIFF
--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -242,7 +242,7 @@ pre#demo-highlight code {
 .prose .docs-heading-anchor {
   position: absolute;
   inset-inline-start: -1.5rem;
-  top: 50%;
+  top: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -257,6 +257,11 @@ pre#demo-highlight code {
 .prose :is(h1, h2, h3, h4, h5, h6):focus-within .docs-heading-anchor {
   color: var(--color-ink);
   opacity: 1;
+}
+.prose .docs-heading-anchor:focus-visible {
+  outline: 2px solid var(--color-ink);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 @media (hover: hover) {
   .prose .docs-heading-anchor {
@@ -280,6 +285,22 @@ pre#demo-highlight code {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+@media (max-width: 767px) {
+  .prose :is(h1, h2, h3, h4, h5, h6) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    scroll-margin-top: 4.5rem;
+  }
+  .prose .docs-heading-anchor {
+    position: static;
+    order: 1;
+    padding: 0;
+    margin-inline-start: 0.25em;
+    transform: none;
+    vertical-align: baseline;
+  }
 }
 .prose ul {
   padding-left: 1.4em;

--- a/website/assets/prin.css
+++ b/website/assets/prin.css
@@ -235,6 +235,52 @@ pre#demo-highlight code {
 .prose h3 {
   font-weight: 600;
 }
+.prose :is(h1, h2, h3, h4, h5, h6) {
+  position: relative;
+  scroll-margin-top: 2.2rem;
+}
+.prose .docs-heading-anchor {
+  position: absolute;
+  inset-inline-start: -1.5rem;
+  top: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  color: var(--color-tertiary);
+  opacity: 1;
+  text-decoration: none;
+  transform: translateY(-50%);
+  transition: opacity 0.15s;
+}
+.prose .docs-heading-anchor:hover,
+.prose :is(h1, h2, h3, h4, h5, h6):focus-within .docs-heading-anchor {
+  color: var(--color-ink);
+  opacity: 1;
+}
+@media (hover: hover) {
+  .prose .docs-heading-anchor {
+    opacity: 0;
+  }
+  .prose :is(h1, h2, h3, h4, h5, h6):hover .docs-heading-anchor {
+    opacity: 1;
+  }
+}
+.prose .docs-heading-symbol {
+  font-size: 0.8em;
+  line-height: 1;
+}
+.prose .docs-heading-anchor .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .prose ul {
   padding-left: 1.4em;
   list-style: disc;

--- a/website/src/content.rs
+++ b/website/src/content.rs
@@ -1,11 +1,12 @@
 use maud::{PreEscaped, Render};
 use maudit::content::{
-    ContentSources, MarkdownOptions, glob_markdown_with_options, markdown_entry,
+    ContentSources, MarkdownComponents, MarkdownOptions, glob_markdown_with_options, markdown_entry,
     shortcodes::MarkdownShortcodes,
 };
 use maudit::content_sources;
 use serde::Deserialize;
 
+use crate::heading::DocsHeading;
 use crate::shortcodes;
 
 #[derive(Deserialize, Eq, PartialEq, PartialOrd, Hash, Clone)]
@@ -69,6 +70,7 @@ fn docs_markdown_options() -> MarkdownOptions {
     shortcodes::register(&mut docs_shortcodes);
 
     MarkdownOptions {
+        components: MarkdownComponents::new().heading(DocsHeading),
         highlight_theme: "base16-eighties.dark".into(),
         shortcodes: docs_shortcodes,
         ..Default::default()

--- a/website/src/heading.rs
+++ b/website/src/heading.rs
@@ -50,4 +50,14 @@ mod tests {
     fn renders_plain_headings_without_ids() {
         assert_eq!(DocsHeading.render_start(3, None, &[]), "<h3>");
     }
+
+    #[test]
+    fn renders_heading_classes() {
+        let output =
+            DocsHeading.render_start(2, Some("some-heading"), &["class-one", "class-two"]);
+
+        assert!(output.starts_with(
+            "<h2 id=\"some-heading\" class=\"class-one class-two\"><a class=\"docs-heading-anchor\""
+        ));
+    }
 }

--- a/website/src/heading.rs
+++ b/website/src/heading.rs
@@ -1,0 +1,53 @@
+use maudit::content::HeadingComponent;
+
+const ANCHOR_ICON: &str =
+    r#"<span class="docs-heading-symbol" aria-hidden="true">#</span>"#;
+
+pub struct DocsHeading;
+
+impl HeadingComponent for DocsHeading {
+    fn render_start(&self, level: u8, id: Option<&str>, classes: &[&str]) -> String {
+        let class_attr = if classes.is_empty() {
+            String::new()
+        } else {
+            format!(" class=\"{}\"", classes.join(" "))
+        };
+
+        let Some(id) = id else {
+            return format!("<h{level}{class_attr}>");
+        };
+
+        format!(
+            "<h{level} id=\"{id}\"{class_attr}><a class=\"docs-heading-anchor\" href=\"#{id}\">{ANCHOR_ICON}<span class=\"sr-only\">Link to this heading</span></a>"
+        )
+    }
+
+    fn render_end(&self, level: u8) -> String {
+        format!("</h{level}>")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_an_anchor_for_headings_with_ids() {
+        let heading = DocsHeading;
+        let output = heading.render_start(2, Some("some-heading"), &[]);
+
+        assert!(output.starts_with(
+            "<h2 id=\"some-heading\"><a class=\"docs-heading-anchor\" href=\"#some-heading\">"
+        ));
+        assert!(output.contains(
+            "<span class=\"docs-heading-symbol\" aria-hidden=\"true\">#</span>"
+        ));
+        assert!(output.contains("<span class=\"sr-only\">Link to this heading</span>"));
+        assert_eq!(heading.render_end(2), "</h2>");
+    }
+
+    #[test]
+    fn renders_plain_headings_without_ids() {
+        assert_eq!(DocsHeading.render_start(3, None, &[]), "<h3>");
+    }
+}

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -5,6 +5,7 @@ use pagefind::api::PagefindIndex;
 
 mod content;
 mod docs_layout;
+mod heading;
 mod layout;
 mod routes;
 mod shortcodes;


### PR DESCRIPTION
#### Description

This PR adds heading anchor links to the headings in the Sätteri docs, which make it possible to easily share specific sections without having to type the fragment manually. The whole implementation is inspired by the [Starlight implementation](https://redirect.github.com/withastro/starlight/pull/3033).

> [!NOTE]
> I used AI to generate the code, fine-tuned some margins manually and validated everything locally.

Here are some screenshots of how it looks like:

- Hover over the heading to show the `#` icon:
	<img width="1129" height="736" alt="image" src="https://github.com/user-attachments/assets/939fc513-9574-4fc1-b4a9-c48e6186bdfc" />

- After clicking on the `#` link, the heading jumps to the top with aligned margins and the URL updates:
	<img width="744" height="94" alt="image" src="https://github.com/user-attachments/assets/6b487291-948f-4557-8860-aa440a185930" />

- The heading anchors links are also responsive:
	<img width="329" height="283" alt="image" src="https://github.com/user-attachments/assets/1f2255b7-9527-4cf2-9d96-b93b8054b884" />


